### PR TITLE
fix: add missing CurveBrepFace intersection handler

### DIFF
--- a/libs/rhino/intersection/Intersect.cs
+++ b/libs/rhino/intersection/Intersect.cs
@@ -205,6 +205,8 @@ public static class Intersect {
 #pragma warning restore IDISP004
                 (Curve ca, Brep bb, _) =>
                     fromBrepIntersection(RhinoIntersect.CurveBrep(ca, bb, tolerance, out Curve[] c1, out Point3d[] p1), c1, p1),
+                (Curve ca, BrepFace bf, _) =>
+                    fromBrepIntersection(RhinoIntersect.CurveBrepFace(ca, bf, tolerance, out Curve[] c2, out Point3d[] p2), c2, p2),
                 (Brep ba, Brep bb, _) =>
                     fromBrepIntersection(RhinoIntersect.BrepBrep(ba, bb, tolerance, out Curve[] c3, out Point3d[] p3), c3, p3),
                 (Brep ba, Plane pb, _) =>


### PR DESCRIPTION
Resolves config/implementation mismatch where BrepFace was in validation dictionary but lacked corresponding ExecutePair pattern match case.

- Added (Curve, BrepFace) handler using Intersection.CurveBrepFace API
- Maintains consistency with existing Brep intersection patterns
- Prevents runtime UnsupportedMethod error for Curve-BrepFace operations