### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ default_language_version:
 repos:
     # --- Formatters first ------------------------------------------------------
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.11.13
+      rev: v0.12.3
       hooks:
           - id: ruff
             name: ruff (autofix and format)


### PR DESCRIPTION
## Pre-commit Hook Updates

This PR updates the pre-commit hooks to their latest versions.

### Changes
- Updated hook versions in `.pre-commit-config.yaml`
- Ran hooks on all files to ensure compatibility

Auto-generated by GitHub Actions workflow.