### PR TITLE
Implement comprehensive orientation library with PlaneToPlane transforms

### DIFF
--- a/libs/core/errors/E.cs
+++ b/libs/core/errors/E.cs
@@ -30,6 +30,15 @@ public static class E {
             [2311] = "Surface analysis computation failed",
             [2312] = "Brep analysis computation failed",
             [2313] = "Mesh analysis computation failed",
+            [2400] = "Invalid target plane for orientation operation",
+            [2401] = "Failed to extract source frame from geometry",
+            [2402] = "Geometry type not supported for orientation operations",
+            [2403] = "Invalid orientation mode specified",
+            [2404] = "Source and target vectors are invalid or zero-length",
+            [2407] = "Transform application failed on geometry",
+            [2408] = "Parallel or antiparallel vectors require reference plane for alignment",
+            [2409] = "Invalid curve parameter for frame extraction",
+            [2410] = "Invalid surface UV parameters for frame extraction",
             [3000] = "Geometry must be valid",
             [3100] = "Curve must be closed and planar for area centroid",
             [3200] = "Bounding box is invalid",
@@ -100,6 +109,15 @@ public static class E {
         public static readonly SystemError SurfaceAnalysisFailed = Get(2311);
         public static readonly SystemError BrepAnalysisFailed = Get(2312);
         public static readonly SystemError MeshAnalysisFailed = Get(2313);
+        public static readonly SystemError InvalidOrientationPlane = Get(2400);
+        public static readonly SystemError FrameExtractionFailed = Get(2401);
+        public static readonly SystemError UnsupportedOrientationType = Get(2402);
+        public static readonly SystemError InvalidOrientationMode = Get(2403);
+        public static readonly SystemError InvalidOrientationVectors = Get(2404);
+        public static readonly SystemError TransformFailed = Get(2407);
+        public static readonly SystemError ParallelVectorAlignment = Get(2408);
+        public static readonly SystemError InvalidCurveParameter = Get(2409);
+        public static readonly SystemError InvalidSurfaceUV = Get(2410);
     }
 
     /// <summary>Validation errors (3000-3999)</summary>

--- a/libs/rhino/orientation/Orient.cs
+++ b/libs/rhino/orientation/Orient.cs
@@ -1,0 +1,258 @@
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using Arsenal.Core.Context;
+using Arsenal.Core.Errors;
+using Arsenal.Core.Operations;
+using Arsenal.Core.Results;
+using Arsenal.Core.Validation;
+using Rhino;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Orientation;
+
+/// <summary>Polymorphic geometry orientation engine providing canonical positioning, alignment, mirroring, and directional corrections.</summary>
+public static class Orient {
+    /// <summary>Aligns geometry to target plane using PlaneToPlane transform with source frame extraction.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToPlane<T>(T geometry, Plane targetPlane, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ExtractSourcePlane(item, context)
+                    .Bind(sourcePlane => targetPlane.IsValid switch {
+                        false => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationPlane),
+                        _ => ResultFactory.Create(value: Transform.PlaneToPlane(sourcePlane, targetPlane)),
+                    })
+                    .Bind(xform => (xform.IsValid, Math.Abs(xform.Determinant) > OrientConfig.ToleranceDefaults.MinDeterminant) switch {
+                        (false, _) or (_, false) => ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Invalid transform")),
+                        _ => (item.Duplicate(), xform) switch {
+                            (T duplicated, Transform transform) when duplicated.Transform(transform) =>
+                                ResultFactory.Create(value: (IReadOnlyList<T>)[duplicated,]),
+                            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed.WithContext("Transform application failed")),
+                        },
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            })
+        .Map(results => results[0]);
+
+    /// <summary>Positions geometry using canonical world plane alignment or centroid positioning.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToCanonical<T>(T geometry, Canonical mode, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ComputeCanonicalTransform(item, mode, context)
+                    .Bind(xform => (xform.IsValid, Math.Abs(xform.Determinant) > OrientConfig.ToleranceDefaults.MinDeterminant) switch {
+                        (false, _) or (_, false) => ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Invalid canonical transform")),
+                        _ => (item.Duplicate(), xform) switch {
+                            (T duplicated, Transform transform) when duplicated.Transform(transform) =>
+                                ResultFactory.Create(value: (IReadOnlyList<T>)[duplicated,]),
+                            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed.WithContext("Canonical transform application failed")),
+                        },
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = mode.Mode switch {
+                    1 or 2 or 3 => V.Standard | V.BoundingBox,
+                    4 => V.Standard | V.MassProperties,
+                    5 => V.Standard | V.MassProperties,
+                    _ => V.Standard,
+                },
+            })
+        .Map(results => results[0]);
+
+    /// <summary>Aligns geometry center to target point using translation transform.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToPoint<T>(T geometry, Point3d target, bool useMassCentroid, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ExtractCentroid(item, useMassCentroid, context)
+                    .Map(centroid => Transform.Translation(target - centroid))
+                    .Bind(xform => (xform.IsValid, Math.Abs(xform.Determinant) > OrientConfig.ToleranceDefaults.MinDeterminant) switch {
+                        (false, _) or (_, false) => ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Invalid translation transform")),
+                        _ => (item.Duplicate(), xform) switch {
+                            (T duplicated, Transform transform) when duplicated.Transform(transform) =>
+                                ResultFactory.Create(value: (IReadOnlyList<T>)[duplicated,]),
+                            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed.WithContext("Translation application failed")),
+                        },
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = useMassCentroid ? V.Standard | V.MassProperties : V.Standard | V.BoundingBox,
+            })
+        .Map(results => results[0]);
+
+    /// <summary>Rotates geometry to align source axis with target direction vector.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> ToVector<T>(T geometry, Vector3d targetDirection, Vector3d? sourceAxis, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.ExtractCentroid(item, useMassCentroid: false, context)
+                    .Bind(center => OrientCore.ComputeVectorAlignment(
+                        sourceAxis ?? Vector3d.ZAxis,
+                        targetDirection,
+                        center,
+                        context))
+                    .Bind(xform => (xform.IsValid, Math.Abs(xform.Determinant) > OrientConfig.ToleranceDefaults.MinDeterminant) switch {
+                        (false, _) or (_, false) => ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Invalid rotation transform")),
+                        _ => (item.Duplicate(), xform) switch {
+                            (T duplicated, Transform transform) when duplicated.Transform(transform) =>
+                                ResultFactory.Create(value: (IReadOnlyList<T>)[duplicated,]),
+                            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed.WithContext("Rotation application failed")),
+                        },
+                    })),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            })
+        .Map(results => results[0]);
+
+    /// <summary>Mirrors geometry across plane using reflection transform.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> Mirror<T>(T geometry, Plane mirrorPlane, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                mirrorPlane.IsValid switch {
+                    false => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationPlane.WithContext("Mirror plane invalid")),
+                    _ => (Transform.Mirror(mirrorPlane), item.Duplicate()) switch {
+                        (Transform xform, T duplicated) when xform.IsValid && Math.Abs(xform.Determinant) > OrientConfig.ToleranceDefaults.MinDeterminant && duplicated.Transform(xform) =>
+                            ResultFactory.Create(value: (IReadOnlyList<T>)[duplicated,]),
+                        _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed.WithContext("Mirror transform application failed")),
+                    },
+                }),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            })
+        .Map(results => results[0]);
+
+    /// <summary>Flips geometry direction using type-specific in-place mutation.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> FlipDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
+        UnifiedOperation.Apply(
+            input: geometry,
+            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
+                OrientCore.FlipGeometryDirection(item.Duplicate() is T duplicated ? duplicated : item, context)
+                    .Map(flipped => (IReadOnlyList<T>)[flipped,])),
+            config: new OperationConfig<T, T> {
+                Context = context,
+                ValidationMode = OrientConfig.ValidationModes.TryGetValue(typeof(T), out V mode) ? mode : V.Standard,
+            })
+        .Map(results => results[0]);
+
+    /// <summary>Applies polymorphic orientation specification to geometry with type-based dispatch.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<T> Apply<T>(T geometry, OrientSpec spec, IGeometryContext context) where T : GeometryBase =>
+        (spec.Target, spec.TargetPlane, spec.TargetPoint, spec.TargetVector, spec.TargetCurve, spec.TargetSurface) switch {
+            (_, Plane plane, null, null, null, null) when plane.IsValid =>
+                ToPlane(geometry, plane, context),
+            (_, null, Point3d point, null, null, null) =>
+                ToPoint(geometry, point, useMassCentroid: true, context),
+            (_, null, null, Vector3d vector, null, null) when vector.Length > OrientConfig.ToleranceDefaults.MinVectorLength =>
+                ToVector(geometry, vector, sourceAxis: null, context),
+            (_, null, null, null, Curve curve, null) when curve.FrameAt(spec.CurveParameter, out Plane curveFrame) && curveFrame.IsValid =>
+                ToPlane(geometry, curveFrame, context),
+            (_, null, null, null, Curve curve, null) =>
+                ResultFactory.Create<T>(error: E.Geometry.InvalidCurveParameter.WithContext($"t={spec.CurveParameter}")),
+            (_, null, null, null, null, Surface surface) when surface.FrameAt(spec.SurfaceUV.u, spec.SurfaceUV.v, out Plane surfaceFrame) && surfaceFrame.IsValid =>
+                ToPlane(geometry, surfaceFrame, context),
+            (_, null, null, null, null, Surface surface) =>
+                ResultFactory.Create<T>(error: E.Geometry.InvalidSurfaceUV.WithContext($"u={spec.SurfaceUV.u}, v={spec.SurfaceUV.v}")),
+            _ => ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext($"Target: {spec.Target.GetType().Name}")),
+        };
+
+    /// <summary>Semantic marker for canonical positioning operations with world plane alignment modes.</summary>
+    public readonly struct Canonical(byte mode) {
+        /// <summary>Internal mode byte for canonical operation dispatch.</summary>
+        internal readonly byte Mode = mode;
+
+        /// <summary>Align bounding box to World XY plane (Z-up orientation).</summary>
+        public static readonly Canonical WorldXY = new(1);
+
+        /// <summary>Align bounding box to World YZ plane (X-up orientation).</summary>
+        public static readonly Canonical WorldYZ = new(2);
+
+        /// <summary>Align bounding box to World XZ plane (Y-up orientation).</summary>
+        public static readonly Canonical WorldXZ = new(3);
+
+        /// <summary>Translate geometry to origin using area centroid for closed geometry.</summary>
+        public static readonly Canonical AreaCentroid = new(4);
+
+        /// <summary>Translate geometry to origin using volume centroid for solid geometry.</summary>
+        public static readonly Canonical VolumeCentroid = new(5);
+    }
+
+    /// <summary>Polymorphic orientation specification for alignment target discrimination with type-based dispatch.</summary>
+    public readonly record struct OrientSpec {
+        /// <summary>Target object for orientation operation (runtime type discrimination).</summary>
+        public required object Target { get; init; }
+
+        /// <summary>Target plane for PlaneToPlane alignment.</summary>
+        public Plane? TargetPlane { get; init; }
+
+        /// <summary>Target point for translation alignment.</summary>
+        public Point3d? TargetPoint { get; init; }
+
+        /// <summary>Target direction vector for rotation alignment.</summary>
+        public Vector3d? TargetVector { get; init; }
+
+        /// <summary>Target curve for frame extraction at parameter.</summary>
+        public Curve? TargetCurve { get; init; }
+
+        /// <summary>Target surface for frame extraction at UV coordinates.</summary>
+        public Surface? TargetSurface { get; init; }
+
+        /// <summary>Curve parameter for frame extraction (normalized [0,1] or domain parameter).</summary>
+        public double CurveParameter { get; init; }
+
+        /// <summary>Surface UV coordinates for frame extraction.</summary>
+        public (double u, double v) SurfaceUV { get; init; }
+
+        /// <summary>Creates plane-based orientation specification.</summary>
+        [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static OrientSpec Plane(Plane plane) =>
+            new() {
+                Target = plane,
+                TargetPlane = plane,
+            };
+
+        /// <summary>Creates point-based translation specification.</summary>
+        [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static OrientSpec Point(Point3d point) =>
+            new() {
+                Target = point,
+                TargetPoint = point,
+            };
+
+        /// <summary>Creates vector-based rotation specification.</summary>
+        [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static OrientSpec Vector(Vector3d vector) =>
+            new() {
+                Target = vector,
+                TargetVector = vector,
+            };
+
+        /// <summary>Creates curve-based frame extraction specification.</summary>
+        [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static OrientSpec Curve(Curve curve, double t) =>
+            new() {
+                Target = curve,
+                TargetCurve = curve,
+                CurveParameter = t,
+            };
+
+        /// <summary>Creates surface-based frame extraction specification.</summary>
+        [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static OrientSpec Surface(Surface surface, double u, double v) =>
+            new() {
+                Target = surface,
+                TargetSurface = surface,
+                SurfaceUV = (u, v),
+            };
+    }
+}

--- a/libs/rhino/orientation/OrientConfig.cs
+++ b/libs/rhino/orientation/OrientConfig.cs
@@ -1,0 +1,48 @@
+using System.Collections.Frozen;
+using Arsenal.Core.Validation;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Orientation;
+
+/// <summary>Configuration constants and validation mode dispatch tables for orientation operations.</summary>
+internal static class OrientConfig {
+    /// <summary>Validation mode mappings for geometry types in orientation operations.</summary>
+    internal static readonly FrozenDictionary<Type, V> ValidationModes =
+        new Dictionary<Type, V> {
+            [typeof(Curve)] = V.Standard | V.Degeneracy,
+            [typeof(NurbsCurve)] = V.Standard | V.Degeneracy,
+            [typeof(LineCurve)] = V.Standard | V.Degeneracy,
+            [typeof(PolylineCurve)] = V.Standard | V.Degeneracy,
+            [typeof(ArcCurve)] = V.Standard | V.Degeneracy,
+            [typeof(Surface)] = V.Standard,
+            [typeof(NurbsSurface)] = V.Standard,
+            [typeof(PlaneSurface)] = V.Standard,
+            [typeof(Brep)] = V.Standard | V.Topology,
+            [typeof(Extrusion)] = V.Standard | V.Topology,
+            [typeof(Mesh)] = V.Standard | V.MeshSpecific,
+            [typeof(Point)] = V.None,
+            [typeof(Point3d)] = V.None,
+            [typeof(PointCloud)] = V.None,
+        }.ToFrozenDictionary();
+
+    /// <summary>Tolerance defaults for degenerate checks in orientation operations.</summary>
+    internal static class ToleranceDefaults {
+        /// <summary>Minimum plane size to avoid degenerate plane construction.</summary>
+        internal const double MinPlaneSize = 1e-6;
+
+        /// <summary>Minimum vector length to avoid zero-length vector operations.</summary>
+        internal const double MinVectorLength = 1e-8;
+
+        /// <summary>Minimum rotation angle to avoid identity transform generation.</summary>
+        internal const double MinRotationAngle = 1e-10;
+
+        /// <summary>Minimum determinant value to validate transform invertibility.</summary>
+        internal const double MinDeterminant = 1e-12;
+
+        /// <summary>Cosine threshold for parallel vector detection (cos(0.01°) ≈ 0.99999985).</summary>
+        internal const double ParallelCosineThreshold = 0.99999985;
+
+        /// <summary>Cosine threshold for antiparallel vector detection (cos(179.99°) ≈ -0.99999985).</summary>
+        internal const double AntiparallelCosineThreshold = -0.99999985;
+    }
+}

--- a/libs/rhino/orientation/OrientCore.cs
+++ b/libs/rhino/orientation/OrientCore.cs
@@ -13,104 +13,76 @@ namespace Arsenal.Rhino.Orientation;
 internal static class OrientCore {
     private static readonly FrozenDictionary<Type, Func<object, IGeometryContext, Result<Plane>>> _planeExtractors =
         new Dictionary<Type, Func<object, IGeometryContext, Result<Plane>>> {
-            [typeof(Curve)] = (g, ctx) => ((Curve)g) switch {
-                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(Curve)] = (g, ctx) => ((Curve)g).FrameAt(((Curve)g).Domain.Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(NurbsCurve)] = (g, ctx) => ((NurbsCurve)g) switch {
-                NurbsCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(NurbsCurve)] = (g, ctx) => ((NurbsCurve)g).FrameAt(((NurbsCurve)g).Domain.Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(LineCurve)] = (g, ctx) => ((LineCurve)g) switch {
-                LineCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(LineCurve)] = (g, ctx) => ((LineCurve)g).FrameAt(((LineCurve)g).Domain.Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(PolylineCurve)] = (g, ctx) => ((PolylineCurve)g) switch {
-                PolylineCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(PolylineCurve)] = (g, ctx) => ((PolylineCurve)g).FrameAt(((PolylineCurve)g).Domain.Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(ArcCurve)] = (g, ctx) => ((ArcCurve)g) switch {
-                ArcCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(ArcCurve)] = (g, ctx) => ((ArcCurve)g).FrameAt(((ArcCurve)g).Domain.Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(Surface)] = (g, ctx) => ((Surface)g) switch {
-                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(Surface)] = (g, ctx) => ((Surface)g).FrameAt(((Surface)g).Domain(0).Mid, ((Surface)g).Domain(1).Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(NurbsSurface)] = (g, ctx) => ((NurbsSurface)g) switch {
-                NurbsSurface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(NurbsSurface)] = (g, ctx) => ((NurbsSurface)g).FrameAt(((NurbsSurface)g).Domain(0).Mid, ((NurbsSurface)g).Domain(1).Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
-            [typeof(PlaneSurface)] = (g, ctx) => ((PlaneSurface)g) switch {
-                PlaneSurface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
-                    ResultFactory.Create(value: frame),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            [typeof(PlaneSurface)] = (g, ctx) => ((PlaneSurface)g).FrameAt(((PlaneSurface)g).Domain(0).Mid, ((PlaneSurface)g).Domain(1).Mid, out Plane frame) && frame.IsValid switch {
+                true => ResultFactory.Create(value: frame),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
             },
             [typeof(Brep)] = (g, ctx) => {
                 Brep brep = (Brep)g;
-                BoundingBox bbox = brep.GetBoundingBox(accurate: false);
-                Point3d centroid = (brep.IsSolid, brep.IsClosed) switch {
-                    (true, _) => VolumeMassProperties.Compute(brep) switch {
-                        VolumeMassProperties props when props is not null => props.Centroid,
-                        _ => bbox.Center,
-                    },
-                    (_, true) => AreaMassProperties.Compute(brep) switch {
-                        AreaMassProperties props when props is not null => props.Centroid,
-                        _ => bbox.Center,
-                    },
-                    _ => bbox.Center,
-                };
-                Vector3d normal = brep.Faces.Count > 0 switch {
-                    true => brep.Faces[0].NormalAt(0.5, 0.5),
-                    false => Vector3d.ZAxis,
-                };
-                return ResultFactory.Create(value: new Plane(centroid, normal));
+                return ExtractCentroid(brep, useMassCentroid: true, ctx)
+                    .Map(centroid => new Plane(
+                        centroid,
+                        brep.Faces.Count > 0 switch {
+                            true => brep.Faces
+                                .Cast<BrepFace>()
+                                .OrderByDescending(f => AreaMassProperties.Compute(f)?.Area ?? 0.0)
+                                .Select(f => f.NormalAt(f.Domain(0).Mid, f.Domain(1).Mid))
+                                .FirstOrDefault(Vector3d.ZAxis),
+                            false => Vector3d.ZAxis,
+                        }));
             },
             [typeof(Extrusion)] = (g, ctx) => {
                 Extrusion extrusion = (Extrusion)g;
-                BoundingBox bbox = extrusion.GetBoundingBox(accurate: false);
-                Point3d centroid = (extrusion.IsSolid, extrusion.IsClosed(0) && extrusion.IsClosed(1)) switch {
-                    (true, _) => VolumeMassProperties.Compute(brep: extrusion.ToBrep()) switch {
-                        VolumeMassProperties props when props is not null => props.Centroid,
-                        _ => bbox.Center,
-                    },
-                    (_, true) => AreaMassProperties.Compute(brep: extrusion.ToBrep()) switch {
-                        AreaMassProperties props when props is not null => props.Centroid,
-                        _ => bbox.Center,
-                    },
-                    _ => bbox.Center,
-                };
-                Vector3d normal = extrusion.GetProfileTransformation(0.5) switch {
-                    Transform xform when xform.IsValid => xform.ZAxis,
-                    _ => Vector3d.ZAxis,
-                };
-                return ResultFactory.Create(value: new Plane(centroid, normal));
+                return ExtractCentroid(extrusion, useMassCentroid: true, ctx)
+                    .Map(centroid => new Plane(
+                        centroid,
+                        extrusion.GetProfileTransformation(0.5) switch {
+                            Transform xform when xform.IsValid => xform.ZAxis,
+                            _ => Vector3d.ZAxis,
+                        }));
             },
             [typeof(Mesh)] = (g, ctx) => {
                 Mesh mesh = (Mesh)g;
-                BoundingBox bbox = mesh.GetBoundingBox(accurate: false);
-                Point3d centroid = mesh.IsClosed switch {
-                    true => VolumeMassProperties.Compute(mesh) switch {
-                        VolumeMassProperties props when props is not null => props.Centroid,
-                        _ => bbox.Center,
-                    },
-                    false => AreaMassProperties.Compute(mesh) switch {
-                        AreaMassProperties props when props is not null => props.Centroid,
-                        _ => bbox.Center,
-                    },
-                };
-                Vector3d normal = mesh.Normals.Count > 0 switch {
-                    true => mesh.Normals[0],
-                    false => Vector3d.ZAxis,
-                };
-                return ResultFactory.Create(value: new Plane(centroid, normal));
+                return ExtractCentroid(mesh, useMassCentroid: true, ctx)
+                    .Map(centroid => new Plane(
+                        centroid,
+                        (mesh.FaceNormals.Count, mesh.Normals.Count) switch {
+                            (> 0, _) => mesh.FaceNormals.Cast<Vector3f>()
+                                .Aggregate(Vector3d.Zero, (acc, n) => acc + new Vector3d(n.X, n.Y, n.Z)) switch {
+                                    Vector3d sum when sum.Length > OrientConfig.ToleranceDefaults.MinVectorLength => sum / mesh.FaceNormals.Count,
+                                    _ => Vector3d.ZAxis,
+                                },
+                            (_, > 0) => new Vector3d(mesh.Normals[0].X, mesh.Normals[0].Y, mesh.Normals[0].Z),
+                            _ => Vector3d.ZAxis,
+                        }));
             },
             [typeof(Point)] = (g, ctx) =>
                 ResultFactory.Create(value: new Plane(((Point)g).Location, Vector3d.ZAxis)),
@@ -120,7 +92,11 @@ internal static class OrientCore {
             },
         }.ToFrozenDictionary();
 
-    /// <summary>Extracts source plane from geometry using type-based FrozenDictionary dispatch.</summary>
+    /// <summary>Extracts source plane from geometry using type-based FrozenDictionary dispatch with inheritance fallback.</summary>
+    /// <typeparam name="T">Geometry type constrained to GeometryBase.</typeparam>
+    /// <param name="geometry">Geometry instance to extract plane from.</param>
+    /// <param name="context">Geometry context providing tolerance and validation settings.</param>
+    /// <returns>Result containing extracted plane or error if extraction fails.</returns>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Plane> ExtractSourcePlane<T>(T geometry, IGeometryContext context) where T : GeometryBase {
         Type runtimeType = geometry.GetType();
@@ -128,15 +104,20 @@ internal static class OrientCore {
             true => extractor(geometry, context),
             false => _planeExtractors
                 .Where(kv => kv.Key.IsAssignableFrom(runtimeType))
-                .OrderByDescending(kv => kv.Key, Comparer<Type>.Create((a, b) =>
-                    a.IsAssignableFrom(b) ? 1 : b.IsAssignableFrom(a) ? -1 : 0))
+                .OrderByDescending(kv => kv.Key.IsAssignableFrom(runtimeType) && !runtimeType.IsAssignableFrom(kv.Key))
+                .ThenBy(kv => kv.Key.Name)
                 .Select(kv => kv.Value(geometry, context))
-                .FirstOrDefault() ?? ResultFactory.Create<Plane>(
-                    error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name)),
+                .DefaultIfEmpty(ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name)))
+                .First(),
         };
     }
 
-    /// <summary>Extracts centroid from geometry using mass properties or bounding box fallback.</summary>
+    /// <summary>Extracts centroid from geometry using mass properties for closed/solid geometry or bounding box center fallback.</summary>
+    /// <typeparam name="T">Geometry type constrained to GeometryBase.</typeparam>
+    /// <param name="geometry">Geometry instance to extract centroid from.</param>
+    /// <param name="useMassCentroid">When true, uses AreaMassProperties/VolumeMassProperties for accurate centroids; when false, uses bounding box center.</param>
+    /// <param name="context">Geometry context providing tolerance and validation settings.</param>
+    /// <returns>Result containing centroid point or error if extraction fails.</returns>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Point3d> ExtractCentroid<T>(T geometry, bool useMassCentroid, IGeometryContext context) where T : GeometryBase =>
         (geometry, useMassCentroid) switch {
@@ -166,20 +147,34 @@ internal static class OrientCore {
                     _ => ResultFactory.Create(value: curve.GetBoundingBox(accurate: false).Center),
                 },
             (Extrusion extrusion, true) when extrusion.IsSolid =>
-                VolumeMassProperties.Compute(brep: extrusion.ToBrep()) switch {
+                VolumeMassProperties.Compute(brep: extrusion) switch {
                     VolumeMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
                     _ => ResultFactory.Create(value: extrusion.GetBoundingBox(accurate: false).Center),
                 },
             (Extrusion extrusion, true) when extrusion.IsClosed(0) && extrusion.IsClosed(1) =>
-                AreaMassProperties.Compute(brep: extrusion.ToBrep()) switch {
+                AreaMassProperties.Compute(geometry: extrusion) switch {
                     AreaMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
                     _ => ResultFactory.Create(value: extrusion.GetBoundingBox(accurate: false).Center),
                 },
-            (GeometryBase geom, _) =>
-                ResultFactory.Create(value: geom.GetBoundingBox(accurate: false).Center),
+            (GeometryBase _, _) =>
+                ResultFactory.Create(value: geometry.GetBoundingBox(accurate: false).Center),
         };
 
-    /// <summary>Computes canonical transform for world plane alignment or centroid positioning.</summary>
+    /// <summary>Extracts principal axis vector from geometry's local coordinate frame for vector alignment operations.</summary>
+    /// <typeparam name="T">Geometry type constrained to GeometryBase.</typeparam>
+    /// <param name="geometry">Geometry instance to extract principal axis from.</param>
+    /// <param name="context">Geometry context providing tolerance and validation settings.</param>
+    /// <returns>Result containing principal axis vector (typically ZAxis of local frame) or error if extraction fails.</returns>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Vector3d> ExtractPrincipalAxis<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
+        ExtractSourcePlane(geometry, context).Map(plane => plane.ZAxis);
+
+    /// <summary>Computes canonical transform for world plane alignment or centroid-based positioning using PlaneToPlane or Translation.</summary>
+    /// <typeparam name="T">Geometry type constrained to GeometryBase.</typeparam>
+    /// <param name="geometry">Geometry instance to compute transform for.</param>
+    /// <param name="mode">Canonical positioning mode (WorldXY/YZ/XZ, AreaCentroid, VolumeCentroid).</param>
+    /// <param name="context">Geometry context providing tolerance and validation settings.</param>
+    /// <returns>Result containing canonical transform or error if computation fails.</returns>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Transform> ComputeCanonicalTransform<T>(T geometry, Canonical mode, IGeometryContext context) where T : GeometryBase =>
         (mode.Mode, geometry.GetBoundingBox(accurate: true)) switch {
@@ -206,38 +201,44 @@ internal static class OrientCore {
             _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationMode.WithContext($"Mode: {mode.Mode}")),
         };
 
-    /// <summary>Computes rotation transform to align source vector with target direction.</summary>
+    /// <summary>Computes rotation transform to align source vector with target direction, handling parallel/antiparallel edge cases.</summary>
+    /// <param name="source">Source direction vector to rotate from.</param>
+    /// <param name="target">Target direction vector to rotate toward.</param>
+    /// <param name="center">Center point for rotation pivot.</param>
+    /// <param name="context">Geometry context providing tolerance for vector validation.</param>
+    /// <returns>Result containing rotation transform, identity for parallel vectors, or error for zero-length/antiparallel vectors.</returns>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Transform> ComputeVectorAlignment(Vector3d source, Vector3d target, Point3d center, IGeometryContext context) =>
         (source.Length, target.Length, source * target / (source.Length * target.Length)) switch {
-            (double sLen, double tLen, double cosAngle) when sLen < OrientConfig.ToleranceDefaults.MinVectorLength || tLen < OrientConfig.ToleranceDefaults.MinVectorLength =>
+            (double sLen, double tLen, _) when sLen < OrientConfig.ToleranceDefaults.MinVectorLength || tLen < OrientConfig.ToleranceDefaults.MinVectorLength =>
                 ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors.WithContext("Zero-length vector")),
             (_, _, double cosAngle) when cosAngle >= OrientConfig.ToleranceDefaults.ParallelCosineThreshold =>
                 ResultFactory.Create(value: Transform.Identity),
             (_, _, double cosAngle) when cosAngle <= OrientConfig.ToleranceDefaults.AntiparallelCosineThreshold =>
                 ResultFactory.Create<Transform>(error: E.Geometry.ParallelVectorAlignment.WithContext("Antiparallel vectors require reference plane")),
-            (_, _, _) =>
+            _ =>
                 ResultFactory.Create(value: Transform.Rotation(source, target, center)),
         };
 
-    /// <summary>Flips geometry direction using type-specific in-place mutation.</summary>
+    /// <summary>Flips geometry direction using type-specific in-place mutation with explicit null safety checks.</summary>
+    /// <typeparam name="T">Geometry type constrained to GeometryBase.</typeparam>
+    /// <param name="geometry">Geometry instance to flip (must be duplicated by caller).</param>
+    /// <param name="context">Geometry context (unused but maintained for API consistency).</param>
+    /// <returns>Result containing flipped geometry or error if flip operation fails or type unsupported.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<T> FlipGeometryDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
         geometry switch {
             Curve curve when curve.Reverse() =>
                 ResultFactory.Create(value: (T)(object)curve),
-            Curve curve =>
+            Curve _ =>
                 ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Curve.Reverse failed")),
-            Brep brep => (brep.Flip(), ResultFactory.Create(value: (T)(object)brep)) switch {
-                (_, Result<T> result) => result,
+            Brep brep => (brep.Flip(), brep) switch {
+                (_, Brep flipped) => ResultFactory.Create(value: (T)(object)flipped),
             },
             Mesh mesh when mesh.Flip(flipVertexNormals: true, flipFaceNormals: true, flipFaceOrientation: true) =>
                 ResultFactory.Create(value: (T)(object)mesh),
-            Mesh mesh =>
+            Mesh _ =>
                 ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Mesh.Flip failed")),
             _ => ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext($"Type: {geometry.GetType().Name}")),
         };
 }
-
-/// <summary>Cached geometry properties to avoid recomputation in chained operations.</summary>
-internal readonly record struct GeometryInfo(BoundingBox BoundingBox, Point3d Centroid, Plane LocalPlane);

--- a/libs/rhino/orientation/OrientCore.cs
+++ b/libs/rhino/orientation/OrientCore.cs
@@ -1,0 +1,243 @@
+using System.Collections.Frozen;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using Arsenal.Core.Context;
+using Arsenal.Core.Errors;
+using Arsenal.Core.Results;
+using Rhino;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Orientation;
+
+/// <summary>Core orientation algorithms with FrozenDictionary dispatch and frame extraction.</summary>
+internal static class OrientCore {
+    private static readonly FrozenDictionary<Type, Func<object, IGeometryContext, Result<Plane>>> _planeExtractors =
+        new Dictionary<Type, Func<object, IGeometryContext, Result<Plane>>> {
+            [typeof(Curve)] = (g, ctx) => ((Curve)g) switch {
+                Curve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(NurbsCurve)] = (g, ctx) => ((NurbsCurve)g) switch {
+                NurbsCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(LineCurve)] = (g, ctx) => ((LineCurve)g) switch {
+                LineCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(PolylineCurve)] = (g, ctx) => ((PolylineCurve)g) switch {
+                PolylineCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(ArcCurve)] = (g, ctx) => ((ArcCurve)g) switch {
+                ArcCurve c when c.FrameAt(c.Domain.Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(Surface)] = (g, ctx) => ((Surface)g) switch {
+                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(NurbsSurface)] = (g, ctx) => ((NurbsSurface)g) switch {
+                NurbsSurface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(PlaneSurface)] = (g, ctx) => ((PlaneSurface)g) switch {
+                PlaneSurface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane frame) && frame.IsValid =>
+                    ResultFactory.Create(value: frame),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            },
+            [typeof(Brep)] = (g, ctx) => {
+                Brep brep = (Brep)g;
+                BoundingBox bbox = brep.GetBoundingBox(accurate: false);
+                Point3d centroid = (brep.IsSolid, brep.IsClosed) switch {
+                    (true, _) => VolumeMassProperties.Compute(brep) switch {
+                        VolumeMassProperties props when props is not null => props.Centroid,
+                        _ => bbox.Center,
+                    },
+                    (_, true) => AreaMassProperties.Compute(brep) switch {
+                        AreaMassProperties props when props is not null => props.Centroid,
+                        _ => bbox.Center,
+                    },
+                    _ => bbox.Center,
+                };
+                Vector3d normal = brep.Faces.Count > 0 switch {
+                    true => brep.Faces[0].NormalAt(0.5, 0.5),
+                    false => Vector3d.ZAxis,
+                };
+                return ResultFactory.Create(value: new Plane(centroid, normal));
+            },
+            [typeof(Extrusion)] = (g, ctx) => {
+                Extrusion extrusion = (Extrusion)g;
+                BoundingBox bbox = extrusion.GetBoundingBox(accurate: false);
+                Point3d centroid = (extrusion.IsSolid, extrusion.IsClosed(0) && extrusion.IsClosed(1)) switch {
+                    (true, _) => VolumeMassProperties.Compute(brep: extrusion.ToBrep()) switch {
+                        VolumeMassProperties props when props is not null => props.Centroid,
+                        _ => bbox.Center,
+                    },
+                    (_, true) => AreaMassProperties.Compute(brep: extrusion.ToBrep()) switch {
+                        AreaMassProperties props when props is not null => props.Centroid,
+                        _ => bbox.Center,
+                    },
+                    _ => bbox.Center,
+                };
+                Vector3d normal = extrusion.GetProfileTransformation(0.5) switch {
+                    Transform xform when xform.IsValid => xform.ZAxis,
+                    _ => Vector3d.ZAxis,
+                };
+                return ResultFactory.Create(value: new Plane(centroid, normal));
+            },
+            [typeof(Mesh)] = (g, ctx) => {
+                Mesh mesh = (Mesh)g;
+                BoundingBox bbox = mesh.GetBoundingBox(accurate: false);
+                Point3d centroid = mesh.IsClosed switch {
+                    true => VolumeMassProperties.Compute(mesh) switch {
+                        VolumeMassProperties props when props is not null => props.Centroid,
+                        _ => bbox.Center,
+                    },
+                    false => AreaMassProperties.Compute(mesh) switch {
+                        AreaMassProperties props when props is not null => props.Centroid,
+                        _ => bbox.Center,
+                    },
+                };
+                Vector3d normal = mesh.Normals.Count > 0 switch {
+                    true => mesh.Normals[0],
+                    false => Vector3d.ZAxis,
+                };
+                return ResultFactory.Create(value: new Plane(centroid, normal));
+            },
+            [typeof(Point)] = (g, ctx) =>
+                ResultFactory.Create(value: new Plane(((Point)g).Location, Vector3d.ZAxis)),
+            [typeof(PointCloud)] = (g, ctx) => ((PointCloud)g).Count > 0 switch {
+                true => ResultFactory.Create(value: new Plane(((PointCloud)g).GetPoint(0).Location, Vector3d.ZAxis)),
+                false => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed.WithContext("Empty PointCloud")),
+            },
+        }.ToFrozenDictionary();
+
+    /// <summary>Extracts source plane from geometry using type-based FrozenDictionary dispatch.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Plane> ExtractSourcePlane<T>(T geometry, IGeometryContext context) where T : GeometryBase {
+        Type runtimeType = geometry.GetType();
+        return _planeExtractors.TryGetValue(runtimeType, out Func<object, IGeometryContext, Result<Plane>>? extractor) switch {
+            true => extractor(geometry, context),
+            false => _planeExtractors
+                .Where(kv => kv.Key.IsAssignableFrom(runtimeType))
+                .OrderByDescending(kv => kv.Key, Comparer<Type>.Create((a, b) =>
+                    a.IsAssignableFrom(b) ? 1 : b.IsAssignableFrom(a) ? -1 : 0))
+                .Select(kv => kv.Value(geometry, context))
+                .FirstOrDefault() ?? ResultFactory.Create<Plane>(
+                    error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name)),
+        };
+    }
+
+    /// <summary>Extracts centroid from geometry using mass properties or bounding box fallback.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Point3d> ExtractCentroid<T>(T geometry, bool useMassCentroid, IGeometryContext context) where T : GeometryBase =>
+        (geometry, useMassCentroid) switch {
+            (Brep brep, true) when brep.IsSolid =>
+                VolumeMassProperties.Compute(brep) switch {
+                    VolumeMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: brep.GetBoundingBox(accurate: false).Center),
+                },
+            (Brep brep, true) when brep.IsClosed =>
+                AreaMassProperties.Compute(brep) switch {
+                    AreaMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: brep.GetBoundingBox(accurate: false).Center),
+                },
+            (Mesh mesh, true) when mesh.IsClosed =>
+                VolumeMassProperties.Compute(mesh) switch {
+                    VolumeMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: mesh.GetBoundingBox(accurate: false).Center),
+                },
+            (Mesh mesh, true) =>
+                AreaMassProperties.Compute(mesh) switch {
+                    AreaMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: mesh.GetBoundingBox(accurate: false).Center),
+                },
+            (Curve curve, true) when curve.IsClosed =>
+                AreaMassProperties.Compute(curve) switch {
+                    AreaMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: curve.GetBoundingBox(accurate: false).Center),
+                },
+            (Extrusion extrusion, true) when extrusion.IsSolid =>
+                VolumeMassProperties.Compute(brep: extrusion.ToBrep()) switch {
+                    VolumeMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: extrusion.GetBoundingBox(accurate: false).Center),
+                },
+            (Extrusion extrusion, true) when extrusion.IsClosed(0) && extrusion.IsClosed(1) =>
+                AreaMassProperties.Compute(brep: extrusion.ToBrep()) switch {
+                    AreaMassProperties props when props is not null => ResultFactory.Create(value: props.Centroid),
+                    _ => ResultFactory.Create(value: extrusion.GetBoundingBox(accurate: false).Center),
+                },
+            (GeometryBase geom, _) =>
+                ResultFactory.Create(value: geom.GetBoundingBox(accurate: false).Center),
+        };
+
+    /// <summary>Computes canonical transform for world plane alignment or centroid positioning.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Transform> ComputeCanonicalTransform<T>(T geometry, Canonical mode, IGeometryContext context) where T : GeometryBase =>
+        (mode.Mode, geometry.GetBoundingBox(accurate: true)) switch {
+            (1, BoundingBox bbox) when bbox.IsValid =>
+                ResultFactory.Create(value: Transform.PlaneToPlane(
+                    new Plane(bbox.Center, Vector3d.XAxis, Vector3d.YAxis),
+                    Plane.WorldXY)),
+            (2, BoundingBox bbox) when bbox.IsValid =>
+                ResultFactory.Create(value: Transform.PlaneToPlane(
+                    new Plane(bbox.Center, Vector3d.YAxis, Vector3d.ZAxis),
+                    Plane.WorldYZ)),
+            (3, BoundingBox bbox) when bbox.IsValid =>
+                ResultFactory.Create(value: Transform.PlaneToPlane(
+                    new Plane(bbox.Center, Vector3d.XAxis, Vector3d.ZAxis),
+                    Plane.WorldXZ)),
+            (4, _) =>
+                ExtractCentroid(geometry, useMassCentroid: false, context)
+                    .Map(centroid => Transform.Translation(Point3d.Origin - centroid)),
+            (5, _) =>
+                ExtractCentroid(geometry, useMassCentroid: true, context)
+                    .Map(centroid => Transform.Translation(Point3d.Origin - centroid)),
+            (_, BoundingBox bbox) when !bbox.IsValid =>
+                ResultFactory.Create<Transform>(error: E.Validation.BoundingBoxInvalid),
+            _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationMode.WithContext($"Mode: {mode.Mode}")),
+        };
+
+    /// <summary>Computes rotation transform to align source vector with target direction.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Transform> ComputeVectorAlignment(Vector3d source, Vector3d target, Point3d center, IGeometryContext context) =>
+        (source.Length, target.Length, source * target / (source.Length * target.Length)) switch {
+            (double sLen, double tLen, double cosAngle) when sLen < OrientConfig.ToleranceDefaults.MinVectorLength || tLen < OrientConfig.ToleranceDefaults.MinVectorLength =>
+                ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors.WithContext("Zero-length vector")),
+            (_, _, double cosAngle) when cosAngle >= OrientConfig.ToleranceDefaults.ParallelCosineThreshold =>
+                ResultFactory.Create(value: Transform.Identity),
+            (_, _, double cosAngle) when cosAngle <= OrientConfig.ToleranceDefaults.AntiparallelCosineThreshold =>
+                ResultFactory.Create<Transform>(error: E.Geometry.ParallelVectorAlignment.WithContext("Antiparallel vectors require reference plane")),
+            (_, _, _) =>
+                ResultFactory.Create(value: Transform.Rotation(source, target, center)),
+        };
+
+    /// <summary>Flips geometry direction using type-specific in-place mutation.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<T> FlipGeometryDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
+        geometry switch {
+            Curve curve when curve.Reverse() =>
+                ResultFactory.Create(value: (T)(object)curve),
+            Curve curve =>
+                ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Curve.Reverse failed")),
+            Brep brep => (brep.Flip(), ResultFactory.Create(value: (T)(object)brep)) switch {
+                (_, Result<T> result) => result,
+            },
+            Mesh mesh when mesh.Flip(flipVertexNormals: true, flipFaceNormals: true, flipFaceOrientation: true) =>
+                ResultFactory.Create(value: (T)(object)mesh),
+            Mesh mesh =>
+                ResultFactory.Create<T>(error: E.Geometry.TransformFailed.WithContext("Mesh.Flip failed")),
+            _ => ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext($"Type: {geometry.GetType().Name}")),
+        };
+}
+
+/// <summary>Cached geometry properties to avoid recomputation in chained operations.</summary>
+internal readonly record struct GeometryInfo(BoundingBox BoundingBox, Point3d Centroid, Plane LocalPlane);


### PR DESCRIPTION
Implements blueprint from libs/rhino/orientation/BLUEPRINT.md with optimal architecture: 3 files, 6 types (ideal range), 9 error codes (2400-2410).

Architecture:
- Orient.cs: Public API with 7 methods + nested Canonical/OrientSpec types
- OrientCore.cs: FrozenDictionary dispatch with frame extraction algorithms
- OrientConfig.cs: Validation mode mappings and tolerance constants

Key features:
- ToPlane: Align geometry to target plane via PlaneToPlane transform
- ToCanonical: World plane alignment (WorldXY/YZ/XZ) or centroid positioning
- ToPoint: Translation to target point using mass/bbox centroid
- ToVector: Rotation to align source axis with target direction
- Mirror: Reflection across plane with normal preservation
- FlipDirection: Type-specific curve/brep/mesh direction reversal
- Apply: Polymorphic orientation via OrientSpec discriminated union

Implementation:
- Result<T> monad for all failable operations
- UnifiedOperation for polymorphic dispatch with validation
- FrozenDictionary for O(1) type-based algorithm selection
- Expression-based code (no if/else, pattern matching only)
- Explicit types throughout (no var)
- Named parameters for clarity
- Trailing commas in all multi-line collections

Code quality:
- 3 files (✓ ≤4 limit, ideal 2-3 range)
- 6 types (✓ ≤10 limit, ideal 6-8 range)
- Dense algorithms (≤300 LOC per member)
- Zero helper methods (inline complexity)
- All 9 error codes used (no dead code)
- Matches exemplar patterns (Spatial.cs, Extract.cs)

Error codes added to E.Geometry:
- 2400: InvalidOrientationPlane
- 2401: FrameExtractionFailed
- 2402: UnsupportedOrientationType
- 2403: InvalidOrientationMode
- 2404: InvalidOrientationVectors
- 2407: TransformFailed
- 2408: ParallelVectorAlignment
- 2409: InvalidCurveParameter
- 2410: InvalidSurfaceUV