### PR TITLE
refactor(analysis): add Normal property, curvature validation, and co…

### DIFF
--- a/libs/rhino/analysis/Analysis.cs
+++ b/libs/rhino/analysis/Analysis.cs
@@ -39,6 +39,7 @@ public static class Analysis {
         Vector3d PrincipalDir1,
         Vector3d PrincipalDir2,
         Plane Frame,
+        Vector3d Normal,
         bool AtSeam,
         bool AtSingularity,
         double Area,
@@ -55,6 +56,7 @@ public static class Analysis {
         Vector3d PrincipalDir1,
         Vector3d PrincipalDir2,
         Plane Frame,
+        Vector3d Normal,
         (int Index, Point3d Point)[] Vertices,
         (int Index, Line Geometry)[] Edges,
         bool IsManifold,
@@ -71,6 +73,7 @@ public static class Analysis {
     public sealed record MeshData(
         Point3d Location,
         Plane Frame,
+        Vector3d Normal,
         (int Index, Point3d Point)[] TopologyVertices,
         (int Index, Line Geometry)[] TopologyEdges,
         bool IsManifold,

--- a/libs/rhino/analysis/AnalysisCompute.cs
+++ b/libs/rhino/analysis/AnalysisCompute.cs
@@ -11,6 +11,8 @@ namespace Arsenal.Rhino.Analysis;
 
 /// <summary>Ultra-dense computation strategies with FrozenDictionary type dispatch and embedded validation.</summary>
 internal static class AnalysisCompute {
+    private const int MaxDiscontinuities = 20;
+
     /// <summary>Type-driven strategy lookup mapping geometry types to validation modes and computation functions.</summary>
     private static readonly FrozenDictionary<Type, (ValidationMode Mode, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>> Compute)> _strategies =
         new Dictionary<Type, (ValidationMode, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>>)> {
@@ -20,10 +22,10 @@ internal static class AnalysisCompute {
                     .Bind(cv => {
                         double param = t ?? cv.Domain.Mid;
                         ArrayPool<double> pool = ArrayPool<double>.Shared;
-                        double[] buffer = pool.Rent(20);
+                        double[] buffer = pool.Rent(MaxDiscontinuities);
                         try {
                             (int discCount, double s) = (0, cv.Domain.Min);
-                            while (discCount < 20 && cv.GetNextDiscontinuity(Continuity.C1_continuous, s, cv.Domain.Max, out double td)) {
+                            while (discCount < MaxDiscontinuities && cv.GetNextDiscontinuity(Continuity.C1_continuous, s, cv.Domain.Max, out double td)) {
                                 buffer[discCount++] = td;
                                 s = td + ctx.AbsoluteTolerance;
                             }
@@ -39,7 +41,7 @@ internal static class AnalysisCompute {
                                     [.. buffer[..discCount]],
                                     [.. buffer[..discCount].Select(dp => cv.IsContinuous(Continuity.C2_continuous, dp) ? Continuity.C1_continuous : Continuity.C0_continuous),],
                                     cv.GetLength(),
-                                    amp.Centroid))
+                                    amp.Centroid,))
                                 : ResultFactory.Create<Analysis.IResult>(error: AnalysisErrors.Evaluation.CurveAnalysisFailed);
                         } finally {
                             pool.Return(buffer, clearArray: true);
@@ -52,10 +54,10 @@ internal static class AnalysisCompute {
                     .Bind(cv => {
                         double param = t ?? cv.Domain.Mid;
                         ArrayPool<double> pool = ArrayPool<double>.Shared;
-                        double[] buffer = pool.Rent(20);
+                        double[] buffer = pool.Rent(MaxDiscontinuities);
                         try {
                             (int discCount, double s) = (0, cv.Domain.Min);
-                            while (discCount < 20 && cv.GetNextDiscontinuity(Continuity.C1_continuous, s, cv.Domain.Max, out double td)) {
+                            while (discCount < MaxDiscontinuities && cv.GetNextDiscontinuity(Continuity.C1_continuous, s, cv.Domain.Max, out double td)) {
                                 buffer[discCount++] = td;
                                 s = td + ctx.AbsoluteTolerance;
                             }
@@ -71,7 +73,7 @@ internal static class AnalysisCompute {
                                     [.. buffer[..discCount]],
                                     [.. buffer[..discCount].Select(dp => cv.IsContinuous(Continuity.C2_continuous, dp) ? Continuity.C1_continuous : Continuity.C0_continuous),],
                                     cv.GetLength(),
-                                    amp.Centroid))
+                                    amp.Centroid,))
                                 : ResultFactory.Create<Analysis.IResult>(error: AnalysisErrors.Evaluation.CurveAnalysisFailed);
                         } finally {
                             pool.Return(buffer, clearArray: true);
@@ -86,6 +88,7 @@ internal static class AnalysisCompute {
                         AreaMassProperties amp = AreaMassProperties.Compute(sf);
                         return sf.Evaluate(u, v, order, out Point3d _, out Vector3d[] derivs) && amp is not null && sf.FrameAt(u, v, out Plane frame)
                             ? ResultFactory.Create(value: sf.CurvatureAt(u, v))
+                                .Filter(sc => sc.IsDefined, error: AnalysisErrors.Evaluation.SurfaceAnalysisFailed)
                                 .Map(sc => (Analysis.IResult)new Analysis.SurfaceData(
                                     sf.PointAt(u, v),
                                     derivs,
@@ -96,10 +99,11 @@ internal static class AnalysisCompute {
                                     sc.Direction(0),
                                     sc.Direction(1),
                                     frame,
+                                    frame.Normal,
                                     sf.IsAtSeam(u, v) != 0,
                                     sf.IsAtSingularity(u, v, exact: true),
                                     amp.Area,
-                                    amp.Centroid))
+                                    amp.Centroid,))
                             : ResultFactory.Create<Analysis.IResult>(error: AnalysisErrors.Evaluation.SurfaceAnalysisFailed);
                     })),
 
@@ -111,6 +115,7 @@ internal static class AnalysisCompute {
                         AreaMassProperties amp = AreaMassProperties.Compute(sf);
                         return sf.Evaluate(u, v, order, out Point3d _, out Vector3d[] derivs) && amp is not null && sf.FrameAt(u, v, out Plane frame)
                             ? ResultFactory.Create(value: sf.CurvatureAt(u, v))
+                                .Filter(sc => sc.IsDefined, error: AnalysisErrors.Evaluation.SurfaceAnalysisFailed)
                                 .Map(sc => (Analysis.IResult)new Analysis.SurfaceData(
                                     sf.PointAt(u, v),
                                     derivs,
@@ -121,10 +126,11 @@ internal static class AnalysisCompute {
                                     sc.Direction(0),
                                     sc.Direction(1),
                                     frame,
+                                    frame.Normal,
                                     sf.IsAtSeam(u, v) != 0,
                                     sf.IsAtSingularity(u, v, exact: true),
                                     amp.Area,
-                                    amp.Centroid))
+                                    amp.Centroid,))
                             : ResultFactory.Create<Analysis.IResult>(error: AnalysisErrors.Evaluation.SurfaceAnalysisFailed);
                     })),
 
@@ -139,6 +145,7 @@ internal static class AnalysisCompute {
                         (AreaMassProperties? amp, VolumeMassProperties? vmp) = (AreaMassProperties.Compute(brep), VolumeMassProperties.Compute(brep));
                         return sf.Evaluate(u, v, order, out Point3d _, out Vector3d[] derivs) && amp is not null && vmp is not null && sf.FrameAt(u, v, out Plane frame) && brep.ClosestPoint(testPoint, out Point3d cp, out ComponentIndex ci, out double uOut, out double vOut, ctx.AbsoluteTolerance * 100, out Vector3d _)
                             ? ResultFactory.Create(value: sf.CurvatureAt(u, v))
+                                .Filter(sc => sc.IsDefined, error: AnalysisErrors.Evaluation.BrepAnalysisFailed)
                                 .Map(sc => (Analysis.IResult)new Analysis.BrepData(
                                     sf.PointAt(u, v),
                                     derivs,
@@ -149,6 +156,7 @@ internal static class AnalysisCompute {
                                     sc.Direction(0),
                                     sc.Direction(1),
                                     frame,
+                                    frame.Normal,
                                     [.. brep.Vertices.Select((vtx, i) => (i, vtx.Location)),],
                                     [.. brep.Edges.Select((e, i) => (i, new Line(e.PointAtStart, e.PointAtEnd))),],
                                     brep.IsManifold,
@@ -159,7 +167,7 @@ internal static class AnalysisCompute {
                                     (uOut, vOut),
                                     amp.Area,
                                     vmp.Volume,
-                                    vmp.Centroid))
+                                    vmp.Centroid,))
                             : ResultFactory.Create<Analysis.IResult>(error: AnalysisErrors.Evaluation.BrepAnalysisFailed);
                     })),
 
@@ -168,17 +176,19 @@ internal static class AnalysisCompute {
                     .Validate(args: [ctx, ValidationMode.MeshSpecific])
                     .Bind(mesh => {
                         int vIdx = Math.Clamp(vertIdx ?? 0, 0, mesh.Vertices.Count - 1);
+                        Vector3d normal = mesh.Normals.Count > vIdx ? mesh.Normals[vIdx] : Vector3d.ZAxis;
                         (AreaMassProperties? amp, VolumeMassProperties? vmp) = (AreaMassProperties.Compute(mesh), VolumeMassProperties.Compute(mesh));
                         return amp is not null && vmp is not null
                             ? ResultFactory.Create(value: (Analysis.IResult)new Analysis.MeshData(
                                 mesh.Vertices[vIdx],
-                                new Plane(mesh.Vertices[vIdx], mesh.Normals.Count > vIdx ? mesh.Normals[vIdx] : Vector3d.ZAxis),
+                                new Plane(mesh.Vertices[vIdx], normal),
+                                normal,
                                 [.. Enumerable.Range(0, mesh.TopologyVertices.Count).Select(i => (i, (Point3d)mesh.TopologyVertices[i])),],
                                 [.. Enumerable.Range(0, mesh.TopologyEdges.Count).Select(i => (i, mesh.TopologyEdges.EdgeLine(i))),],
                                 mesh.IsManifold(topologicalTest: true, out bool _, out bool _),
                                 mesh.IsClosed,
                                 amp.Area,
-                                vmp.Volume))
+                                vmp.Volume,))
                             : ResultFactory.Create<Analysis.IResult>(error: AnalysisErrors.Evaluation.MeshAnalysisFailed);
                     })),
         }.ToFrozenDictionary();


### PR DESCRIPTION
…de quality fixes

- Add Vector3d Normal property to SurfaceData, BrepData, MeshData records (derived from Frame.Normal, zero SDK overhead)
- Add SurfaceCurvature.IsDefined validation using Result.Filter for surfaces and breps
- Add const MaxDiscontinuities = 20 to eliminate magic number in discontinuity buffer
- Fix trailing commas in 6 record constructor calls per CLAUDE.md standards
- Enhance downstream usability with direct normal access for lighting/orientation analysis