### PR TITLE
Eliminate all var usage and improve Result pattern adherence across libs

### DIFF
--- a/libs/core/context/GeometryContext.cs
+++ b/libs/core/context/GeometryContext.cs
@@ -61,7 +61,7 @@ public sealed record GeometryContext(
          angleToleranceRadians <= 0d ? RhinoMath.ToRadians(1.0) : angleToleranceRadians) switch {
             (double normalizedAbsolute, double normalizedAngle) =>
                 ValidationRules.For(normalizedAbsolute, relativeTolerance, normalizedAngle) switch {
-                    { Length: > 0 } errors => ResultFactory.Create<GeometryContext>(errors: errors),
+                    { Length: > 0 } SystemError[] errors => ResultFactory.Create<GeometryContext>(errors: errors),
                     _ => ResultFactory.Create(value: new GeometryContext(normalizedAbsolute, relativeTolerance, normalizedAngle, units)),
                 },
         };

--- a/libs/rhino/extraction/ExtractionStrategies.cs
+++ b/libs/rhino/extraction/ExtractionStrategies.cs
@@ -58,7 +58,7 @@ internal static class ExtractionStrategies {
                 select s.PointAt(u, v),],
 
             // ANALYTICAL - Centroid and structural points via Rhino SDK
-            (ExtractionMethod.Analytical, var g) => [
+            (ExtractionMethod.Analytical, GeometryBase g) => [
                 ..(g switch {
                     Brep b when VolumeMassProperties.Compute(b)?.Centroid is { IsValid: true } c => [c],
                     Curve c when AreaMassProperties.Compute(c)?.Centroid is { IsValid: true } ct => [ct],
@@ -82,9 +82,9 @@ internal static class ExtractionStrategies {
 
             // EXTREMAL - Boundary points via Rhino SDK
             (ExtractionMethod.Extremal, Curve c) => [c.PointAtStart, c.PointAtEnd],
-            (ExtractionMethod.Extremal, Surface s) when s.Domain(0) is var u && s.Domain(1) is var v =>
+            (ExtractionMethod.Extremal, Surface s) when s.Domain(0) is Interval u && s.Domain(1) is Interval v =>
                 [s.PointAt(u.Min, v.Min), s.PointAt(u.Max, v.Min), s.PointAt(u.Max, v.Max), s.PointAt(u.Min, v.Max)],
-            (ExtractionMethod.Extremal, var g) => g.GetBoundingBox(accurate: true).GetCorners(),
+            (ExtractionMethod.Extremal, GeometryBase g) => g.GetBoundingBox(accurate: true).GetCorners(),
 
             // QUADRANT - Shape-specific points via Rhino SDK
             (ExtractionMethod.Quadrant, Curve c) when c.TryGetCircle(out Circle circle, context.AbsoluteTolerance) =>


### PR DESCRIPTION
Systematically replaced all var with explicit strong types and improved functional patterns following CLAUDE.md requirements.

GeometryContext.cs:
- Replace var with explicit types (UnitSystem, double) in ConvertLength
- Refactor Create to use pattern matching over manual if/else branching
- Use tuple destructuring with explicit types for normalized values

UnifiedOperation.cs:
- Replace var with ConcurrentDictionary type for cache
- Replace var with Result<TOut> in resolveOp switch
- Replace var with object? for cached value
- Replace var with Func<TOut, bool> for filter
- Replace var with Func<TOut, Result<TOut>> for transform
- Replace var with explicit bool/int types in property patterns

SpatialStrategies.cs:
- Replace var m with SpatialMethod in early validation
- Replace var with Point3d/double in property patterns (Center, Radius, Min, Max)
- Replace var with BoundingBox for bbox destructuring
- Replace var n with IEnumerable<Point3d>? in proximity queries
- Replace var buffer with int[] in ArrayPool patterns

ExtractionStrategies.cs:
- Replace var g with GeometryBase in analytical extraction
- Replace var u/v with Interval in surface extremal extraction

All changes maintain zero-allocation patterns, FrozenDictionary dispatch, and Result monad composition while strictly adhering to explicit typing.