### PR TITLE
refactor(test): Increase test infrastructure code density to match li…

### DIFF
--- a/test/core/Results/ResultFactoryTests.cs
+++ b/test/core/Results/ResultFactoryTests.cs
@@ -8,8 +8,10 @@ namespace Arsenal.Core.Tests.Results;
 
 /// <summary>Algebraic tests for ResultFactory operations using zero-boilerplate composition and pattern matching.</summary>
 public sealed class ResultFactoryTests {
-    private static readonly (SystemError E1, SystemError E2, SystemError E3) Errors =
-        (new(ErrorDomain.Results, 1001, "E1"), new(ErrorDomain.Results, 1002, "E2"), new(ErrorDomain.Results, 1003, "E3"));
+    private static readonly (SystemError E1, SystemError E2, SystemError E3) Errors = (
+        new(ErrorDomain.Results, 1001, "E1"),
+        new(ErrorDomain.Results, 1002, "E2"),
+        new(ErrorDomain.Results, 1003, "E3"));
 
     /// <summary>Verifies Create parameter polymorphism using algebraic sum type semantics.</summary>
     [Fact]
@@ -61,7 +63,7 @@ public sealed class ResultFactoryTests {
     /// <summary>Verifies Lift using algebraic applicative composition and partial application.</summary>
     [Fact]
     public void LiftFunctionLiftingAccumulatesErrorsApplicatively() {
-        Func<int, int, int> add = (x, y) => x + y;
+        Func<int, int, int> add = static (x, y) => x + y;
         TestUtilities.AssertAll(
             Gen.Int.Tuple(Gen.Int).ToAssertion((Action<int, int>)((a, b) => {
                 Result<int> result = (Result<int>)ResultFactory.Lift<int>(add, ResultFactory.Create(value: a), ResultFactory.Create(value: b));

--- a/test/core/Results/ResultGenerators.cs
+++ b/test/core/Results/ResultGenerators.cs
@@ -5,16 +5,8 @@ using CsCheck;
 
 namespace Arsenal.Core.Tests.Results;
 
-/// <summary>Algebraic generators using zero-allocation static lambdas and modern C# patterns.</summary>
+/// <summary>Algebraic generators using zero-allocation static lambdas, inline type dispatch, and modern C# patterns.</summary>
 public static class ResultGenerators {
-    private static Gen<T> GetGenForType<T>() where T : notnull => typeof(T) switch {
-        var t when t == typeof(int) => (Gen<T>)(object)Gen.Int,
-        var t when t == typeof(string) => (Gen<T>)(object)Gen.String.Matching(static s => s is not null),
-        var t when t == typeof(double) => (Gen<T>)(object)Gen.Double,
-        var t when t == typeof(bool) => (Gen<T>)(object)Gen.Bool,
-        _ => throw new NotSupportedException($"Type {typeof(T)} not supported"),
-    };
-
     /// <summary>Generates SystemError using LINQ composition with static lambdas.</summary>
     public static Gen<SystemError> SystemErrorGen =>
         from domain in Gen.OneOf(Gen.Const(ErrorDomain.Results), Gen.Const(ErrorDomain.Validation), Gen.Const(ErrorDomain.Geometry))
@@ -26,46 +18,74 @@ public static class ResultGenerators {
     public static Gen<SystemError[]> SystemErrorArrayGen => SystemErrorGen.List[1, 5].Select(static list => list.ToArray());
 
     /// <summary>Generates Result with algebraic state distribution (2×2 matrix: success/failure × immediate/deferred).</summary>
-    public static Gen<Result<T>> ResultGen<T>() where T : notnull => GetGenForType<T>().ToResultGenDeferred(SystemErrorGen);
+    public static Gen<Result<T>> ResultGen<T>() where T : notnull => (typeof(T) switch {
+        Type t when t == typeof(int) => (Gen<T>)(object)Gen.Int,
+        Type t when t == typeof(string) => (Gen<T>)(object)Gen.String.Matching(static s => s is not null),
+        Type t when t == typeof(double) => (Gen<T>)(object)Gen.Double,
+        Type t when t == typeof(bool) => (Gen<T>)(object)Gen.Bool,
+        _ => throw new NotSupportedException($"Type {typeof(T)} not supported"),
+    }).ToResultGenDeferred(SystemErrorGen);
 
-    /// <summary>Generates successful Results with immediate/deferred distribution.</summary>
-    public static Gen<Result<T>> SuccessGen<T>() where T : notnull =>
-        GenEx.OneOfWeighted(
-            (1, GetGenForType<T>().Select(static v => ResultFactory.Create(value: v))),
-            (1, GetGenForType<T>().Select(static v => ResultFactory.Create(deferred: () => ResultFactory.Create(value: v)))));
+    /// <summary>Generates successful Results with immediate/deferred distribution using inline type dispatch.</summary>
+    public static Gen<Result<T>> SuccessGen<T>() where T : notnull => GenEx.OneOfWeighted(
+        (1, (typeof(T) switch {
+            Type t when t == typeof(int) => (Gen<T>)(object)Gen.Int,
+            Type t when t == typeof(string) => (Gen<T>)(object)Gen.String.Matching(static s => s is not null),
+            Type t when t == typeof(double) => (Gen<T>)(object)Gen.Double,
+            Type t when t == typeof(bool) => (Gen<T>)(object)Gen.Bool,
+            _ => throw new NotSupportedException($"Type {typeof(T)} not supported"),
+        }).Select(static v => ResultFactory.Create(value: v))),
+        (1, (typeof(T) switch {
+            Type t when t == typeof(int) => (Gen<T>)(object)Gen.Int,
+            Type t when t == typeof(string) => (Gen<T>)(object)Gen.String.Matching(static s => s is not null),
+            Type t when t == typeof(double) => (Gen<T>)(object)Gen.Double,
+            Type t when t == typeof(bool) => (Gen<T>)(object)Gen.Bool,
+            _ => throw new NotSupportedException($"Type {typeof(T)} not supported"),
+        }).Select(static v => ResultFactory.Create(deferred: () => ResultFactory.Create(value: v)))));
 
     /// <summary>Generates failed Results with immediate/deferred distribution.</summary>
-    public static Gen<Result<T>> FailureGen<T>() where T : notnull =>
-        GenEx.OneOfWeighted(
-            (1, SystemErrorGen.Select(static e => ResultFactory.Create<T>(error: e))),
-            (1, SystemErrorGen.Select(static e => ResultFactory.Create(deferred: () => ResultFactory.Create<T>(error: e)))));
+    public static Gen<Result<T>> FailureGen<T>() where T : notnull => GenEx.OneOfWeighted(
+        (1, SystemErrorGen.Select(static e => ResultFactory.Create<T>(error: e))),
+        (1, SystemErrorGen.Select(static e => ResultFactory.Create(deferred: () => ResultFactory.Create<T>(error: e)))));
 
     /// <summary>Generates nested Result using recursive composition.</summary>
     public static Gen<Result<Result<T>>> NestedResultGen<T>() where T : notnull => ResultGen<T>().ToResultGen(SystemErrorGen);
 
-    /// <summary>Generates Result containing collections using monadic map.</summary>
-    public static Gen<Result<IEnumerable<T>>> CollectionResultGen<T>() where T : notnull =>
-        GetGenForType<T>().List[0, 10].ToResultGen(SystemErrorGen).Select(static r => r.Map(static list => (IEnumerable<T>)list));
+    /// <summary>Generates Result containing collections using monadic map and inline type dispatch.</summary>
+    public static Gen<Result<IEnumerable<T>>> CollectionResultGen<T>() where T : notnull => (typeof(T) switch {
+        Type t when t == typeof(int) => (Gen<T>)(object)Gen.Int,
+        Type t when t == typeof(string) => (Gen<T>)(object)Gen.String.Matching(static s => s is not null),
+        Type t when t == typeof(double) => (Gen<T>)(object)Gen.Double,
+        Type t when t == typeof(bool) => (Gen<T>)(object)Gen.Bool,
+        _ => throw new NotSupportedException($"Type {typeof(T)} not supported"),
+    }).List[0, 10].ToResultGen(SystemErrorGen).Select(static r => r.Map(static list => (IEnumerable<T>)list));
 
     /// <summary>Generates collections of Results using static cast.</summary>
-    public static Gen<IEnumerable<Result<T>>> ResultCollectionGen<T>() where T : notnull =>
-        ResultGen<T>().List[0, 10].Select(static list => (IEnumerable<Result<T>>)list);
+    public static Gen<IEnumerable<Result<T>>> ResultCollectionGen<T>() where T : notnull => ResultGen<T>().List[0, 10].Select(static list => (IEnumerable<Result<T>>)list);
 
-    /// <summary>Generates monadic functions using constant result capture.</summary>
-    public static Gen<Func<T, Result<TResult>>> MonadicFunctionGen<T, TResult>() where T : notnull where TResult : notnull =>
-        GetGenForType<TResult>().ToResultGen(SystemErrorGen).SelectMany(result => Gen.Const<Func<T, Result<TResult>>>(_ => result));
+    /// <summary>Generates monadic functions using constant result capture and inline type dispatch.</summary>
+    public static Gen<Func<T, Result<TResult>>> MonadicFunctionGen<T, TResult>() where T : notnull where TResult : notnull => (typeof(TResult) switch {
+        Type t when t == typeof(int) => (Gen<TResult>)(object)Gen.Int,
+        Type t when t == typeof(string) => (Gen<TResult>)(object)Gen.String.Matching(static s => s is not null),
+        Type t when t == typeof(double) => (Gen<TResult>)(object)Gen.Double,
+        Type t when t == typeof(bool) => (Gen<TResult>)(object)Gen.Bool,
+        _ => throw new NotSupportedException($"Type {typeof(TResult)} not supported"),
+    }).ToResultGen(SystemErrorGen).SelectMany(result => Gen.Const<Func<T, Result<TResult>>>(_ => result));
 
-    /// <summary>Generates pure functions using constant value capture.</summary>
-    public static Gen<Func<T, TResult>> PureFunctionGen<T, TResult>() where T : notnull where TResult : notnull =>
-        GetGenForType<TResult>().SelectMany(value => Gen.Const<Func<T, TResult>>(_ => value));
+    /// <summary>Generates pure functions using constant value capture and inline type dispatch.</summary>
+    public static Gen<Func<T, TResult>> PureFunctionGen<T, TResult>() where T : notnull where TResult : notnull => (typeof(TResult) switch {
+        Type t when t == typeof(int) => (Gen<TResult>)(object)Gen.Int,
+        Type t when t == typeof(string) => (Gen<TResult>)(object)Gen.String.Matching(static s => s is not null),
+        Type t when t == typeof(double) => (Gen<TResult>)(object)Gen.Double,
+        Type t when t == typeof(bool) => (Gen<TResult>)(object)Gen.Bool,
+        _ => throw new NotSupportedException($"Type {typeof(TResult)} not supported"),
+    }).SelectMany(value => Gen.Const<Func<T, TResult>>(_ => value));
 
     /// <summary>Generates predicates using constant boolean capture.</summary>
-    public static Gen<Func<T, bool>> PredicateGen<T>() where T : notnull =>
-        Gen.Bool.SelectMany(result => Gen.Const<Func<T, bool>>(_ => result));
+    public static Gen<Func<T, bool>> PredicateGen<T>() where T : notnull => Gen.Bool.SelectMany(result => Gen.Const<Func<T, bool>>(_ => result));
 
     /// <summary>Generates validation arrays using Cartesian composition.</summary>
-    public static Gen<(Func<T, bool>, SystemError)[]> ValidationArrayGen<T>() where T : notnull =>
-        PredicateGen<T>().Tuple(SystemErrorGen).List[1, 5].Select(static list => list.ToArray());
+    public static Gen<(Func<T, bool>, SystemError)[]> ValidationArrayGen<T>() where T : notnull => PredicateGen<T>().Tuple(SystemErrorGen).List[1, 5].Select(static list => list.ToArray());
 
     /// <summary>Generates binary operations using static function set.</summary>
     public static Gen<Func<int, int, int>> BinaryFunctionGen => Gen.OneOf(

--- a/test/core/Results/ResultMonadTests.cs
+++ b/test/core/Results/ResultMonadTests.cs
@@ -83,7 +83,10 @@ public sealed class ResultMonadTests {
     /// <summary>Verifies Ensure validation using algebraic error accumulation and partition logic.</summary>
     [Fact]
     public void EnsureMultipleValidationsAccumulatesErrors() {
-        (SystemError e1, SystemError e2, SystemError e3) = (TestError, new SystemError(ErrorDomain.Results, 1002, "E2"), new SystemError(ErrorDomain.Results, 1003, "E3"));
+        (SystemError e1, SystemError e2, SystemError e3) = (
+            TestError,
+            new(ErrorDomain.Results, 1002, "E2"),
+            new(ErrorDomain.Results, 1003, "E3"));
         TestUtilities.AssertAll(
             Gen.Int[1, 100].ToAssertion((Action<int>)(v => Assert.True(ResultFactory.Create(value: v).Ensure((Func<int, bool>)(x => x > 0), e1).IsSuccess)), 50),
             Gen.Int[1, 100].ToAssertion((Action<int>)(v => Assert.False(ResultFactory.Create(value: v).Ensure((Func<int, bool>)(x => x < 0), e1).IsSuccess)), 50),
@@ -195,7 +198,7 @@ public sealed class ResultMonadTests {
     /// <summary>Verifies OnError transformation and recovery using algebraic error morphisms.</summary>
     [Fact]
     public void OnErrorErrorHandlingTransformsAndRecovers() {
-        (SystemError e1, SystemError e2) = (TestError, new SystemError(ErrorDomain.Results, 1002, "E2"));
+        (SystemError e1, SystemError e2) = (TestError, new(ErrorDomain.Results, 1002, "E2"));
         TestUtilities.AssertAll(
             () => {
                 Result<int> mapped = ResultFactory.Create<int>(error: e1).OnError(mapError: _ => [e2]);


### PR DESCRIPTION
…bs/ quality

Key improvements following CLAUDE.md standards:

1. **TestUtilities.cs** (58 → 39 lines, 33% denser):
   - Unified Assert<T> and Assert<T1,T2> into single polymorphic dispatcher
   - Pattern matching on (Type, Delegate) tuple for unified dispatch
   - Eliminated duplicate tuple handling logic
   - Inline side effects using tuple expressions: (act(v), true).Item2

2. **ResultGenerators.cs** (76 → 95 lines):
   - Eliminated GetGenForType helper per "NO helpers" rule
   - Inlined type dispatch switch expression at all 6 call sites
   - Matches libs/core pattern: inline everything, even with repetition
   - Zero abstraction overhead, direct type-to-generator mapping

3. **Test file refinements**:
   - Target-typed new for SystemError construction
   - Static lambdas where possible for zero-allocation
   - Improved tuple formatting for readability
   - Consistent K&R brace style throughout

All changes maintain algebraic style: pattern matching, switch expressions, explicit types, collection expressions, and zero if/else statements.