### PR TITLE
Refactor Result monad: reduce from 10 to 8 method names, improve API …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,14 @@ ResultFactory.Create(error: err)               // ✅ Named parameter for errors
 ResultFactory.Create(errors: [err1, err2,])    // ✅ Named + trailing comma
 .Map(x => transform)                           // Functor transform
 .Bind(x => Result<Y>)                          // Monadic chain
-.Apply(Result<Func>)                           // Applicative parallel
-.Filter(predicate, error: ValidationErrors.X)  // ✅ Named error parameter
-.OnError(recover: x => value)                  // ✅ Named recover parameter
-.Traverse(transform)                           // Collection inside Result
+.Ensure(predicate, error: ValidationErrors.X)  // ✅ Validation with named error parameter
+.Match(onSuccess, onFailure)                   // Pattern match exhaustive
+.Tap(onSuccess, onFailure)                     // Side effects, preserves state
+.Apply(Result<Func>)                           // Applicative parallel validation
+.OnError((Func<SystemError[], T>)recover)      // ✅ Explicit overload for recovery
+.OnError((Func<SystemError[], SystemError[]>)map) // ✅ Explicit overload for error mapping
+.OnError((Func<SystemError[], Result<T>>)recovWith) // ✅ Explicit overload for monadic recovery
+.Traverse(transform)                           // Collection traversal with Result
 ```
 
 ### Polymorphic Patterns

--- a/libs/core/results/ResultFactory.cs
+++ b/libs/core/results/ResultFactory.cs
@@ -29,7 +29,7 @@ public static class ResultFactory {
             _ => throw new ArgumentException(ResultErrors.Factory.InvalidCreateParameters.Message, nameof(value)),
         };
 
-    /// <summary>Validates Result using polymorphic parameter detection.</summary>
+    /// <summary>Validates Result using polymorphic parameter detection with unified validation semantics.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Validate<T>(
         this Result<T> result,
@@ -44,7 +44,7 @@ public static class ResultFactory {
         (predicate ?? premise, validation, validations, args) switch {
             (Func<T, bool> p, null, null, _) when error.HasValue => result.Ensure(unless is true ? x => !p(x) : conclusion is not null ? x => !p(x) || conclusion(x) : p, error.Value),
             (Func<T, bool> p, Func<T, Result<T>> v, null, _) => result.Bind(value => (unless is true ? !p(value) : p(value)) ? v(value) : Create(value: value)),
-            (null, null, (Func<T, bool>, SystemError)[] vs, _) when vs?.Length > 0 => result.Ensure([.. vs]),
+            (null, null, (Func<T, bool>, SystemError)[] vs, _) when vs?.Length > 0 => result.Ensure(vs),
             (null, null, null, [IGeometryContext ctx, ValidationMode mode]) when IsGeometryType(typeof(T)) => result.Bind(g => ValidationRules.GetOrCompileValidator(g!.GetType(), mode)(g, ctx) switch { { Length: 0 } => Create(value: g),
                 var errs => Create<T>(errors: errs),
             }),


### PR DESCRIPTION
…clarity

BREAKING CHANGES - Full rebuild, no backward compatibility:

**Core Improvements:**
- Reduced method count: 10 method names → 8 method names (20% reduction)
- Clearer intent through explicit overloading instead of optional parameters
- Better type safety by removing params object[] usage
- More explicit error handling with separate OnError overloads

**API Changes:**

1. **Removed methods:**
   - `TryGet()` → use `Match()` for value extraction
   - `Filter()` → renamed to `Ensure()` (clearer validation semantics)
   - `Reduce()` → use `Match()` for reduction operations
   - `Apply(Action<T>)` → renamed to `Tap()` (clearer side-effect intent)

2. **Refactored methods:**
   - `OnError()`: Split optional parameters into 3 explicit overloads: - `OnError(Func<SystemError[], SystemError[]>)` - error mapping - `OnError(Func<SystemError[], T>)` - recovery with value - `OnError(Func<SystemError[], Result<T>>)` - monadic recovery

   - `Ensure()`: Improved overloads for validation:
     - `Ensure(Func<T, bool>, SystemError)` - single predicate
     - `Ensure(params (Func<T, bool>, SystemError)[])` - multiple predicates

3. **Clarified methods:**
   - `Tap()` - Side effects only (was Apply with Action)
   - `Apply()` - Applicative functor only (no ambiguity)
   - `Ensure()` - Validation only (was Filter)
   - `Match()` - Pattern matching and reduction (absorbed TryGet, Reduce)

**Implementation Details:**
- All functionality retained, just reorganized
- UnifiedOperation.cs updated for new API
- All tests updated to use new explicit overloads
- CLAUDE.md documentation updated with new patterns

**Benefits:**
- Less API surface area (easier to learn)
- More explicit intent (no overload ambiguity)
- Better type safety (explicit casts for overloads)
- Consistent naming (Ensure for validation, Tap for side effects)
- Clearer separation of concerns (Apply = applicative only)

Files changed:
- libs/core/results/Result.cs
- libs/core/results/ResultFactory.cs
- libs/core/operations/UnifiedOperation.cs
- test/core/Results/*.cs (all test files updated)
- CLAUDE.md (documentation updated)