### PR TITLE
Refactor Result monad system for improved ergonomics and type safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,14 +86,23 @@ dotnet test --filter "FullyQualifiedName~Result" # Run specific test
 ```csharp
 Result<T>                                      // Lazy evaluation, monadic composition
 ResultFactory.Create(value: x)                 // ✅ Named parameter, never new Result
-ResultFactory.Create(error: err)               // ✅ Named parameter for errors
-ResultFactory.Create(errors: [err1, err2,])    // ✅ Named + trailing comma
+ResultFactory.Create(error: err)               // ✅ Named parameter for single error
+ResultFactory.Create(errors: [err1, err2,])    // ✅ Named + trailing comma for multiple
+ResultFactory.Ok(x)                            // Explicit success creation
+ResultFactory.Err<T>(error: err)               // Explicit error creation
 .Map(x => transform)                           // Functor transform
-.Bind(x => Result<Y>)                          // Monadic chain
-.Apply(Result<Func>)                           // Applicative parallel
+.Bind(x => Result<Y>)                          // Monadic chain (alias: SelectMany for LINQ)
+.Apply(Result<Func>)                           // Applicative parallel validation
 .Filter(predicate, error: ValidationErrors.X)  // ✅ Named error parameter
-.OnError(recover: x => value)                  // ✅ Named recover parameter
+.Tap(onSuccess: x => log, onFailure: e => log) // Side effects without state change
+.MapError(errs => transformed)                 // Transform errors only
+.Recover(errs => fallbackValue)                // Recover from errors with value
+.RecoverWith(errs => Result<T>)                // Recover from errors with Result
+.Ensure(pred, error: ValidationErrors.X)       // Single validation
+.EnsureAll((pred1, err1), (pred2, err2))       // Multiple validations with accumulation
 .Traverse(transform)                           // Collection inside Result
+.Validate(context: ctx, mode: ValidationMode)  // Geometry validation
+[result1, result2,].Sequence()                 // Turn list of Results into Result of list
 ```
 
 ### Polymorphic Patterns


### PR DESCRIPTION
**Breaking Changes:**
- Split OnError into MapError, Recover, RecoverWith for clarity
- Renamed Apply(Action) → Tap for side effects
- Simplified Ensure to type-safe overloads (Ensure/EnsureAll)
- Removed Reduce (use Match instead)
- Simplified Validate in factory to geometry-only validation

**New Features:**
- Added SelectMany overloads for LINQ query syntax support
- Added explicit creation helpers: Ok, Err, Errs
- Added Sequence for converting IEnumerable<Result<T>> → Result<IReadOnlyList<T>>
- Added Flatten for Result<Result<T>> → Result<T>

**Improvements:**
- More explicit error recovery methods (MapError/Recover/RecoverWith)
- Type-safe validation tuples instead of object[] parameters
- Clearer separation between side-effects (Tap) and applicative (Apply)
- Better LINQ integration with SelectMany
- Updated UnifiedOperation to use new API
- Updated CLAUDE.md with comprehensive new API documentation

Result count: 15 → 17 methods (added SelectMany variants, split OnError, added Ensure/EnsureAll)
Factory count: 6 → 9 methods (added Ok/Err/Errs/Sequence/Flatten, simplified Validate)

Net result: More methods but each is focused, type-safe, and explicit.