### PR TITLE
Optimize ValidationRules.cs: type-safe caches, cached reflection, Has…

### DIFF
--- a/libs/core/validation/ValidationRules.cs
+++ b/libs/core/validation/ValidationRules.cs
@@ -31,12 +31,20 @@ public static class ValidationRules {
         public override bool Equals(object? obj) => obj is CacheKey other && this.Equals(other);
 
         [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override int GetHashCode() => (this.Type, this.Mode, this.Member, this.Kind).GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(this.Type, this.Mode, this.Member, this.Kind);
 
         [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(CacheKey other) => (this.Type, this.Mode, this.Member, this.Kind).Equals((other.Type, other.Mode, other.Member, other.Kind));
     }
-    private static readonly ConcurrentDictionary<CacheKey, object> _cache = new();
+
+    private static readonly ConcurrentDictionary<CacheKey, Func<object, IGeometryContext, SystemError[]>> _validatorCache = new();
+    private static readonly ConcurrentDictionary<CacheKey, MemberInfo> _memberCache = new();
+
+    private static readonly MethodInfo _enumerableWhere = typeof(Enumerable).GetMethods()
+        .First(static m => string.Equals(m.Name, nameof(Enumerable.Where), StringComparison.Ordinal) && m.GetParameters().Length == 2);
+    private static readonly MethodInfo _enumerableSelect = typeof(Enumerable).GetMethods()
+        .First(static m => string.Equals(m.Name, nameof(Enumerable.Select), StringComparison.Ordinal) && m.GetParameters().Length == 2);
+    private static readonly MethodInfo _enumerableToArray = typeof(Enumerable).GetMethod(nameof(Enumerable.ToArray))!;
 
     private static readonly FrozenDictionary<ValidationMode, (string[] Properties, string[] Methods, SystemError Error)> _validationRules =
         new Dictionary<ValidationMode, (string[], string[], SystemError)> {
@@ -54,11 +62,8 @@ public static class ValidationRules {
 
     /// <summary>Gets or compiles cached validator function for runtime type and validation mode.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Func<object, IGeometryContext, SystemError[]> GetOrCompileValidator(Type runtimeType, ValidationMode mode) {
-        CacheKey key = new(runtimeType, mode);
-        object validator = _cache.GetOrAdd(key, k => CompileValidator(k.Type, k.Mode));
-        return (Func<object, IGeometryContext, SystemError[]>)validator;
-    }
+    internal static Func<object, IGeometryContext, SystemError[]> GetOrCompileValidator(Type runtimeType, ValidationMode mode) =>
+        _validatorCache.GetOrAdd(new CacheKey(runtimeType, mode), static k => CompileValidator(k.Type, k.Mode));
 
     /// <summary>Generates validation errors for tolerance values using polymorphic parameter detection.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -80,19 +85,19 @@ public static class ValidationRules {
     private static Func<object, IGeometryContext, SystemError[]> CompileValidator(Type runtimeType, ValidationMode mode) {
         (ParameterExpression geometry, ParameterExpression context, ParameterExpression error) = (Expression.Parameter(typeof(object), "g"), Expression.Parameter(typeof(IGeometryContext), "c"), Expression.Parameter(typeof(SystemError?), "e"));
 
-        (object Member, SystemError Error)[] memberValidations =
+        (MemberInfo Member, SystemError Error)[] memberValidations =
             [.. Enum.GetValues<ValidationMode>()
                 .Where(flag => flag is not (ValidationMode.None or ValidationMode.All) && mode.HasFlag(flag) && _validationRules.ContainsKey(flag))
                 .SelectMany(flag => {
                     (string[] properties, string[] methods, SystemError error) = _validationRules[flag];
-                    return (IEnumerable<(object Member, SystemError Error)>)[
+                    return (IEnumerable<(MemberInfo Member, SystemError Error)>)[
                         .. properties.Select(prop => (
-                            Member: _cache.GetOrAdd(new CacheKey(runtimeType, ValidationMode.None, prop, 1),
-                                static (key, type) => type.GetProperty(key.Member!) ?? (object)typeof(void), runtimeType),
+                            Member: _memberCache.GetOrAdd(new CacheKey(runtimeType, ValidationMode.None, prop, 1),
+                                static (key, type) => (type.GetProperty(key.Member!) ?? (MemberInfo)typeof(void)), runtimeType),
                             error)),
                         .. methods.Select(method => (
-                            Member: _cache.GetOrAdd(new CacheKey(runtimeType, ValidationMode.None, method, 2),
-                                static (key, type) => type.GetMethod(key.Member!) ?? (object)typeof(void), runtimeType),
+                            Member: _memberCache.GetOrAdd(new CacheKey(runtimeType, ValidationMode.None, method, 2),
+                                static (key, type) => (type.GetMethod(key.Member!) ?? (MemberInfo)typeof(void)), runtimeType),
                             error)),
                     ];
                 }),
@@ -100,7 +105,7 @@ public static class ValidationRules {
 
         Expression[] validationExpressions = [.. memberValidations
             .Where(validation => validation.Member is not null and not Type { Name: "Void" })
-            .Select<(object Member, SystemError Error), Expression>(validation => validation.Member switch {
+            .Select<(MemberInfo Member, SystemError Error), Expression>(validation => validation.Member switch {
                 PropertyInfo { PropertyType: Type pt } prop when pt == typeof(bool) =>
                     Expression.Condition(Expression.Not(Expression.Property(Expression.Convert(geometry, runtimeType), prop)),
                         Expression.Convert(Expression.Constant(validation.Error), typeof(SystemError?)),
@@ -128,9 +133,9 @@ public static class ValidationRules {
         ];
 
         return Expression.Lambda<Func<object, IGeometryContext, SystemError[]>>(
-            Expression.Call(typeof(Enumerable).GetMethod(nameof(Enumerable.ToArray))!.MakeGenericMethod(typeof(SystemError)),
-                Expression.Call(typeof(Enumerable).GetMethods().First(static m => string.Equals(m.Name, nameof(Enumerable.Select), StringComparison.Ordinal) && m.GetParameters().Length == 2).MakeGenericMethod(typeof(SystemError?), typeof(SystemError)),
-                    Expression.Call(typeof(Enumerable).GetMethods().First(static m => string.Equals(m.Name, nameof(Enumerable.Where), StringComparison.Ordinal) && m.GetParameters().Length == 2).MakeGenericMethod(typeof(SystemError?)),
+            Expression.Call(_enumerableToArray.MakeGenericMethod(typeof(SystemError)),
+                Expression.Call(_enumerableSelect.MakeGenericMethod(typeof(SystemError?), typeof(SystemError)),
+                    Expression.Call(_enumerableWhere.MakeGenericMethod(typeof(SystemError?)),
                         Expression.NewArrayInit(typeof(SystemError?), validationExpressions),
                         Expression.Lambda<Func<SystemError?, bool>>(Expression.NotEqual(error, Expression.Constant(null, typeof(SystemError?))), error)),
                     Expression.Lambda<Func<SystemError?, SystemError>>(Expression.Convert(error, typeof(SystemError)), error))),


### PR DESCRIPTION
…hCode.Combine

Performance improvements:
- Split single object cache into type-safe _validatorCache and _memberCache
- Cache Enumerable MethodInfo (Where/Select/ToArray) to eliminate repeated reflection
- Use HashCode.Combine instead of tuple GetHashCode for better distribution

Code quality improvements:
- Eliminate boxing/unboxing with explicit MemberInfo types
- Simplify GetOrCompileValidator to inline expression
- Improve cache locality with separate typed dictionaries

Zero API changes, maintains exact same behavior with enhanced performance.