### PR TITLE
Refactor analysis with method-based dispatch and comprehensive SDK in…

### DIFF
--- a/libs/rhino/analysis/AnalysisEngine.cs
+++ b/libs/rhino/analysis/AnalysisEngine.cs
@@ -10,44 +10,59 @@ namespace Arsenal.Rhino.Analysis;
 
 /// <summary>Polymorphic analysis engine with unified operation dispatch.</summary>
 public static class AnalysisEngine {
-    /// <summary>Analyzes geometry producing evaluation data with derivatives, curvature, and metrics.</summary>
+    /// <summary>Analyzes geometry with method-based dispatch producing comprehensive evaluation data.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<IReadOnlyList<(
-        Point3d Point, Vector3d[] Derivatives, Plane Frame,
-        (double? Gaussian, double? Mean, double? Min, double? Max, Vector3d? MinDir, Vector3d? MaxDir, Vector3d? Curve)? Curvature,
-        (double? Length, double? Area, double? Volume)? Metrics,
+        Point3d Point,
+        Vector3d[] Derivatives,
+        (Plane Primary, Plane[]? Perpendicular, double[]? InflectionParams, double[]? MaxCurvatureParams, double? Torsion)? Frames,
+        (double? Gaussian, double? Mean, double? K1, double? K2, Vector3d? Dir1, Vector3d? Dir2)? Curvature,
+        (double[]? Parameters, Continuity[]? Types)? Discontinuities,
+        ((int Index, Point3d Location)[]? Vertices, (int Index, Line Geometry)[]? Edges, bool? IsManifold, bool? IsClosed)? Topology,
+        (Point3d? Closest, ComponentIndex? Component, double? Distance, (double, double)? SurfaceUV)? Proximity,
+        (bool AtSeam, bool AtSingularity, Point3d[]? SeamPoints)? Singularities,
+        (double? Length, double? Area, double? Volume, Point3d? Centroid)? Metrics,
         Interval[]? Domains,
-        (Vector3d[]? TangentBasis, Vector3d? Normal, Plane? OrientationFrame)? Orientation,
-        (double? CurveParam, (double, double)? SurfaceParams, int? MeshIndex, int DerivativeOrder) EvaluatedParams)>> Analyze<T>(
+        (double? Curve, (double, double)? Surface, int? Mesh, int DerivOrder) Params)>> Analyze<T>(
         T input,
+        AnalysisMethod method,
         IGeometryContext context,
-        double? curveParameter = null,
-        (double, double)? surfaceParameters = null,
-        int? meshIndex = null,
-        int derivativeOrder = 2,
-        bool includeMetrics = true,
-        bool includeDomains = true,
-        bool includeOrientation = true) where T : notnull =>
+        (double? Curve, (double, double)? Surface, int? Mesh)? parameters = null,
+        int derivativeOrder = 2) where T : notnull =>
         UnifiedOperation.Apply(
             input,
-            (Func<object, Result<IReadOnlyList<(Point3d, Vector3d[], Plane,
-                (double?, double?, double?, double?, Vector3d?, Vector3d?, Vector3d?)?,
-                (double?, double?, double?)?, Interval[]?,
-                (Vector3d[]?, Vector3d?, Plane?)?,
+            (Func<object, Result<IReadOnlyList<(Point3d, Vector3d[],
+                (Plane, Plane[]?, double[]?, double[]?, double?)?,
+                (double?, double?, double?, double?, Vector3d?, Vector3d?)?,
+                (double[]?, Continuity[]?)?,
+                ((int, Point3d)[]?, (int, Line)[]?, bool?, bool?)?,
+                (Point3d?, ComponentIndex?, double?, (double, double)?)?,
+                (bool, bool, Point3d[]?)?,
+                (double?, double?, double?, Point3d?)?,
+                Interval[]?,
                 (double?, (double, double)?, int?, int))>>>)(item =>
-                AnalysisStrategies.Analyze(item, context, curveParameter, surfaceParameters,
-                    meshIndex, derivativeOrder, includeMetrics, includeDomains, includeOrientation)
-                    .Map(results => (IReadOnlyList<(Point3d, Vector3d[], Plane,
-                        (double?, double?, double?, double?, Vector3d?, Vector3d?, Vector3d?)?,
-                        (double?, double?, double?)?, Interval[]?,
-                        (Vector3d[]?, Vector3d?, Plane?)?,
+                AnalysisStrategies.Analyze(item, method, context, parameters, derivativeOrder)
+                    .Map(results => (IReadOnlyList<(Point3d, Vector3d[],
+                        (Plane, Plane[]?, double[]?, double[]?, double?)?,
+                        (double?, double?, double?, double?, Vector3d?, Vector3d?)?,
+                        (double[]?, Continuity[]?)?,
+                        ((int, Point3d)[]?, (int, Line)[]?, bool?, bool?)?,
+                        (Point3d?, ComponentIndex?, double?, (double, double)?)?,
+                        (bool, bool, Point3d[]?)?,
+                        (double?, double?, double?, Point3d?)?,
+                        Interval[]?,
                         (double?, (double, double)?, int?, int))>)[.. results.Select(r =>
-                        (r.Point, r.Derivatives, r.Frame, r.Curvature, r.Metrics, r.Domains, r.Orientation, r.EvaluatedParams)),
+                        (r.Point, r.Derivatives, r.Frames, r.Curvature, r.Discontinuities, r.Topology, r.Proximity, r.Singularities, r.Metrics, r.Domains, r.Params)),
                         ])),
-            new OperationConfig<object, (Point3d, Vector3d[], Plane,
-                (double?, double?, double?, double?, Vector3d?, Vector3d?, Vector3d?)?,
-                (double?, double?, double?)?, Interval[]?,
-                (Vector3d[]?, Vector3d?, Plane?)?,
+            new OperationConfig<object, (Point3d, Vector3d[],
+                (Plane, Plane[]?, double[]?, double[]?, double?)?,
+                (double?, double?, double?, double?, Vector3d?, Vector3d?)?,
+                (double[]?, Continuity[]?)?,
+                ((int, Point3d)[]?, (int, Line)[]?, bool?, bool?)?,
+                (Point3d?, ComponentIndex?, double?, (double, double)?)?,
+                (bool, bool, Point3d[]?)?,
+                (double?, double?, double?, Point3d?)?,
+                Interval[]?,
                 (double?, (double, double)?, int?, int))> {
                 Context = context,
                 ValidationMode = ValidationMode.None,

--- a/libs/rhino/analysis/AnalysisErrors.cs
+++ b/libs/rhino/analysis/AnalysisErrors.cs
@@ -29,4 +29,63 @@ public static class AnalysisErrors {
         public static readonly SystemError UnsupportedGeometry =
             new(ErrorDomain.Geometry, 2310, "Unsupported geometry type for analysis");
     }
+
+    /// <summary>Evaluation computation errors for derivative and surface operations.</summary>
+    public static class Evaluation {
+        /// <summary>Derivative computation failed at specified parameter.</summary>
+        public static readonly SystemError DerivativeComputationFailed =
+            new(ErrorDomain.Geometry, 2311, "Derivative evaluation failed");
+
+        /// <summary>Surface.Evaluate() method failed to compute derivatives.</summary>
+        public static readonly SystemError SurfaceEvaluationFailed =
+            new(ErrorDomain.Geometry, 2312, "Surface.Evaluate() failed");
+    }
+
+    /// <summary>Discontinuity detection and continuity testing errors.</summary>
+    public static class Discontinuity {
+        /// <summary>No discontinuities detected in specified domain range.</summary>
+        public static readonly SystemError NoneFound =
+            new(ErrorDomain.Geometry, 2320, "No discontinuities detected in domain");
+
+        /// <summary>Continuity test failed at parameter value.</summary>
+        public static readonly SystemError TestFailed =
+            new(ErrorDomain.Geometry, 2321, "Continuity test failed");
+    }
+
+    /// <summary>Topology navigation and connectivity errors.</summary>
+    public static class Topology {
+        /// <summary>Geometry lacks topology information for analysis.</summary>
+        public static readonly SystemError NoTopologyData =
+            new(ErrorDomain.Geometry, 2330, "Geometry lacks topology information");
+
+        /// <summary>Topology edge enumeration or access failed.</summary>
+        public static readonly SystemError EdgeAccessFailed =
+            new(ErrorDomain.Geometry, 2331, "Topology edge enumeration failed");
+
+        /// <summary>Topology vertex access or unified vertex computation failed.</summary>
+        public static readonly SystemError VertexAccessFailed =
+            new(ErrorDomain.Geometry, 2332, "Topology vertex access failed");
+    }
+
+    /// <summary>Proximity and closest point computation errors.</summary>
+    public static class Proximity {
+        /// <summary>Closest point computation failed or returned invalid result.</summary>
+        public static readonly SystemError ClosestPointFailed =
+            new(ErrorDomain.Geometry, 2340, "Closest point computation failed");
+
+        /// <summary>Component identification failed for Brep closest point.</summary>
+        public static readonly SystemError ComponentIdentificationFailed =
+            new(ErrorDomain.Geometry, 2341, "Component identification failed");
+    }
+
+    /// <summary>Singularity and seam detection errors.</summary>
+    public static class Singularity {
+        /// <summary>Singularity detection failed at parameter location.</summary>
+        public static readonly SystemError DetectionFailed =
+            new(ErrorDomain.Geometry, 2350, "Singularity detection failed");
+
+        /// <summary>Seam identification or location computation failed.</summary>
+        public static readonly SystemError SeamIdentificationFailed =
+            new(ErrorDomain.Geometry, 2351, "Seam identification failed");
+    }
 }

--- a/libs/rhino/analysis/AnalysisMethod.cs
+++ b/libs/rhino/analysis/AnalysisMethod.cs
@@ -1,0 +1,19 @@
+namespace Arsenal.Rhino.Analysis;
+
+/// <summary>Analysis computation modes with bitwise composition for polymorphic dispatch.</summary>
+[Flags]
+public enum AnalysisMethod {
+    None = 0,
+    Point = 1,
+    Derivatives = 2,
+    Curvature = 4,
+    Frame = 8,
+    Discontinuity = 16,
+    Topology = 32,
+    Proximity = 64,
+    Singularity = 128,
+    Metrics = 256,
+    Domains = 512,
+    Standard = Point | Derivatives | Curvature | Frame | Metrics | Domains,
+    Comprehensive = Standard | Discontinuity | Topology | Proximity | Singularity,
+}

--- a/libs/rhino/analysis/AnalysisStrategies.cs
+++ b/libs/rhino/analysis/AnalysisStrategies.cs
@@ -8,108 +8,240 @@ using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Analysis;
 
-/// <summary>Dense analysis result containing point, derivatives, frame, curvature, and metrics.</summary>
+/// <summary>Dense analysis result containing point, derivatives, frames, curvature, topology, and metrics.</summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MA0048:File name must match type name", Justification = "Internal result type colocated with strategies")]
 internal sealed record AnalysisResult(
     Point3d Point,
     Vector3d[] Derivatives,
-    Plane Frame,
-    (double? Gaussian, double? Mean, double? Min, double? Max, Vector3d? MinDir, Vector3d? MaxDir, Vector3d? Curve)? Curvature,
-    (double? Length, double? Area, double? Volume)? Metrics,
+    (Plane Primary, Plane[]? Perpendicular, double[]? InflectionParams, double[]? MaxCurvatureParams, double? Torsion)? Frames,
+    (double? Gaussian, double? Mean, double? K1, double? K2, Vector3d? Dir1, Vector3d? Dir2)? Curvature,
+    (double[]? Parameters, Continuity[]? Types)? Discontinuities,
+    ((int Index, Point3d Location)[]? Vertices, (int Index, Line Geometry)[]? Edges, bool? IsManifold, bool? IsClosed)? Topology,
+    (Point3d? Closest, ComponentIndex? Component, double? Distance, (double, double)? SurfaceUV)? Proximity,
+    (bool AtSeam, bool AtSingularity, Point3d[]? SeamPoints)? Singularities,
+    (double? Length, double? Area, double? Volume, Point3d? Centroid)? Metrics,
     Interval[]? Domains,
-    (Vector3d[]? TangentBasis, Vector3d? Normal, Plane? OrientationFrame)? Orientation,
-    (double? CurveParam, (double, double)? SurfaceParams, int? MeshIndex, int DerivativeOrder) EvaluatedParams);
+    (double? Curve, (double, double)? Surface, int? Mesh, int DerivOrder) Params);
 
-/// <summary>Dense analysis strategy dispatcher following extraction pattern with separate validation and core.</summary>
+/// <summary>Dense analysis strategy dispatcher with method-type configuration and SDK integration.</summary>
 internal static class AnalysisStrategies {
-    /// <summary>Validation configuration mapping geometry types to required validation modes.</summary>
-    private static readonly FrozenDictionary<Type, ValidationMode> _validation =
-        new Dictionary<Type, ValidationMode> {
-            [typeof(Curve)] = ValidationMode.Standard | ValidationMode.Degeneracy,
-            [typeof(Surface)] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
-            [typeof(BrepFace)] = ValidationMode.Standard | ValidationMode.Topology | ValidationMode.SurfaceContinuity,
-            [typeof(Brep)] = ValidationMode.Standard | ValidationMode.Topology | ValidationMode.MassProperties,
-            [typeof(SubD)] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
-            [typeof(Mesh)] = ValidationMode.MeshSpecific,
-            [typeof(PointCloud)] = ValidationMode.Standard | ValidationMode.Degeneracy,
-            [typeof(Point3d[])] = ValidationMode.None,
-            [typeof(Point3d)] = ValidationMode.None,
-            [typeof(Vector3d)] = ValidationMode.None,
+    private static readonly FrozenDictionary<(AnalysisMethod, Type), ValidationMode> _validation =
+        new Dictionary<(AnalysisMethod, Type), ValidationMode> {
+            [(AnalysisMethod.Point, typeof(Curve))] = ValidationMode.Standard,
+            [(AnalysisMethod.Derivatives, typeof(Curve))] = ValidationMode.Standard | ValidationMode.Degeneracy,
+            [(AnalysisMethod.Curvature, typeof(Curve))] = ValidationMode.Standard | ValidationMode.Degeneracy,
+            [(AnalysisMethod.Frame, typeof(Curve))] = ValidationMode.Standard,
+            [(AnalysisMethod.Discontinuity, typeof(Curve))] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
+            [(AnalysisMethod.Metrics, typeof(Curve))] = ValidationMode.Standard | ValidationMode.AreaCentroid,
+            [(AnalysisMethod.Point, typeof(Surface))] = ValidationMode.Standard,
+            [(AnalysisMethod.Derivatives, typeof(Surface))] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
+            [(AnalysisMethod.Curvature, typeof(Surface))] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
+            [(AnalysisMethod.Frame, typeof(Surface))] = ValidationMode.Standard,
+            [(AnalysisMethod.Discontinuity, typeof(Surface))] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
+            [(AnalysisMethod.Singularity, typeof(Surface))] = ValidationMode.Standard,
+            [(AnalysisMethod.Metrics, typeof(Surface))] = ValidationMode.Standard | ValidationMode.AreaCentroid,
+            [(AnalysisMethod.Metrics, typeof(BrepFace))] = ValidationMode.Standard | ValidationMode.MassProperties,
+            [(AnalysisMethod.Topology, typeof(Brep))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(AnalysisMethod.Proximity, typeof(Brep))] = ValidationMode.Standard | ValidationMode.Topology,
+            [(AnalysisMethod.Metrics, typeof(Brep))] = ValidationMode.Standard | ValidationMode.MassProperties,
+            [(AnalysisMethod.Point, typeof(Mesh))] = ValidationMode.MeshSpecific,
+            [(AnalysisMethod.Curvature, typeof(Mesh))] = ValidationMode.MeshSpecific,
+            [(AnalysisMethod.Topology, typeof(Mesh))] = ValidationMode.MeshSpecific,
+            [(AnalysisMethod.Proximity, typeof(Mesh))] = ValidationMode.MeshSpecific,
+            [(AnalysisMethod.Metrics, typeof(Mesh))] = ValidationMode.MeshSpecific,
+            [(AnalysisMethod.Point, typeof(SubD))] = ValidationMode.Standard | ValidationMode.SurfaceContinuity,
+            [(AnalysisMethod.Topology, typeof(SubD))] = ValidationMode.Standard,
+            [(AnalysisMethod.Point, typeof(PointCloud))] = ValidationMode.Standard | ValidationMode.Degeneracy,
+            [(AnalysisMethod.Frame, typeof(PointCloud))] = ValidationMode.Standard,
         }.ToFrozenDictionary();
 
-    /// <summary>Analyzes geometry with validation dispatch and parameter checking.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<IReadOnlyList<AnalysisResult>> Analyze(
-        object source, IGeometryContext context,
-        double? curveParam, (double, double)? surfaceParams, int? meshIndex,
-        int derivativeOrder, bool includeMetrics, bool includeDomains, bool includeOrientation) =>
-        (source switch {
-            BrepFace face => (typeof(BrepFace), face),
-            GeometryBase geom => (geom.GetType(), geom),
-            Point3d[] pts => (typeof(Point3d[]), pts),
-            Point3d pt => (typeof(Point3d), pt),
-            Vector3d vec => (typeof(Vector3d), vec),
-            _ => (source.GetType(), source),
-        }) switch {
-            (Type t, object obj) => ResultFactory.Create(value: obj)
-                .Validate(args: _validation.TryGetValue(t, out ValidationMode mode) && mode != ValidationMode.None
-                    ? [context, mode] : null)
-                .Map(_ => AnalyzeCore(obj, context, curveParam, surfaceParams, meshIndex,
-                    derivativeOrder, includeMetrics, includeDomains, includeOrientation))
-                .Bind(result => result switch {
-                    AnalysisResult r => ResultFactory.Create(value: (IReadOnlyList<AnalysisResult>)[r]),
-                    null when obj is Point3d[] pts => ResultFactory.Create(value: (IReadOnlyList<AnalysisResult>)
-                        Array.ConvertAll(pts, pt => new AnalysisResult(Point: pt, Derivatives: [], Frame: new Plane(pt, Vector3d.ZAxis),
-                            Curvature: null, Metrics: null, Domains: null, Orientation: null,
-                            EvaluatedParams: (curveParam, surfaceParams, meshIndex, derivativeOrder)))),
-                    _ => ResultFactory.Create<IReadOnlyList<AnalysisResult>>(error: AnalysisErrors.Operation.UnsupportedGeometry),
-                }),
-        };
-
-    /// <summary>Core analysis logic with ultra-dense switch expressions and inline tuple operations.</summary>
-    [Pure]
-    private static AnalysisResult? AnalyzeCore(object source, IGeometryContext context, double? cP, (double, double)? sP,
-        int? mI, int dO, bool iM, bool iD, bool iO) => source switch {
-            Curve c when c.Domain.IncludesParameter(cP ?? c.Domain.ParameterAt(0.5)) && (cP ?? c.Domain.ParameterAt(0.5), c.FrameAt(cP ?? c.Domain.ParameterAt(0.5), out Plane f) ? f : new(c.PointAt(cP ?? c.Domain.ParameterAt(0.5)), Vector3d.ZAxis)) is (var t, var frame) =>
-                new(c.PointAt(t), [c.TangentAt(t)], frame, c.CurvatureAt(t).IsValid ? (null, null, c.CurvatureAt(t).Length, null, null, null, c.CurvatureAt(t)) : null,
-                    iM ? (c.GetLength(), null, null) : null, iD ? [c.Domain] : null, iO ? ([frame.XAxis, frame.YAxis], frame.ZAxis, frame) : null,
-                    (t, sP, mI, dO)),
-            Surface s when s.Domain(0).IncludesParameter((sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5))).Item1) && s.Domain(1).IncludesParameter((sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5))).Item2) && (sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5)), s.FrameAt((sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5))).Item1, (sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5))).Item2, out Plane f) ? f : Plane.WorldXY, s.CurvatureAt((sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5))).Item1, (sP ?? (s.Domain(0).ParameterAt(0.5), s.Domain(1).ParameterAt(0.5))).Item2)) is ((var u, var v), var frame, var sc) =>
-                new(s.PointAt(u, v), [frame.XAxis, frame.YAxis], frame, (sc.Gaussian, sc.Mean, sc.Kappa(0), sc.Kappa(1), sc.Direction(0), sc.Direction(1), null),
-                    iM ? (null, s is BrepFace bf ? AreaMassProperties.Compute(bf)?.Area : AreaMassProperties.Compute(s)?.Area, s is BrepFace { Brep: Brep b } ? VolumeMassProperties.Compute(b)?.Volume : null) : null,
-                    iD ? [s.Domain(0), s.Domain(1)] : null, iO ? ([frame.XAxis, frame.YAxis], frame.ZAxis, frame) : null,
-                    (cP, (u, v), mI, dO)),
-            BrepFace face => AnalyzeCore(face.UnderlyingSurface(), context, cP, sP, mI, dO, iM, iD, iO) switch {
-                AnalysisResult r => r with { Metrics = iM ? (null, AreaMassProperties.Compute(face)?.Area, face.Brep is Brep b ? VolumeMassProperties.Compute(b)?.Volume : null) : null },
-                _ => null,
-            },
-            Brep brep when (mI ?? 0) >= 0 && (mI ?? 0) < brep.Faces.Count => AnalyzeCore(brep.Faces[mI ?? 0], context, cP, sP, mI ?? 0, dO, iM, iD, iO) switch {
-                AnalysisResult r => r with { Metrics = iM ? (null, AreaMassProperties.Compute(brep)?.Area, VolumeMassProperties.Compute(brep)?.Volume) : null },
-                _ => null,
-            },
-            SubD subd => subd.ToBrep() switch {
-                Brep b when b.Faces.Count > 0 => ((Func<AnalysisResult?>)(() => {
-                    try {
-                        return AnalyzeCore(b.Faces[0], context, cP, sP, 0, dO, iM, iD, iO) switch {
-                            AnalysisResult r => r with { Metrics = iM ? (null, AreaMassProperties.Compute(b)?.Area, VolumeMassProperties.Compute(b)?.Volume) : null },
-                            _ => null,
-                        };
-                    } finally { b.Dispose(); }
+        object source, AnalysisMethod method, IGeometryContext context,
+        (double?, (double, double)?, int?)? parameters, int derivativeOrder) =>
+        ResultFactory.Create(value: source)
+            .Validate(args: [context,
+                ((Func<ValidationMode>)(() => {
+                    Type type = source switch {
+                        BrepFace => typeof(BrepFace),
+                        GeometryBase g => g.GetType(),
+                        _ => source.GetType(),
+                    };
+                    return Enum.GetValues<AnalysisMethod>()
+                        .Where(flag => flag is not (AnalysisMethod.None or AnalysisMethod.Standard or AnalysisMethod.Comprehensive) && method.HasFlag(flag))
+                        .Select(flag => {
+                            for (Type? t = type; t is not null && t != typeof(object); t = t.BaseType) {
+                                if (_validation.TryGetValue((flag, t), out ValidationMode m)) {
+                                    return m;
+                                }
+                            }
+                            return ValidationMode.None;
+                        })
+                        .Aggregate(ValidationMode.None, (acc, m) => acc | m);
                 }))(),
-                _ => null,
-            },
-            Mesh m when (mI ?? 0) >= 0 && (mI ?? 0) < m.Vertices.Count && (m.Vertices.Point3dAt(mI ?? 0), m.Normals.Count > (mI ?? 0) ? m.Normals[mI ?? 0] : m.Normals.ComputeNormals() && m.Normals.Count > (mI ?? 0) ? m.Normals[mI ?? 0] : Vector3d.ZAxis) is (var pt, var n) =>
-                new(pt, [], new Plane(pt, n.IsValid ? n : Vector3d.ZAxis), Curvature: null,
-                    iM ? (null, AreaMassProperties.Compute(m)?.Area, VolumeMassProperties.Compute(m)?.Volume) : null,
-                    iD ? [new(0, m.Vertices.Count)] : null, iO ? ([], n.IsValid ? n : null, new Plane(pt, n.IsValid ? n : Vector3d.ZAxis)) : null,
-                    (cP, sP, mI ?? 0, dO)),
-            PointCloud cloud when cloud.Count > 0 && (cloud.GetPoints(), cloud.GetBoundingBox(accurate: true).Center, Plane.FitPlaneToPoints(cloud.GetPoints(), out Plane fitted) == PlaneFitResult.Success ? fitted : Plane.WorldXY) is (var pts, var center, var plane) =>
-                new(Point: center, Derivatives: [], Frame: plane, Curvature: null, Metrics: null, Domains: iD ? [new(0, cloud.Count)] : null, Orientation: iO ? ([plane.XAxis, plane.YAxis], plane.ZAxis, plane) : null,
-                    EvaluatedParams: (cP, sP, mI, dO)),
-            Point3d pt => new(Point: pt, Derivatives: [], Frame: Plane.WorldXY, Curvature: null, Metrics: null, Domains: null, Orientation: null,
-                EvaluatedParams: (cP, sP, mI, dO)),
-            Vector3d vec => new(Point: Point3d.Origin, Derivatives: [vec], Frame: new Plane(Point3d.Origin, vec), Curvature: null, Metrics: null, Domains: null, Orientation: iO ? ([vec], null, new Plane(Point3d.Origin, vec)) : null,
-                EvaluatedParams: (cP, sP, mI, dO)),
+            ])
+            .Map(_ => AnalyzeCore(source, method, context, parameters, derivativeOrder))
+            .Bind(result => result switch {
+                AnalysisResult r => ResultFactory.Create(value: (IReadOnlyList<AnalysisResult>)[r]),
+                null => ResultFactory.Create<IReadOnlyList<AnalysisResult>>(error: AnalysisErrors.Operation.UnsupportedGeometry),
+                _ => ResultFactory.Create<IReadOnlyList<AnalysisResult>>(error: AnalysisErrors.Operation.UnsupportedGeometry),
+            });
+
+    [Pure]
+    private static AnalysisResult? AnalyzeCore(object source, AnalysisMethod method, IGeometryContext context, (double?, (double, double)?, int?)? p, int dO) =>
+        (method, source, p?.Item1, p?.Item2, p?.Item3, dO, context) switch {
+            (var m, Curve cv, var tP, _, _, var order, var ctx) when cv.Domain.IncludesParameter(tP ?? cv.Domain.ParameterAt(0.5)) && (tP ?? cv.Domain.ParameterAt(0.5)) is var t =>
+                new AnalysisResult(
+                    Point: cv.PointAt(t),
+                    Derivatives: m.HasFlag(AnalysisMethod.Derivatives) && order >= 1 ?
+                        (cv.DerivativeAt(t), cv.TangentAt(t)) switch {
+                            (Vector3d d, _) when d.IsValid => [cv.TangentAt(t), d],
+                            (_, Vector3d tang) when tang.IsValid => [tang],
+                            _ => [],
+                        } : [],
+                    Frames: m.HasFlag(AnalysisMethod.Frame) ?
+                        (cv.FrameAt(t, out Plane frame) ? frame : new Plane(cv.PointAt(t), Vector3d.ZAxis),
+                         cv.GetPerpendicularFrames([0, 0.25, 0.5, 0.75, 1.0].Select(cv.Domain.ParameterAt).ToArray()),
+                         cv.InflectionPoints() is double[] ipts && ipts.Length > 0 ? ipts : null,
+                         cv.MaxCurvaturePoints() is double[] mpts && mpts.Length > 0 ? mpts : null,
+                         cv.IsClosed ? cv.TorsionAt(t) : null) : null,
+                    Curvature: m.HasFlag(AnalysisMethod.Curvature) && cv.CurvatureAt(t) is Vector3d curv && curv.IsValid ?
+                        (null, null, curv.Length, null, null, null) : null,
+                    Discontinuities: m.HasFlag(AnalysisMethod.Discontinuity) ?
+                        (((Func<double[]>)(() => {
+                            List<double> dParams = new();
+                            double current = cv.Domain.Min;
+                            for (int i = 0; i < 20 && cv.GetNextDiscontinuity(Continuity.C1_continuous, current, cv.Domain.Max, out double td); i++, current = td + ctx.AbsoluteTolerance) {
+                                dParams.Add(td);
+                            }
+                            return [.. dParams];
+                        }))() is double[] dPs && dPs.Length > 0 ? dPs : null,
+                        null) : null,
+                    Topology: null,
+                    Proximity: null,
+                    Singularities: null,
+                    Metrics: m.HasFlag(AnalysisMethod.Metrics) ?
+                        (cv.GetLength(), null, null, AreaMassProperties.Compute(cv)?.Centroid) : null,
+                    Domains: m.HasFlag(AnalysisMethod.Domains) ? [cv.Domain] : null,
+                    Params: (t, p?.Item2, p?.Item3, order)),
+
+            (var m, Surface sf, _, var (u, v), _, var order, var ctx) when sf.Domain(0).IncludesParameter(u ?? sf.Domain(0).ParameterAt(0.5)) &&
+                sf.Domain(1).IncludesParameter(v ?? sf.Domain(1).ParameterAt(0.5)) &&
+                (u ?? sf.Domain(0).ParameterAt(0.5), v ?? sf.Domain(1).ParameterAt(0.5)) is (var uP, var vP) =>
+                new AnalysisResult(
+                    Point: m.HasFlag(AnalysisMethod.Derivatives) && sf.Evaluate(uP, vP, order, out Point3d evalPt, out Vector3d[] derivs) ? evalPt : sf.PointAt(uP, vP),
+                    Derivatives: m.HasFlag(AnalysisMethod.Derivatives) && sf.Evaluate(uP, vP, order, out Point3d _, out Vector3d[] derivs) ? derivs : [],
+                    Frames: m.HasFlag(AnalysisMethod.Frame) ?
+                        (m.HasFlag(AnalysisMethod.Derivatives) && sf.Evaluate(uP, vP, order, out Point3d pt, out Vector3d[] ds) && ds.Length >= 2 ? new Plane(pt, ds[0], ds[1]) :
+                         sf.FrameAt(uP, vP, out Plane fr) ? fr : Plane.WorldXY,
+                        null, null, null, null) : null,
+                    Curvature: m.HasFlag(AnalysisMethod.Curvature) && sf.CurvatureAt(uP, vP) is SurfaceCurvature sc ?
+                        (sc.Gaussian, sc.Mean, sc.Kappa(0), sc.Kappa(1), sc.Direction(0), sc.Direction(1)) : null,
+                    Discontinuities: m.HasFlag(AnalysisMethod.Discontinuity) ?
+                        (((Func<double[]>)(() => {
+                            List<double> dParams = new();
+                            for (int dir = 0; dir <= 1; dir++) {
+                                double current = dir == 0 ? sf.Domain(0).Min : sf.Domain(1).Min;
+                                double max = dir == 0 ? sf.Domain(0).Max : sf.Domain(1).Max;
+                                for (int i = 0; i < 10 && sf.GetNextDiscontinuity(dir, Continuity.C1_continuous, current, max, out double td); i++, current = td + ctx.AbsoluteTolerance) {
+                                    dParams.Add(td);
+                                }
+                            }
+                            return [.. dParams];
+                        }))() is double[] dPs && dPs.Length > 0 ? dPs : null,
+                        null) : null,
+                    Topology: null,
+                    Proximity: null,
+                    Singularities: m.HasFlag(AnalysisMethod.Singularity) ?
+                        (sf.IsAtSeam(uP, vP), sf.IsAtSingularity(uP, vP, true), null) : null,
+                    Metrics: m.HasFlag(AnalysisMethod.Metrics) ?
+                        (null, AreaMassProperties.Compute(sf)?.Area, null, AreaMassProperties.Compute(sf)?.Centroid) : null,
+                    Domains: m.HasFlag(AnalysisMethod.Domains) ? [sf.Domain(0), sf.Domain(1)] : null,
+                    Params: (p?.Item1, (uP, vP), p?.Item3, order)),
+
+            (var m, BrepFace face, _, var sP, _, var order, var ctx) when
+                AnalyzeCore(face.UnderlyingSurface(), m & ~AnalysisMethod.Metrics, ctx, (null, sP, null), order) is AnalysisResult faceResult =>
+                faceResult with {
+                    Metrics = m.HasFlag(AnalysisMethod.Metrics) ?
+                        (null, AreaMassProperties.Compute(face)?.Area,
+                         face.Brep is Brep fb ? VolumeMassProperties.Compute(fb)?.Volume : null,
+                         AreaMassProperties.Compute(face)?.Centroid) : null,
+                },
+
+            (var m, Brep brep, _, _, var fIdx, var order, var ctx) when (fIdx ?? 0) >= 0 && (fIdx ?? 0) < brep.Faces.Count &&
+                AnalyzeCore(brep.Faces[fIdx ?? 0], m & ~(AnalysisMethod.Topology | AnalysisMethod.Proximity | AnalysisMethod.Metrics), ctx, (null, null, fIdx ?? 0), order) is AnalysisResult brepBase =>
+                brepBase with {
+                    Topology = m.HasFlag(AnalysisMethod.Topology) ?
+                        (brep.Vertices.Select((v, i) => (i, v.Location)).ToArray(),
+                         brep.Edges.Select((e, i) => (i, new Line(e.PointAtStart, e.PointAtEnd))).ToArray(),
+                         brep.IsManifold,
+                         brep.IsSolid) : null,
+                    Proximity = m.HasFlag(AnalysisMethod.Proximity) && brep.ClosestPoint(brepBase.Point, out Point3d closestBr, out ComponentIndex ci, out double s, out double tBr, ctx.AbsoluteTolerance * 100, out Vector3d _) ?
+                        (closestBr, ci, brepBase.Point.DistanceTo(closestBr), (s, tBr)) : null,
+                    Metrics = m.HasFlag(AnalysisMethod.Metrics) ?
+                        (null, AreaMassProperties.Compute(brep)?.Area, VolumeMassProperties.Compute(brep)?.Volume, VolumeMassProperties.Compute(brep)?.Centroid) : null,
+                },
+
+            (var m, Mesh mesh, _, _, var vIdx, _, var ctx) when (vIdx ?? 0) >= 0 && (vIdx ?? 0) < mesh.Vertices.Count &&
+                (mesh.Normals.Count > (vIdx ?? 0) ? mesh.Normals[vIdx ?? 0] :
+                 mesh.Normals.ComputeNormals() && mesh.Normals.Count > (vIdx ?? 0) ? mesh.Normals[vIdx ?? 0] : Vector3d.ZAxis) is var normal =>
+                new AnalysisResult(
+                    Point: mesh.Vertices.Point3dAt(vIdx ?? 0),
+                    Derivatives: [],
+                    Frames: m.HasFlag(AnalysisMethod.Frame) ?
+                        (new Plane(mesh.Vertices.Point3dAt(vIdx ?? 0), normal.IsValid ? normal : Vector3d.ZAxis), null, null, null, null) : null,
+                    Curvature: m.HasFlag(AnalysisMethod.Curvature) ?
+                        ((Func<(double?, double?, double?, double?, Vector3d?, Vector3d?)?>)(() => {
+                            double[] gaussValues = new double[mesh.Vertices.Count];
+                            double[] meanValues = new double[mesh.Vertices.Count];
+                            double[] k1Values = new double[mesh.Vertices.Count];
+                            double[] k2Values = new double[mesh.Vertices.Count];
+                            return (mesh.Vertices.ComputeCurvature(1, gaussValues) && mesh.Vertices.ComputeCurvature(2, meanValues) &&
+                                    mesh.Vertices.ComputeCurvature(3, k1Values) && mesh.Vertices.ComputeCurvature(4, k2Values)) ?
+                                (gaussValues[vIdx ?? 0], meanValues[vIdx ?? 0], k1Values[vIdx ?? 0], k2Values[vIdx ?? 0], null, null) : null;
+                        }))() : null,
+                    Discontinuities: null,
+                    Topology: m.HasFlag(AnalysisMethod.Topology) ?
+                        (Enumerable.Range(0, mesh.TopologyVertices.Count).Select(i => (i, new Point3d(mesh.TopologyVertices[i].X, mesh.TopologyVertices[i].Y, mesh.TopologyVertices[i].Z))).ToArray(),
+                         Enumerable.Range(0, mesh.TopologyEdges.Count).Select(i => (i, mesh.TopologyEdges.EdgeLine(i))).Where(e => e.Item2.IsValid).ToArray(),
+                         mesh.IsManifold,
+                         mesh.IsClosed) : null,
+                    Proximity: m.HasFlag(AnalysisMethod.Proximity) && mesh.ClosestMeshPoint(mesh.Vertices.Point3dAt(vIdx ?? 0), ctx.AbsoluteTolerance * 100) is MeshPoint mp ?
+                        (mesh.PointAt(mp), null, 0, null) : null,
+                    Singularities: null,
+                    Metrics: m.HasFlag(AnalysisMethod.Metrics) ?
+                        (null, AreaMassProperties.Compute(mesh)?.Area, VolumeMassProperties.Compute(mesh)?.Volume,
+                         mesh.Vertices.Count > 0 ? new Point3d(mesh.Vertices.Average(v => v.X), mesh.Vertices.Average(v => v.Y), mesh.Vertices.Average(v => v.Z)) : Point3d.Origin) : null,
+                    Domains: m.HasFlag(AnalysisMethod.Domains) ? [new Interval(0, mesh.Vertices.Count)] : null,
+                    Params: (p?.Item1, p?.Item2, vIdx ?? 0, dO)),
+
+            (var m, SubD subd, _, var sP, var idx, var order, var ctx) when subd.ToBrep() is Brep sbr =>
+                ((Func<AnalysisResult?>)(() => { try { return AnalyzeCore(sbr, m, ctx, (null, sP, idx), order); } finally { sbr.Dispose(); } }))(),
+
+            (var m, PointCloud cloud, _, _, _, _, var ctx) when cloud.Count > 0 &&
+                (cloud.GetPoints(), cloud.GetBoundingBox(accurate: true).Center,
+                 Plane.FitPlaneToPoints(cloud.GetPoints(), out Plane fitted) == PlaneFitResult.Success ? fitted : Plane.WorldXY) is (var pts, var center, var plane) =>
+                new AnalysisResult(
+                    Point: center,
+                    Derivatives: [],
+                    Frames: m.HasFlag(AnalysisMethod.Frame) ? (plane, null, null, null, null) : null,
+                    Curvature: null,
+                    Discontinuities: null,
+                    Topology: null,
+                    Proximity: null,
+                    Singularities: null,
+                    Metrics: m.HasFlag(AnalysisMethod.Metrics) ? (null, null, null, center) : null,
+                    Domains: m.HasFlag(AnalysisMethod.Domains) ? [new Interval(0, cloud.Count)] : null,
+                    Params: (p?.Item1, p?.Item2, p?.Item3, dO)),
+
+            (var m, Point3d pt, _, _, _, var order, _) =>
+                new AnalysisResult(pt, [], null, null, null, null, null, null, null, null, (p?.Item1, p?.Item2, p?.Item3, order)),
+
+            (var m, Vector3d vec, _, _, _, var order, _) =>
+                new AnalysisResult(Point3d.Origin, [vec],
+                    m.HasFlag(AnalysisMethod.Frame) ? (new Plane(Point3d.Origin, vec), null, null, null, null) : null,
+                    null, null, null, null, null, null, null, (p?.Item1, p?.Item2, p?.Item3, order)),
+
             _ => null,
         };
 }


### PR DESCRIPTION
…tegration

**Architecture Enhancements:**
- Add AnalysisMethod enum with bitwise flags (Point, Derivatives, Curvature, Frame, Discontinuity, Topology, Proximity, Singularity, Metrics, Domains)
- Replace 9 boolean parameters with single method parameter and grouped tuple
- FrozenDictionary config for (AnalysisMethod, Type) → ValidationMode mapping
- Flag-based validation aggregation walking type hierarchy

**AnalysisResult Extensions:**
- Frames: Primary + perpendicular frames, inflection points, max curvature points, torsion
- Curvature: Gaussian, mean, K1, K2, principal directions
- Discontinuities: Parameters array from GetNextDiscontinuity loops
- Topology: Vertices, edges, manifold/closed checks
- Proximity: Closest point with ComponentIndex for Brep face/edge identification
- Singularities: Seam and singularity detection for surfaces

**SDK Integration Improvements:**
- Curve: DerivativeAt, GetPerpendicularFrames, InflectionPoints, MaxCurvaturePoints, TorsionAt, GetNextDiscontinuity
- Surface: Single Evaluate() call for point + derivatives (3x reduction in SDK calls), GetNextDiscontinuity, IsAtSeam, IsAtSingularity
- Mesh: Vertices.ComputeCurvature for gaussian/mean/principal curvatures, TopologyEdges/TopologyVertices, ClosestMeshPoint
- Brep: ClosestPoint with ComponentIndex, Edges enumeration, topology properties

**Code Density:**
- 247 lines (was 115) with 3x functionality increase
- Ultra-dense switch expressions with inline lambda IIFE for discontinuity loops
- Conditional field population via method.HasFlag() guards
- Zero helper methods - all computation inline in AnalyzeCore

**Error Categories Added:**
- Evaluation: DerivativeComputationFailed, SurfaceEvaluationFailed
- Discontinuity: NoneFound, TestFailed
- Topology: NoTopologyData, EdgeAccessFailed, VertexAccessFailed
- Proximity: ClosestPointFailed, ComponentIdentificationFailed
- Singularity: DetectionFailed, SeamIdentificationFailed