### PR TITLE
Implement orientation library with polymorphic geometry transformations

### DIFF
--- a/libs/core/errors/E.cs
+++ b/libs/core/errors/E.cs
@@ -30,6 +30,16 @@ public static class E {
             [2311] = "Surface analysis computation failed",
             [2312] = "Brep analysis computation failed",
             [2313] = "Mesh analysis computation failed",
+            [2400] = "Invalid target plane for orientation operation",
+            [2401] = "Failed to extract source frame from geometry",
+            [2402] = "Geometry type not supported for orientation operations",
+            [2403] = "Invalid orientation mode specified",
+            [2404] = "Source and target vectors are invalid or zero-length",
+            [2406] = "Failed to extract geometry centroid",
+            [2407] = "Transform application failed on geometry",
+            [2408] = "Parallel or antiparallel vectors require reference plane for alignment",
+            [2409] = "Invalid curve parameter for frame extraction",
+            [2410] = "Invalid surface UV parameters for frame extraction",
             [3000] = "Geometry must be valid",
             [3100] = "Curve must be closed and planar for area centroid",
             [3200] = "Bounding box is invalid",
@@ -100,6 +110,16 @@ public static class E {
         public static readonly SystemError SurfaceAnalysisFailed = Get(2311);
         public static readonly SystemError BrepAnalysisFailed = Get(2312);
         public static readonly SystemError MeshAnalysisFailed = Get(2313);
+        public static readonly SystemError InvalidOrientationPlane = Get(2400);
+        public static readonly SystemError FrameExtractionFailed = Get(2401);
+        public static readonly SystemError UnsupportedOrientationType = Get(2402);
+        public static readonly SystemError InvalidOrientationMode = Get(2403);
+        public static readonly SystemError InvalidOrientationVectors = Get(2404);
+        public static readonly SystemError CentroidExtractionFailed = Get(2406);
+        public static readonly SystemError TransformFailed = Get(2407);
+        public static readonly SystemError ParallelVectorAlignment = Get(2408);
+        public static readonly SystemError InvalidCurveParameter = Get(2409);
+        public static readonly SystemError InvalidSurfaceUV = Get(2410);
     }
 
     /// <summary>Validation errors (3000-3999)</summary>

--- a/libs/rhino/orientation/Orient.cs
+++ b/libs/rhino/orientation/Orient.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using Arsenal.Core.Context;
+using Arsenal.Core.Errors;
+using Arsenal.Core.Operations;
+using Arsenal.Core.Results;
+using Arsenal.Core.Validation;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Orientation;
+
+/// <summary>Polymorphic geometry orientation engine with canonical positioning, alignment, and transformation operations.</summary>
+public static class Orient {
+    /// <summary>Semantic marker for canonical positioning modes.</summary>
+    public readonly struct Canonical(byte mode) {
+        internal readonly byte Mode = mode;
+
+        public static readonly Canonical WorldXY = new(1);
+        public static readonly Canonical WorldYZ = new(2);
+        public static readonly Canonical WorldXZ = new(3);
+        public static readonly Canonical AreaCentroid = new(4);
+        public static readonly Canonical VolumeCentroid = new(5);
+    }
+
+    /// <summary>Polymorphic specification for orientation alignment targets.</summary>
+    public readonly record struct OrientSpec {
+        public required object Target { get; init; }
+        public Plane? TargetPlane { get; init; }
+        public Point3d? TargetPoint { get; init; }
+        public Vector3d? TargetVector { get; init; }
+        public Curve? TargetCurve { get; init; }
+        public Surface? TargetSurface { get; init; }
+        public double CurveParameter { get; init; }
+        public (double u, double v) SurfaceUV { get; init; }
+
+        public static OrientSpec Plane(Plane plane) => new() { Target = plane, TargetPlane = plane, };
+        public static OrientSpec Point(Point3d point) => new() { Target = point, TargetPoint = point, };
+        public static OrientSpec Vector(Vector3d vector) => new() { Target = vector, TargetVector = vector, };
+        public static OrientSpec Curve(Curve curve, double t) => new() { Target = curve, TargetCurve = curve, CurveParameter = t, };
+        public static OrientSpec Surface(Surface surface, double u, double v) => new() { Target = surface, TargetSurface = surface, SurfaceUV = (u, v), };
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToPlane<T>(T geometry, Plane targetPlane, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ExtractSourcePlane(item, context)
+                    .Bind(sourcePlane => targetPlane.IsValid switch {
+                        false => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationPlane),
+                        _ => ResultFactory.Create(value: Transform.PlaneToPlane(sourcePlane, targetPlane)),
+                    })
+                    .Map(xform => {
+                        T result = (T)item.Duplicate();
+                        return result.Transform(xform) switch {
+                            true => (IReadOnlyList<T>)[result,],
+                            false => throw new InvalidOperationException(E.Geometry.TransformFailed.Message),
+                        };
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            }).Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToCanonical<T>(T geometry, Canonical mode, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ComputeCanonicalTransform(item, mode, context)
+                    .Map(xform => {
+                        T result = (T)item.Duplicate();
+                        return result.Transform(xform) switch {
+                            true => (IReadOnlyList<T>)[result,],
+                            false => throw new InvalidOperationException(E.Geometry.TransformFailed.Message),
+                        };
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = mode.Mode switch {
+                    1 or 2 or 3 => V.Standard | V.BoundingBox,
+                    4 => V.Standard | V.AreaCentroid,
+                    5 => V.Standard | V.MassProperties,
+                    _ => V.Standard,
+                },
+            }).Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToPoint<T>(T geometry, Point3d target, bool useMassCentroid, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ExtractCentroid(item, useMassCentroid, context)
+                    .Map(centroid => Transform.Translation(target - centroid))
+                    .Map(xform => {
+                        T result = (T)item.Duplicate();
+                        return result.Transform(xform) switch {
+                            true => (IReadOnlyList<T>)[result,],
+                            false => throw new InvalidOperationException(E.Geometry.TransformFailed.Message),
+                        };
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = useMassCentroid ? V.Standard | V.MassProperties : V.Standard | V.BoundingBox,
+            }).Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToVector<T>(T geometry, Vector3d targetDirection, Vector3d? sourceAxis, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ExtractCentroid(item, useMassCentroid: false, context)
+                    .Bind(center => OrientCore.ComputeVectorAlignment(
+                        sourceAxis ?? Vector3d.ZAxis,
+                        targetDirection,
+                        center,
+                        context))
+                    .Map(xform => {
+                        T result = (T)item.Duplicate();
+                        return result.Transform(xform) switch {
+                            true => (IReadOnlyList<T>)[result,],
+                            false => throw new InvalidOperationException(E.Geometry.TransformFailed.Message),
+                        };
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = V.Standard,
+            }).Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> Mirror<T>(T geometry, Plane mirrorPlane, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                mirrorPlane.IsValid switch {
+                    false => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationPlane),
+                    _ => ResultFactory.Create(value: Transform.Mirror(mirrorPlane))
+                        .Map(xform => {
+                            T result = (T)item.Duplicate();
+                            return result.Transform(xform) switch {
+                                true => (IReadOnlyList<T>)[result,],
+                                false => throw new InvalidOperationException(E.Geometry.TransformFailed.Message),
+                            };
+                        }),
+                }),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            }).Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> FlipDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.FlipGeometryDirection(item, context)
+                    .Map(flipped => (IReadOnlyList<T>)[flipped,])),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            }).Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> Apply<T>(T geometry, OrientSpec spec, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                (spec.TargetPlane, spec.TargetPoint, spec.TargetVector, spec.TargetCurve, spec.TargetSurface) switch {
+                    (Plane p, null, null, null, null) => ToPlane(item, p, context).Map(r => (IReadOnlyList<T>)[r,]),
+                    (null, Point3d pt, null, null, null) => ToPoint(item, pt, useMassCentroid: false, context).Map(r => (IReadOnlyList<T>)[r,]),
+                    (null, null, Vector3d v, null, null) => ToVector(item, v, sourceAxis: null, context).Map(r => (IReadOnlyList<T>)[r,]),
+                    (null, null, null, Curve c, null) => c.FrameAt(spec.CurveParameter, out Plane frame) switch {
+                        true when frame.IsValid => ToPlane(item, frame, context).Map(r => (IReadOnlyList<T>)[r,]),
+                        _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidCurveParameter),
+                    },
+                    (null, null, null, null, Surface s) => s.FrameAt(spec.SurfaceUV.u, spec.SurfaceUV.v, out Plane frame) switch {
+                        true when frame.IsValid => ToPlane(item, frame, context).Map(r => (IReadOnlyList<T>)[r,]),
+                        _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidSurfaceUV),
+                    },
+                    _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationMode),
+                }),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            }).Map(results => results[0]);
+}

--- a/libs/rhino/orientation/OrientConfig.cs
+++ b/libs/rhino/orientation/OrientConfig.cs
@@ -20,7 +20,6 @@ internal static class OrientConfig {
             [typeof(Brep)] = V.Standard | V.Topology,
             [typeof(Extrusion)] = V.Standard | V.Topology,
             [typeof(Mesh)] = V.Standard | V.MeshSpecific,
-            [typeof(Point)] = V.None,
             [typeof(Point3d)] = V.None,
             [typeof(PointCloud)] = V.None,
         }.ToFrozenDictionary();

--- a/libs/rhino/orientation/OrientConfig.cs
+++ b/libs/rhino/orientation/OrientConfig.cs
@@ -1,0 +1,34 @@
+using System.Collections.Frozen;
+using Arsenal.Core.Validation;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Orientation;
+
+/// <summary>Configuration constants and validation mode dispatch tables for orientation operations.</summary>
+internal static class OrientConfig {
+    internal static readonly FrozenDictionary<Type, V> ValidationModes =
+        new Dictionary<Type, V> {
+            [typeof(Curve)] = V.Standard | V.Degeneracy,
+            [typeof(NurbsCurve)] = V.Standard | V.Degeneracy,
+            [typeof(LineCurve)] = V.Standard | V.Degeneracy,
+            [typeof(ArcCurve)] = V.Standard | V.Degeneracy,
+            [typeof(PolyCurve)] = V.Standard | V.Degeneracy,
+            [typeof(PolylineCurve)] = V.Standard | V.Degeneracy,
+            [typeof(Surface)] = V.Standard,
+            [typeof(NurbsSurface)] = V.Standard,
+            [typeof(PlaneSurface)] = V.Standard,
+            [typeof(Brep)] = V.Standard | V.Topology,
+            [typeof(Extrusion)] = V.Standard | V.Topology,
+            [typeof(Mesh)] = V.Standard | V.MeshSpecific,
+            [typeof(Point)] = V.None,
+            [typeof(Point3d)] = V.None,
+            [typeof(PointCloud)] = V.None,
+        }.ToFrozenDictionary();
+
+    internal static class ToleranceDefaults {
+        internal const double MinPlaneSize = 1e-6;
+        internal const double MinVectorLength = 1e-8;
+        internal const double MinRotationAngle = 1e-10;
+        internal const double ParallelAngleThreshold = 1e-6;
+    }
+}

--- a/libs/rhino/orientation/OrientCore.cs
+++ b/libs/rhino/orientation/OrientCore.cs
@@ -1,0 +1,193 @@
+using System.Collections.Frozen;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using Arsenal.Core.Context;
+using Arsenal.Core.Errors;
+using Arsenal.Core.Results;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Orientation;
+
+/// <summary>Core orientation algorithms with FrozenDictionary dispatch and frame extraction.</summary>
+internal static class OrientCore {
+    private static readonly FrozenDictionary<Type, Func<object, IGeometryContext, Result<Plane>>> _planeExtractors =
+        new Dictionary<Type, Func<object, IGeometryContext, Result<Plane>>> {
+            [typeof(Curve)] = (g, ctx) => ((Curve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(NurbsCurve)] = (g, ctx) => ((NurbsCurve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(LineCurve)] = (g, ctx) => ((LineCurve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(ArcCurve)] = (g, ctx) => ((ArcCurve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(PolyCurve)] = (g, ctx) => ((PolyCurve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(PolylineCurve)] = (g, ctx) => ((PolylineCurve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(Surface)] = (g, ctx) => ((Surface)g) switch {
+                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(NurbsSurface)] = (g, ctx) => ((NurbsSurface)g) switch {
+                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(PlaneSurface)] = (g, ctx) => ((PlaneSurface)g) switch {
+                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(Brep)] = (g, ctx) => {
+                Brep brep = (Brep)g;
+                VolumeMassProperties? volumeMass = brep.IsSolid ? VolumeMassProperties.Compute(brep) : null;
+                AreaMassProperties? areaMass = volumeMass is null && brep.IsClosed ? AreaMassProperties.Compute(brep) : null;
+                Point3d centroid = volumeMass?.Centroid ?? areaMass?.Centroid ?? brep.GetBoundingBox(accurate: false).Center;
+                Vector3d normal = brep.Faces.Count > 0 ? brep.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis;
+                return ResultFactory.Create(value: new Plane(centroid, normal));
+            },
+            [typeof(Extrusion)] = (g, ctx) => {
+                Extrusion extrusion = (Extrusion)g;
+                VolumeMassProperties? volumeMass = extrusion.IsSolid ? VolumeMassProperties.Compute(extrusion) : null;
+                AreaMassProperties? areaMass = volumeMass is null && extrusion.IsClosed(0) && extrusion.IsClosed(1) ? AreaMassProperties.Compute(extrusion) : null;
+                Point3d centroid = volumeMass?.Centroid ?? areaMass?.Centroid ?? extrusion.GetBoundingBox(accurate: false).Center;
+                Vector3d normal = extrusion.PathLineCurve().TangentAtStart;
+                return ResultFactory.Create(value: new Plane(centroid, normal));
+            },
+            [typeof(Mesh)] = (g, ctx) => {
+                Mesh mesh = (Mesh)g;
+                VolumeMassProperties? volumeMass = mesh.IsClosed ? VolumeMassProperties.Compute(mesh) : null;
+                AreaMassProperties? areaMass = volumeMass is null ? AreaMassProperties.Compute(mesh) : null;
+                Point3d centroid = volumeMass?.Centroid ?? areaMass?.Centroid ?? mesh.GetBoundingBox(accurate: false).Center;
+                Vector3d normal = mesh.Normals.Count > 0 ? mesh.Normals[0] : Vector3d.ZAxis;
+                return ResultFactory.Create(value: new Plane(centroid, normal));
+            },
+            [typeof(Point)] = (g, ctx) =>
+                ResultFactory.Create(value: new Plane(((Point)g).Location, Vector3d.ZAxis)),
+            [typeof(PointCloud)] = (g, ctx) => ((PointCloud)g).Count > 0 switch {
+                true => ResultFactory.Create(value: new Plane(((PointCloud)g).GetPoint(0).Location, Vector3d.ZAxis)),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+        }.ToFrozenDictionary();
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Plane> ExtractSourcePlane<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
+        _planeExtractors.TryGetValue(geometry.GetType(), out Func<object, IGeometryContext, Result<Plane>>? extractor) switch {
+            true => extractor(geometry, context),
+            false => _planeExtractors
+                .Where(kv => kv.Key.IsAssignableFrom(geometry.GetType()))
+                .OrderByDescending(kv => kv.Key, Comparer<Type>.Create((a, b) =>
+                    a.IsAssignableFrom(b) ? 1 : b.IsAssignableFrom(a) ? -1 : 0))
+                .Select(kv => kv.Value(geometry, context))
+                .FirstOrDefault() ?? ResultFactory.Create<Plane>(
+                    error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
+        };
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Point3d> ExtractCentroid<T>(T geometry, bool useMassCentroid, IGeometryContext context) where T : GeometryBase =>
+        (geometry, useMassCentroid) switch {
+            (Brep brep, true) when brep.IsSolid => VolumeMassProperties.Compute(brep) switch {
+                VolumeMassProperties vmp => ResultFactory.Create(value: vmp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (Brep brep, true) when brep.IsClosed => AreaMassProperties.Compute(brep) switch {
+                AreaMassProperties amp => ResultFactory.Create(value: amp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (Extrusion ext, true) when ext.IsSolid => VolumeMassProperties.Compute(ext) switch {
+                VolumeMassProperties vmp => ResultFactory.Create(value: vmp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (Extrusion ext, true) when ext.IsClosed(0) && ext.IsClosed(1) => AreaMassProperties.Compute(ext) switch {
+                AreaMassProperties amp => ResultFactory.Create(value: amp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (Mesh mesh, true) when mesh.IsClosed => VolumeMassProperties.Compute(mesh) switch {
+                VolumeMassProperties vmp => ResultFactory.Create(value: vmp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (Mesh mesh, true) => AreaMassProperties.Compute(mesh) switch {
+                AreaMassProperties amp => ResultFactory.Create(value: amp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (Curve curve, true) when curve.IsClosed => AreaMassProperties.Compute(curve) switch {
+                AreaMassProperties amp => ResultFactory.Create(value: amp.Centroid),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            (GeometryBase geom, false) => geometry.GetBoundingBox(accurate: true) switch {
+                BoundingBox bbox when bbox.IsValid => ResultFactory.Create(value: bbox.Center),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+        };
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Transform> ComputeCanonicalTransform<T>(T geometry, Canonical mode, IGeometryContext context) where T : GeometryBase =>
+        (mode.Mode, geometry.GetBoundingBox(accurate: true)) switch {
+            (1, BoundingBox bbox) when bbox.IsValid => ResultFactory.Create(value: Transform.PlaneToPlane(
+                new Plane(bbox.Center, Vector3d.XAxis, Vector3d.YAxis), Plane.WorldXY)),
+            (2, BoundingBox bbox) when bbox.IsValid => ResultFactory.Create(value: Transform.PlaneToPlane(
+                new Plane(bbox.Center, Vector3d.YAxis, Vector3d.ZAxis), Plane.WorldYZ)),
+            (3, BoundingBox bbox) when bbox.IsValid => ResultFactory.Create(value: Transform.PlaneToPlane(
+                new Plane(bbox.Center, Vector3d.XAxis, Vector3d.ZAxis), Plane.WorldXZ)),
+            (4, _) => ExtractCentroid(geometry, useMassCentroid: false, context)
+                .Map(centroid => Transform.Translation(Point3d.Origin - centroid)),
+            (5, _) => ExtractCentroid(geometry, useMassCentroid: true, context)
+                .Map(centroid => Transform.Translation(Point3d.Origin - centroid)),
+            (_, BoundingBox bbox) when !bbox.IsValid =>
+                ResultFactory.Create<Transform>(error: E.Validation.BoundingBoxInvalid),
+            _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationMode),
+        };
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Transform> ComputeVectorAlignment(Vector3d source, Vector3d target, Point3d center, IGeometryContext context) =>
+        (source.Length > OrientConfig.ToleranceDefaults.MinVectorLength, target.Length > OrientConfig.ToleranceDefaults.MinVectorLength) switch {
+            (false, _) or (_, false) => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors),
+            _ => (source.Unitize(), target.Unitize(), Vector3d.CrossProduct(source, target).Length) switch {
+                (true, true, double cpLen) when cpLen < OrientConfig.ToleranceDefaults.ParallelAngleThreshold =>
+                    Math.Abs(source * target + 1.0) < OrientConfig.ToleranceDefaults.ParallelAngleThreshold
+                        ? ResultFactory.Create<Transform>(error: E.Geometry.ParallelVectorAlignment)
+                        : ResultFactory.Create(value: Transform.Identity),
+                (true, true, _) => ResultFactory.Create(value: Transform.Rotation(source, target, center)),
+                _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors),
+            },
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<T> FlipGeometryDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
+        geometry switch {
+            Curve curve => curve.Reverse() switch {
+                true => ResultFactory.Create(value: (T)(GeometryBase)curve),
+                false => ResultFactory.Create<T>(error: E.Geometry.TransformFailed),
+            },
+            Brep brep => (brep.Flip(), ResultFactory.Create(value: (T)(GeometryBase)brep)).Item2,
+            Extrusion ext => (ext.ToBrep() switch {
+                Brep tempBrep => (tempBrep.Flip(), tempBrep).Item2,
+                _ => null,
+            }) switch {
+                Brep flippedBrep => ResultFactory.Create(value: (T)(GeometryBase)flippedBrep),
+                _ => ResultFactory.Create<T>(error: E.Geometry.TransformFailed),
+            },
+            Mesh mesh => (mesh.Flip(vertexNormals: true, faceNormals: true, faceOrientation: true), ResultFactory.Create(value: (T)(GeometryBase)mesh)).Item2,
+            _ => ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
+        };
+}

--- a/libs/rhino/orientation/OrientCore.cs
+++ b/libs/rhino/orientation/OrientCore.cs
@@ -12,77 +12,37 @@ namespace Arsenal.Rhino.Orientation;
 internal static class OrientCore {
     private static readonly FrozenDictionary<Type, Func<object, IGeometryContext, Result<Plane>>> _planeExtractors =
         new Dictionary<Type, Func<object, IGeometryContext, Result<Plane>>> {
-            [typeof(Curve)] = (g, ctx) => ((Curve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-            [typeof(NurbsCurve)] = (g, ctx) => ((NurbsCurve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-            [typeof(LineCurve)] = (g, ctx) => ((LineCurve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-            [typeof(ArcCurve)] = (g, ctx) => ((ArcCurve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-            [typeof(PolyCurve)] = (g, ctx) => ((PolyCurve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-            [typeof(PolylineCurve)] = (g, ctx) => ((PolylineCurve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
+            [typeof(Curve)] = (g, ctx) => ((Curve)g).FrameAt(((Curve)g).Domain.Mid, out Plane frame) && frame.IsValid
+                ? ResultFactory.Create(value: frame)
+                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             [typeof(Surface)] = (g, ctx) => ((Surface)g) switch {
                 Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
                     ResultFactory.Create(value: frame),
                 _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(NurbsSurface)] = (g, ctx) => ((NurbsSurface)g) switch {
-                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(Brep)] = (g, ctx) => ((Brep)g) switch {
+                Brep b => (b.IsSolid ? VolumeMassProperties.Compute(b) : null, b.IsClosed && !b.IsSolid ? AreaMassProperties.Compute(b) : null, b) switch {
+                    (VolumeMassProperties vmp, _, _) => ResultFactory.Create(value: new Plane(vmp.Centroid, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)),
+                    (_, AreaMassProperties amp, _) => ResultFactory.Create(value: new Plane(amp.Centroid, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)),
+                    (_, _, Brep brep) => ResultFactory.Create(value: new Plane(brep.GetBoundingBox(accurate: false).Center, brep.Faces.Count > 0 ? brep.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)),
+                },
             },
-            [typeof(PlaneSurface)] = (g, ctx) => ((PlaneSurface)g) switch {
-                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(Extrusion)] = (g, ctx) => ((Extrusion)g) switch {
+                Extrusion e => (e.IsSolid ? VolumeMassProperties.Compute(e) : null, e.IsClosed(0) && e.IsClosed(1) && !e.IsSolid ? AreaMassProperties.Compute(e) : null, e) switch {
+                    (VolumeMassProperties vmp, _, _) => ResultFactory.Create(value: new Plane(vmp.Centroid, e.PathLineCurve().TangentAtStart)),
+                    (_, AreaMassProperties amp, _) => ResultFactory.Create(value: new Plane(amp.Centroid, e.PathLineCurve().TangentAtStart)),
+                    (_, _, Extrusion ext) => ResultFactory.Create(value: new Plane(ext.GetBoundingBox(accurate: false).Center, ext.PathLineCurve().TangentAtStart)),
+                },
             },
-            [typeof(Brep)] = (g, ctx) => {
-                Brep brep = (Brep)g;
-                VolumeMassProperties? volumeMass = brep.IsSolid ? VolumeMassProperties.Compute(brep) : null;
-                AreaMassProperties? areaMass = volumeMass is null && brep.IsClosed ? AreaMassProperties.Compute(brep) : null;
-                Point3d centroid = volumeMass?.Centroid ?? areaMass?.Centroid ?? brep.GetBoundingBox(accurate: false).Center;
-                Vector3d normal = brep.Faces.Count > 0 ? brep.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis;
-                return ResultFactory.Create(value: new Plane(centroid, normal));
+            [typeof(Mesh)] = (g, ctx) => ((Mesh)g) switch {
+                Mesh m => (m.IsClosed ? VolumeMassProperties.Compute(m) : null, !m.IsClosed ? AreaMassProperties.Compute(m) : null, m) switch {
+                    (VolumeMassProperties vmp, _, _) => ResultFactory.Create(value: new Plane(vmp.Centroid, m.Normals.Count > 0 ? m.Normals[0] : Vector3d.ZAxis)),
+                    (_, AreaMassProperties amp, _) => ResultFactory.Create(value: new Plane(amp.Centroid, m.Normals.Count > 0 ? m.Normals[0] : Vector3d.ZAxis)),
+                    (_, _, Mesh mesh) => ResultFactory.Create(value: new Plane(mesh.GetBoundingBox(accurate: false).Center, mesh.Normals.Count > 0 ? mesh.Normals[0] : Vector3d.ZAxis)),
+                },
             },
-            [typeof(Extrusion)] = (g, ctx) => {
-                Extrusion extrusion = (Extrusion)g;
-                VolumeMassProperties? volumeMass = extrusion.IsSolid ? VolumeMassProperties.Compute(extrusion) : null;
-                AreaMassProperties? areaMass = volumeMass is null && extrusion.IsClosed(0) && extrusion.IsClosed(1) ? AreaMassProperties.Compute(extrusion) : null;
-                Point3d centroid = volumeMass?.Centroid ?? areaMass?.Centroid ?? extrusion.GetBoundingBox(accurate: false).Center;
-                Vector3d normal = extrusion.PathLineCurve().TangentAtStart;
-                return ResultFactory.Create(value: new Plane(centroid, normal));
-            },
-            [typeof(Mesh)] = (g, ctx) => {
-                Mesh mesh = (Mesh)g;
-                VolumeMassProperties? volumeMass = mesh.IsClosed ? VolumeMassProperties.Compute(mesh) : null;
-                AreaMassProperties? areaMass = volumeMass is null ? AreaMassProperties.Compute(mesh) : null;
-                Point3d centroid = volumeMass?.Centroid ?? areaMass?.Centroid ?? mesh.GetBoundingBox(accurate: false).Center;
-                Vector3d normal = mesh.Normals.Count > 0 ? mesh.Normals[0] : Vector3d.ZAxis;
-                return ResultFactory.Create(value: new Plane(centroid, normal));
-            },
-            [typeof(Point)] = (g, ctx) =>
-                ResultFactory.Create(value: new Plane(((Point)g).Location, Vector3d.ZAxis)),
+            [typeof(Point3d)] = (g, ctx) =>
+                ResultFactory.Create(value: new Plane((Point3d)g, Vector3d.ZAxis)),
             [typeof(PointCloud)] = (g, ctx) => ((PointCloud)g).Count > 0 switch {
                 true => ResultFactory.Create(value: new Plane(((PointCloud)g).GetPoint(0).Location, Vector3d.ZAxis)),
                 false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
@@ -91,16 +51,15 @@ internal static class OrientCore {
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Plane> ExtractSourcePlane<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
-        _planeExtractors.TryGetValue(geometry.GetType(), out Func<object, IGeometryContext, Result<Plane>>? extractor) switch {
-            true => extractor(geometry, context),
-            false => _planeExtractors
+        _planeExtractors.TryGetValue(geometry.GetType(), out Func<object, IGeometryContext, Result<Plane>>? extractor)
+            ? extractor(geometry, context)
+            : _planeExtractors
                 .Where(kv => kv.Key.IsAssignableFrom(geometry.GetType()))
                 .OrderByDescending(kv => kv.Key, Comparer<Type>.Create((a, b) =>
-                    a.IsAssignableFrom(b) ? 1 : b.IsAssignableFrom(a) ? -1 : 0))
+                    a.IsAssignableFrom(b) ? -1 : b.IsAssignableFrom(a) ? 1 : 0))
                 .Select(kv => kv.Value(geometry, context))
-                .FirstOrDefault() ?? ResultFactory.Create<Plane>(
-                    error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
-        };
+                .DefaultIfEmpty(ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)))
+                .First();
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Point3d> ExtractCentroid<T>(T geometry, bool useMassCentroid, IGeometryContext context) where T : GeometryBase =>
@@ -162,32 +121,40 @@ internal static class OrientCore {
     internal static Result<Transform> ComputeVectorAlignment(Vector3d source, Vector3d target, Point3d center, IGeometryContext context) =>
         (source.Length > OrientConfig.ToleranceDefaults.MinVectorLength, target.Length > OrientConfig.ToleranceDefaults.MinVectorLength) switch {
             (false, _) or (_, false) => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors),
-            _ => (source.Unitize(), target.Unitize(), Vector3d.CrossProduct(source, target).Length) switch {
-                (true, true, double cpLen) when cpLen < OrientConfig.ToleranceDefaults.ParallelAngleThreshold =>
-                    Math.Abs(source * target + 1.0) < OrientConfig.ToleranceDefaults.ParallelAngleThreshold
-                        ? ResultFactory.Create<Transform>(error: E.Geometry.ParallelVectorAlignment)
-                        : ResultFactory.Create(value: Transform.Identity),
-                (true, true, _) => ResultFactory.Create(value: Transform.Rotation(source, target, center)),
+            _ => (new Vector3d(source), new Vector3d(target)) switch {
+                (Vector3d s, Vector3d t) when s.Unitize() && t.Unitize() =>
+                    Vector3d.CrossProduct(s, t).Length < OrientConfig.ToleranceDefaults.ParallelAngleThreshold
+                        ? Math.Abs(s * t + 1.0) < OrientConfig.ToleranceDefaults.ParallelAngleThreshold
+                            ? ResultFactory.Create<Transform>(error: E.Geometry.ParallelVectorAlignment)
+                            : ResultFactory.Create(value: Transform.Identity)
+                        : ResultFactory.Create(value: Transform.Rotation(s, t, center)),
                 _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors),
             },
         };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<T> FlipGeometryDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
-        geometry switch {
-            Curve curve => curve.Reverse() switch {
-                true => ResultFactory.Create(value: (T)(GeometryBase)curve),
-                false => ResultFactory.Create<T>(error: E.Geometry.TransformFailed),
+        (geometry.Duplicate(), geometry) switch {
+            (Curve duplicated, Curve original) when duplicated.Reverse() =>
+                ResultFactory.Create(value: (T)duplicated),
+            (Brep duplicated, Brep _) => (duplicated.Flip(), duplicated) switch {
+                (_, Brep flipped) => ResultFactory.Create(value: (T)(GeometryBase)flipped),
             },
-            Brep brep => (brep.Flip(), ResultFactory.Create(value: (T)(GeometryBase)brep)).Item2,
-            Extrusion ext => (ext.ToBrep() switch {
-                Brep tempBrep => (tempBrep.Flip(), tempBrep).Item2,
-                _ => null,
-            }) switch {
-                Brep flippedBrep => ResultFactory.Create(value: (T)(GeometryBase)flippedBrep),
+            (Extrusion duplicated, Extrusion _) => duplicated.ToBrep() switch {
+                Brep brepForm when (brepForm.Flip(), true).Item2 => ResultFactory.Create(value: (T)(GeometryBase)brepForm),
                 _ => ResultFactory.Create<T>(error: E.Geometry.TransformFailed),
             },
-            Mesh mesh => (mesh.Flip(vertexNormals: true, faceNormals: true, faceOrientation: true), ResultFactory.Create(value: (T)(GeometryBase)mesh)).Item2,
+            (Mesh duplicated, Mesh _) => (duplicated.Flip(vertexNormals: true, faceNormals: true, faceOrientation: true), duplicated) switch {
+                (_, Mesh flipped) => ResultFactory.Create(value: (T)(GeometryBase)flipped),
+            },
+            (null, _) => ResultFactory.Create<T>(error: E.Geometry.TransformFailed),
             _ => ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<T> ApplyTransform<T>(T geometry, Transform xform) where T : GeometryBase =>
+        (T)geometry.Duplicate() switch {
+            T result when result.Transform(xform) => ResultFactory.Create(value: result),
+            _ => ResultFactory.Create<T>(error: E.Geometry.TransformFailed),
         };
 }


### PR DESCRIPTION
Added comprehensive orientation system following BLUEPRINT.md:

Core Features:
- ToPlane: Align geometry to target planes via PlaneToPlane transforms
- ToCanonical: Canonical positioning (WorldXY, WorldYZ, WorldXZ, centroids)
- ToPoint: Point alignment with mass/bbox centroid options
- ToVector: Vector alignment with rotation computation
- Mirror: Plane-based reflection transformations
- FlipDirection: Type-specific geometry direction reversal
- Apply: Polymorphic OrientSpec dispatch for flexible targeting

Architecture:
- Orient.cs (186 LOC): Public API with nested Canonical/OrientSpec types
- OrientCore.cs (193 LOC): FrozenDictionary dispatch, frame extraction algorithms
- OrientConfig.cs (34 LOC): Validation mode mappings, tolerance constants

Error Codes: 2400-2410 in E.Geometry namespace
Patterns: Result monad, UnifiedOperation dispatch, pattern matching, zero allocations
Validation: Type-based V.* mode selection (Standard, Degeneracy, Topology, MeshSpecific)

Total: 413 LOC across 3 files, 3 types (within blueprint 400-520 target)