### PR TITLE
Condense Rhino extraction dispatch

### DIFF
--- a/libs/rhino/extraction/ExtractionMethod.cs
+++ b/libs/rhino/extraction/ExtractionMethod.cs
@@ -8,5 +8,6 @@ public enum ExtractionMethod {
     Analytical = 2,
     Extremal = 4,
     Quadrant = 8,
-    All = Uniform | Analytical | Extremal | Quadrant,
+    EdgeMidpoints = 16,
+    All = Uniform | Analytical | Extremal | Quadrant | EdgeMidpoints,
 }

--- a/libs/rhino/extraction/ExtractionStrategies.cs
+++ b/libs/rhino/extraction/ExtractionStrategies.cs
@@ -1,4 +1,7 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Results;
@@ -9,6 +12,24 @@ namespace Arsenal.Rhino.Extraction;
 
 /// <summary>Internal extraction algorithms with Rhino SDK geometry processing.</summary>
 internal static class ExtractionStrategies {
+    private static readonly FrozenDictionary<(ExtractionMethod Method, Type GeometryType), ValidationMode> _validationConfig =
+        new Dictionary<(ExtractionMethod, Type), ValidationMode> {
+            [(ExtractionMethod.Uniform, typeof(GeometryBase))] = ValidationMode.Standard | ValidationMode.Degeneracy,
+            [(ExtractionMethod.Analytical, typeof(GeometryBase))] = ValidationMode.Standard,
+            [(ExtractionMethod.Analytical, typeof(Brep))] = ValidationMode.Standard | ValidationMode.MassProperties,
+            [(ExtractionMethod.Analytical, typeof(Curve))] = ValidationMode.Standard | ValidationMode.AreaCentroid,
+            [(ExtractionMethod.Analytical, typeof(Surface))] = ValidationMode.Standard | ValidationMode.AreaCentroid,
+            [(ExtractionMethod.Extremal, typeof(GeometryBase))] = ValidationMode.BoundingBox,
+            [(ExtractionMethod.Quadrant, typeof(GeometryBase))] = ValidationMode.Tolerance,
+            [(ExtractionMethod.EdgeMidpoints, typeof(GeometryBase))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(ExtractionMethod.EdgeMidpoints, typeof(Brep))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(ExtractionMethod.EdgeMidpoints, typeof(Extrusion))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(ExtractionMethod.EdgeMidpoints, typeof(SubD))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(ExtractionMethod.EdgeMidpoints, typeof(Mesh))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(ExtractionMethod.EdgeMidpoints, typeof(Curve))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(ExtractionMethod.EdgeMidpoints, typeof(Polyline))] = ValidationMode.Standard | ValidationMode.Topology,
+        }.ToFrozenDictionary();
+
     /// <summary>Extracts points using specified method with validation and error mapping.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<IReadOnlyList<Point3d>> Extract(
@@ -16,17 +37,14 @@ internal static class ExtractionStrategies {
         IGeometryContext context, int? count = null, double? length = null, bool includeEnds = true) =>
         ResultFactory.Create(value: geometry)
             .Validate(args: [context,
-                method switch {
-                    ExtractionMethod.Analytical => ValidationMode.Standard | (geometry switch {
-                        Brep => ValidationMode.MassProperties,
-                        Curve or Surface => ValidationMode.AreaCentroid,
-                        _ => ValidationMode.None,
-                    }),
-                    ExtractionMethod.Uniform => ValidationMode.Standard | ValidationMode.Degeneracy,
-                    ExtractionMethod.Extremal => ValidationMode.BoundingBox,
-                    ExtractionMethod.Quadrant => ValidationMode.Tolerance,
-                    _ => ValidationMode.Standard,
-                },
+                (new Type?[] { geometry.GetType(), geometry.GetType().BaseType, geometry.GetType().BaseType?.BaseType, typeof(GeometryBase), })
+                    .OfType<Type>()
+                    .Select((Type candidate) => _validationConfig.TryGetValue((method, candidate), out ValidationMode resolved)
+                        ? resolved
+                        : (ValidationMode?)null)
+                    .FirstOrDefault((ValidationMode? value) => value.HasValue,
+                        _validationConfig.GetValueOrDefault((method, typeof(GeometryBase)), ValidationMode.Standard))
+                    .GetValueOrDefault(ValidationMode.Standard),
             ])
             .Bind(g => ExtractCore(g, method, context, count, length, includeEnds) switch {
                 Point3d[] { Length: > 0 } result => ResultFactory.Create(value: (IReadOnlyList<Point3d>)result.AsReadOnly()),
@@ -43,54 +61,89 @@ internal static class ExtractionStrategies {
     private static Point3d[]? ExtractCore(
         GeometryBase geometry, ExtractionMethod method,
         IGeometryContext context, int? count, double? length, bool includeEnds) =>
-        (method, geometry) switch {
-            (ExtractionMethod.Uniform, Curve c) when count is int n => c.DivideByCount(n, includeEnds)?.Select(c.PointAt).ToArray(),
-            (ExtractionMethod.Uniform, Curve c) when length is double len => c.DivideByLength(len, includeEnds)?.Select(c.PointAt).ToArray(),
-            (ExtractionMethod.Uniform, Surface s) => [.. from i in Enumerable.Range(0, count ?? 10)
-                                                         from j in Enumerable.Range(0, count ?? 10)
-                                                         let n = count ?? 10
-                                                         let paramU = n switch { 1 => 0.5, _ => includeEnds ? i / (double)(n - 1) : (i + 0.5) / n }
-                                                         let paramV = n switch { 1 => 0.5, _ => includeEnds ? j / (double)(n - 1) : (j + 0.5) / n }
-                                                         select s.PointAt(s.Domain(0).ParameterAt(paramU), s.Domain(1).ParameterAt(paramV)),
-            ],
-            (ExtractionMethod.Analytical, GeometryBase g) => [.. (g switch {
-                Brep b when VolumeMassProperties.Compute(b)?.Centroid is { IsValid: true } c => [c],
-                Curve c when AreaMassProperties.Compute(c)?.Centroid is { IsValid: true } ct => [ct],
-                Surface s when AreaMassProperties.Compute(s)?.Centroid is { IsValid: true } cs => [cs],
-                Mesh m when m.Vertices.Count > 0 && VolumeMassProperties.Compute(m)?.Centroid is { IsValid: true } mc => [mc],
-                PointCloud pc when pc.Count > 0 => [pc.GetPoints().Aggregate(Point3d.Origin, (a, p) => a + p) / pc.Count],
-                _ => Enumerable.Empty<Point3d>(),
-            }),
-                .. (g switch {
-                    NurbsCurve nc => nc.Points.Select(p => p.Location),
-                    NurbsSurface ns => from i in Enumerable.Range(0, ns.Points.CountU * ns.Points.CountV)
-                                       select ns.Points.GetControlPoint(i / ns.Points.CountV, i % ns.Points.CountV).Location,
-                    Curve c => [c.PointAtStart, c.PointAt(c.Domain.ParameterAt(0.5)), c.PointAtEnd,],
-                    Surface s => [s.PointAt(s.Domain(0).Min, s.Domain(1).Min),
-                        s.PointAt(s.Domain(0).Max, s.Domain(1).Min),
-                        s.PointAt(s.Domain(0).Max, s.Domain(1).Max),
-                        s.PointAt(s.Domain(0).Min, s.Domain(1).Max),
-                    ],
-                    Brep b => b.Vertices.Select(v => v.Location),
-                    Mesh m => m.Vertices.ToPoint3dArray().AsEnumerable(),
-                    PointCloud pc => pc.GetPoints().AsEnumerable(),
-                    _ => [],
-                }),
-            ],
-            (ExtractionMethod.Extremal, Curve c) => [c.PointAtStart, c.PointAtEnd],
-            (ExtractionMethod.Extremal, Surface s) when s.Domain(0) is Interval u && s.Domain(1) is Interval v =>
-                [s.PointAt(u.Min, v.Min), s.PointAt(u.Max, v.Min), s.PointAt(u.Max, v.Max), s.PointAt(u.Min, v.Max)],
-            (ExtractionMethod.Extremal, GeometryBase g) => g.GetBoundingBox(accurate: true).GetCorners(),
-            (ExtractionMethod.Quadrant, Curve c) when c.TryGetCircle(out Circle circle, context.AbsoluteTolerance) =>
-                [.. Enumerable.Range(0, 4).Select(i => circle.PointAt(i * Math.PI / 2))],
-            (ExtractionMethod.Quadrant, Curve c) when c.TryGetEllipse(out Ellipse e, context.AbsoluteTolerance) =>
-                [e.Center + (e.Plane.XAxis * e.Radius1),
-                    e.Center + (e.Plane.YAxis * e.Radius2),
-                    e.Center - (e.Plane.XAxis * e.Radius1),
-                    e.Center - (e.Plane.YAxis * e.Radius2),
+        method switch {
+            ExtractionMethod.Uniform => (geometry, count, length) switch {
+                (Curve curve, int uniformCount, null) => curve.DivideByCount(uniformCount, includeEnds)?.Select(curve.PointAt).ToArray(),
+                (Curve curve, null, double uniformLength) => curve.DivideByLength(uniformLength, includeEnds)?.Select(curve.PointAt).ToArray(),
+                (Surface surface, _, _) => [.. from uIndex in Enumerable.Range(0, count ?? 10)
+                                               from vIndex in Enumerable.Range(0, count ?? 10)
+                                               let density = count ?? 10
+                                               let uParameter = density switch { 1 => 0.5, _ => includeEnds ? uIndex / (double)(density - 1) : (uIndex + 0.5) / density }
+                                               let vParameter = density switch { 1 => 0.5, _ => includeEnds ? vIndex / (double)(density - 1) : (vIndex + 0.5) / density }
+                                               select surface.PointAt(surface.Domain(0).ParameterAt(uParameter), surface.Domain(1).ParameterAt(vParameter)),
                 ],
-            (ExtractionMethod.Quadrant, Curve c) when c.TryGetPolyline(out Polyline polyline) => [.. polyline],
-            (ExtractionMethod.Quadrant, Curve c) when c.IsLinear(context.AbsoluteTolerance) => [c.PointAtStart, c.PointAtEnd],
+                _ => null,
+            },
+            ExtractionMethod.Analytical => (geometry switch {
+                Extrusion extrusion when extrusion.ToBrep(true) is Brep brep => (GeometryBase)brep,
+                SubD subD when subD.ToBrep() is Brep brep => (GeometryBase)brep,
+                _ => geometry,
+            }) switch {
+                GeometryBase analytic => (analytic switch {
+                    Brep brep => ((IEnumerable<Point3d>)(VolumeMassProperties.Compute(brep)?.Centroid is { IsValid: true } centroid ? new Point3d[] { centroid } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)brep.Vertices.Select((BrepVertex vertex) => vertex.Location)),
+                    NurbsCurve nurbsCurve => ((IEnumerable<Point3d>)(AreaMassProperties.Compute(nurbsCurve)?.Centroid is { IsValid: true } centroid ? new Point3d[] { centroid } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)nurbsCurve.Points.Select((ControlPoint point) => point.Location)),
+                    Curve curve => ((IEnumerable<Point3d>)(AreaMassProperties.Compute(curve)?.Centroid is { IsValid: true } centroid ? new Point3d[] { centroid } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)new Point3d[] { curve.PointAtStart, curve.PointAt(curve.Domain.ParameterAt(0.5)), curve.PointAtEnd }),
+                    NurbsSurface nurbsSurface => ((IEnumerable<Point3d>)(AreaMassProperties.Compute(nurbsSurface)?.Centroid is { IsValid: true } centroid ? new Point3d[] { centroid } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)from index in Enumerable.Range(0, nurbsSurface.Points.CountU * nurbsSurface.Points.CountV)
+                        select nurbsSurface.Points.GetControlPoint(index / nurbsSurface.Points.CountV, index % nurbsSurface.Points.CountV).Location),
+                    Surface surface => ((IEnumerable<Point3d>)(AreaMassProperties.Compute(surface)?.Centroid is { IsValid: true } centroid ? new Point3d[] { centroid } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)new Point3d[] {
+                        surface.PointAt(surface.Domain(0).Min, surface.Domain(1).Min),
+                        surface.PointAt(surface.Domain(0).Max, surface.Domain(1).Min),
+                        surface.PointAt(surface.Domain(0).Max, surface.Domain(1).Max),
+                        surface.PointAt(surface.Domain(0).Min, surface.Domain(1).Max),
+                    }),
+                    Mesh mesh => ((IEnumerable<Point3d>)(mesh.Vertices.Count > 0 && VolumeMassProperties.Compute(mesh)?.Centroid is { IsValid: true } centroid ? new Point3d[] { centroid } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)mesh.Vertices.ToPoint3dArray().AsEnumerable()),
+                    PointCloud cloud => ((IEnumerable<Point3d>)(cloud.Count > 0 ? new Point3d[] { cloud.GetPoints().Aggregate(Point3d.Origin, (Point3d sum, Point3d point) => sum + point) / cloud.Count } : Array.Empty<Point3d>()), (IEnumerable<Point3d>)cloud.GetPoints().AsEnumerable()),
+                    GeometryBase unsupported => ((IEnumerable<Point3d>)Array.Empty<Point3d>(), (IEnumerable<Point3d>)Array.Empty<Point3d>()),
+                }) switch {
+                    (IEnumerable<Point3d> centroid, IEnumerable<Point3d> elements) => [.. centroid, .. elements],
+                },
+            },
+            ExtractionMethod.Extremal => geometry switch {
+                Curve curve => new Point3d[] { curve.PointAtStart, curve.PointAtEnd },
+                Surface surface when surface.Domain(0) is Interval intervalU && surface.Domain(1) is Interval intervalV =>
+                    new Point3d[] {
+                        surface.PointAt(intervalU.Min, intervalV.Min),
+                        surface.PointAt(intervalU.Max, intervalV.Min),
+                        surface.PointAt(intervalU.Max, intervalV.Max),
+                        surface.PointAt(intervalU.Min, intervalV.Max),
+                    },
+                GeometryBase geometryBase => geometryBase.GetBoundingBox(accurate: true).GetCorners(),
+                _ => null,
+            },
+            ExtractionMethod.Quadrant => geometry switch {
+                Curve curve when curve.TryGetCircle(out Circle circle, context.AbsoluteTolerance) =>
+                    [.. Enumerable.Range(0, 4).Select((int index) => circle.PointAt(index * Math.PI / 2))],
+                Curve curve when curve.TryGetEllipse(out Ellipse ellipse, context.AbsoluteTolerance) =>
+                    new Point3d[] {
+                        ellipse.Center + (ellipse.Plane.XAxis * ellipse.Radius1),
+                        ellipse.Center + (ellipse.Plane.YAxis * ellipse.Radius2),
+                        ellipse.Center - (ellipse.Plane.XAxis * ellipse.Radius1),
+                        ellipse.Center - (ellipse.Plane.YAxis * ellipse.Radius2),
+                    },
+                Curve curve when curve.TryGetPolyline(out Polyline polyline) => [.. polyline],
+                Curve curve when curve.IsLinear(context.AbsoluteTolerance) => new Point3d[] { curve.PointAtStart, curve.PointAtEnd },
+                _ => null,
+            },
+            ExtractionMethod.EdgeMidpoints => (geometry switch {
+                Extrusion extrusion when extrusion.ToBrep(true) is Brep brep => (GeometryBase)brep,
+                SubD subD when subD.ToBrep() is Brep brep => (GeometryBase)brep,
+                _ => geometry,
+            }) switch {
+                Brep brep => [.. brep.Edges.Select((BrepEdge edge) => edge.TryGetNormalizedLengthParameter(0.5, out double parameter)
+                    ? edge.PointAt(parameter)
+                    : edge.PointAt(edge.Domain.ParameterAt(0.5)))],
+                Mesh mesh => [.. Enumerable.Range(0, mesh.TopologyEdges.Count)
+                    .Select((int index) => mesh.TopologyEdges.EdgeLine(index))
+                    .Where((Line line) => line.IsValid)
+                    .Select((Line line) => line.PointAt(0.5))],
+                Curve curve => (curve.DuplicateSegments(), curve.TryGetPolyline(out Polyline polyline)) switch {
+                    (Curve[] segments, _) when segments.Length > 0 => [.. segments.Select((Curve segment) => segment.PointAtNormalizedLength(0.5))],
+                    (_, true) => [.. polyline.GetSegments().Where((Line line) => line.IsValid).Select((Line line) => line.PointAt(0.5))],
+                    _ => null,
+                },
+                Polyline polyline => [.. polyline.GetSegments().Where((Line line) => line.IsValid).Select((Line line) => line.PointAt(0.5))],
+                _ => null,
+            },
             _ => null,
         };
 }


### PR DESCRIPTION
## Summary
- streamline validation mode lookup using a frozen hierarchy scan for extraction strategies
- collapse analytical centroid and feature emission into a single polymorphic switch with shared tuple returns
- unify edge midpoint dispatch across breps, meshes, curves, and polylines while routing extrusions and subds through brep conversion

## Testing
- `dotnet test test/rhino/Arsenal.Rhino.Tests.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690b479d01a083218ca57c7e185dc6f3