### PR TITLE
Fix syntax error in GeometryContext.cs pattern matching

### DIFF
--- a/libs/core/context/GeometryContext.cs
+++ b/libs/core/context/GeometryContext.cs
@@ -61,7 +61,7 @@ public sealed record GeometryContext(
          angleToleranceRadians <= 0d ? RhinoMath.ToRadians(1.0) : angleToleranceRadians) switch {
             (double normalizedAbsolute, double normalizedAngle) =>
                 ValidationRules.For(normalizedAbsolute, relativeTolerance, normalizedAngle) switch {
-                    { Length: > 0 } SystemError[] errors => ResultFactory.Create<GeometryContext>(errors: errors),
+                    SystemError[] { Length: > 0 } errors => ResultFactory.Create<GeometryContext>(errors: errors),
                     _ => ResultFactory.Create(value: new GeometryContext(normalizedAbsolute, relativeTolerance, normalizedAngle, units)),
                 },
         };


### PR DESCRIPTION
Error: CS1003 Identifier expected at line 64
Root cause: Incorrect pattern syntax - property pattern before type

Before (WRONG):
{ Length: > 0 } SystemError[] errors

After (CORRECT):
SystemError[] { Length: > 0 } errors

C# pattern matching requires type declaration BEFORE property patterns. This fixes the 6 compiler errors from CI build.