### PR TITLE
Fix CI build failure by excluding Grasshopper on Linux

### DIFF
--- a/.github/workflows/claude-validation.yml
+++ b/.github/workflows/claude-validation.yml
@@ -23,16 +23,20 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Restore dependencies
-        run: dotnet restore Parametric_Arsenal.sln
+        run: |
+          dotnet restore libs/core/Core.csproj
+          dotnet restore libs/rhino/Rhino.csproj
+          dotnet restore test/shared/Arsenal.Tests.Shared.csproj
+          dotnet restore test/core/Arsenal.Core.Tests.csproj
+          dotnet restore test/rhino/Arsenal.Rhino.Tests.csproj
 
       - name: Build with analyzers (warnings as errors)
         run: |
-          dotnet build Parametric_Arsenal.sln \
-            --configuration Release \
-            --no-restore \
-            -p:TreatWarningsAsErrors=true \
-            -p:EnforceCodeStyleInBuild=true \
-            -warnaserror
+          dotnet build libs/core/Core.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -p:EnforceCodeStyleInBuild=true -warnaserror
+          dotnet build libs/rhino/Rhino.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -p:EnforceCodeStyleInBuild=true -warnaserror
+          dotnet build test/shared/Arsenal.Tests.Shared.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -p:EnforceCodeStyleInBuild=true -warnaserror
+          dotnet build test/core/Arsenal.Core.Tests.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -p:EnforceCodeStyleInBuild=true -warnaserror
+          dotnet build test/rhino/Arsenal.Rhino.Tests.csproj --configuration Release --no-restore -p:TreatWarningsAsErrors=true -p:EnforceCodeStyleInBuild=true -warnaserror
 
       - name: Build summary
         if: success()
@@ -41,6 +45,8 @@ jobs:
           echo "- Zero warnings"
           echo "- Zero code style violations"
           echo "- Zero analyzer errors"
+          echo ""
+          echo "Note: Grasshopper project skipped (Windows/macOS only)"
 
       - name: Build failed
         if: failure()


### PR DESCRIPTION
Root cause: Grasshopper project only supports Windows (NuGet package) and macOS (direct references). On Linux CI (ubuntu-latest), there are no Grasshopper references, causing build failure.

Surgical fix:
- Build individual projects instead of solution file
- Explicitly exclude libs/grasshopper/Grasshopper.csproj
- Build only: Core, Rhino, and all test projects
- Maintain full analyzer validation (TreatWarningsAsErrors=true)

Projects validated on CI:
✅ libs/core/Core.csproj
✅ libs/rhino/Rhino.csproj
✅ test/shared/Arsenal.Tests.Shared.csproj
✅ test/core/Arsenal.Core.Tests.csproj
✅ test/rhino/Arsenal.Rhino.Tests.csproj
⏭️ libs/grasshopper/Grasshopper.csproj (Windows/macOS only)

This allows CI to pass while maintaining strict analyzer enforcement on all cross-platform projects.