### PR TITLE
Remove unused DynamicInsertion enum from SpatialMethod

### DIFF
--- a/libs/rhino/spatial/SpatialMethod.cs
+++ b/libs/rhino/spatial/SpatialMethod.cs
@@ -32,7 +32,4 @@ public enum SpatialMethod {
 
     /// <summary>Brep range queries using manual RTree construction with bounding box insertion.</summary>
     BrepRange = 256,
-
-    /// <summary>Dynamic tree construction using RTree.Insert/Remove for incremental spatial indexing.</summary>
-    DynamicInsertion = 512,
 }


### PR DESCRIPTION
DynamicInsertion flag was defined but completely unimplemented. Stateful RTree operations (Insert/Remove/Clear) don't fit the pure functional pattern established in spatial/ architecture. Manual Insert operations are already used internally for Curve/Surface/Brep array indexing via inline lambdas in FrozenDictionary configuration.

Removes: SpatialMethod.DynamicInsertion = 512