### PR TITLE
Refactor libs/rhino/ to canonical 3-file architecture pattern

### DIFF
--- a/libs/rhino/extraction/ExtractionData.cs
+++ b/libs/rhino/extraction/ExtractionData.cs
@@ -1,0 +1,36 @@
+using System.Collections.Frozen;
+using Arsenal.Core.Validation;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Extraction;
+
+/// <summary>Configuration data for extraction algorithms with semantic kind and type-based validation dispatch.</summary>
+internal static class ExtractionData {
+    /// <summary>Validation configuration mapping extraction semantic kinds and geometry types to validation modes.</summary>
+    internal static readonly FrozenDictionary<(byte Kind, Type GeometryType), V> ValidationConfig =
+        new Dictionary<(byte, Type), V> {
+            [(1, typeof(GeometryBase))] = V.Standard,
+            [(1, typeof(Brep))] = V.Standard | V.MassProperties,
+            [(1, typeof(Curve))] = V.Standard | V.AreaCentroid,
+            [(1, typeof(Surface))] = V.Standard | V.AreaCentroid,
+            [(1, typeof(Mesh))] = V.Standard | V.MassProperties,
+            [(1, typeof(PointCloud))] = V.Standard,
+            [(2, typeof(GeometryBase))] = V.BoundingBox,
+            [(3, typeof(NurbsCurve))] = V.Standard,
+            [(3, typeof(NurbsSurface))] = V.Standard,
+            [(3, typeof(Curve))] = V.Standard,
+            [(3, typeof(Surface))] = V.Standard,
+            [(4, typeof(Curve))] = V.Standard | V.Degeneracy,
+            [(5, typeof(Curve))] = V.Tolerance,
+            [(6, typeof(Brep))] = V.Standard | V.Topology,
+            [(6, typeof(Mesh))] = V.Standard | V.MeshSpecific,
+            [(6, typeof(Curve))] = V.Standard,
+            [(7, typeof(Brep))] = V.Standard | V.Topology,
+            [(7, typeof(Mesh))] = V.Standard | V.MeshSpecific,
+            [(10, typeof(Curve))] = V.Standard | V.Degeneracy,
+            [(10, typeof(Surface))] = V.Standard,
+            [(11, typeof(Curve))] = V.Standard | V.Degeneracy,
+            [(12, typeof(Curve))] = V.Standard,
+            [(13, typeof(Curve))] = V.Standard,
+        }.ToFrozenDictionary();
+}

--- a/libs/rhino/intersection/Intersect.cs
+++ b/libs/rhino/intersection/Intersect.cs
@@ -10,26 +10,6 @@ namespace Arsenal.Rhino.Intersection;
 
 /// <summary>Polymorphic intersection engine with automatic type-based method detection.</summary>
 public static class Intersect {
-    /// <summary>Type-safe optional parameters for intersection operations.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct IntersectionOptions(
-        double? Tolerance = null,
-        Vector3d? ProjectionDirection = null,
-        int? MaxHits = null,
-        bool WithIndices = false,
-        bool Sorted = false);
-
-    /// <summary>Unified intersection output with zero nullable fields.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct IntersectionOutput(
-        IReadOnlyList<Point3d> Points,
-        IReadOnlyList<Curve> Curves,
-        IReadOnlyList<double> ParametersA,
-        IReadOnlyList<double> ParametersB,
-        IReadOnlyList<int> FaceIndices,
-        IReadOnlyList<Polyline> Sections) {
-        public static readonly IntersectionOutput Empty = new([], [], [], [], [], []);
-    }
     /// <summary>Performs intersection with automatic type detection, validation, and collection handling.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<IntersectionOutput> Execute<T1, T2>(
@@ -44,8 +24,8 @@ public static class Intersect {
         Type elementType = t1Type is { IsGenericType: true } t && t.GetGenericTypeDefinition() == typeof(IReadOnlyList<>)
             ? t.GetGenericArguments()[0]
             : t1Type;
-        V mode = IntersectionCore._validationConfig.TryGetValue((t1Type, t2Type), out V m1) ? m1
-            : IntersectionCore._validationConfig.TryGetValue((elementType, t2Type), out V m2) ? m2
+        V mode = IntersectionData.ValidationConfig.TryGetValue((t1Type, t2Type), out V m1) ? m1
+            : IntersectionData.ValidationConfig.TryGetValue((elementType, t2Type), out V m2) ? m2
             : V.None;
 
         return UnifiedOperation.Apply(

--- a/libs/rhino/intersection/IntersectionCore.cs
+++ b/libs/rhino/intersection/IntersectionCore.cs
@@ -1,9 +1,7 @@
-using System.Collections.Frozen;
 using System.Diagnostics.Contracts;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 using Rhino.Geometry.Intersect;
@@ -13,119 +11,83 @@ namespace Arsenal.Rhino.Intersection;
 
 /// <summary>Internal intersection computation engine with RhinoCommon SDK algorithms and type-based dispatch.</summary>
 internal static class IntersectionCore {
-    internal static readonly FrozenDictionary<(Type, Type), V> _validationConfig =
-        new Dictionary<(Type, Type), V> {
-            [(typeof(Curve), typeof(Curve))] = V.Standard | V.Degeneracy,
-            [(typeof(Curve), typeof(Surface))] = V.Standard,
-            [(typeof(Curve), typeof(Brep))] = V.Standard | V.Topology,
-            [(typeof(Curve), typeof(BrepFace))] = V.Standard | V.Topology,
-            [(typeof(Curve), typeof(Plane))] = V.Standard | V.Degeneracy,
-            [(typeof(Curve), typeof(Line))] = V.Standard | V.Degeneracy,
-            [(typeof(Brep), typeof(Brep))] = V.Standard | V.Topology,
-            [(typeof(Brep), typeof(Plane))] = V.Standard | V.Topology,
-            [(typeof(Brep), typeof(Surface))] = V.Standard | V.Topology,
-            [(typeof(Surface), typeof(Surface))] = V.Standard,
-            [(typeof(Mesh), typeof(Mesh))] = V.MeshSpecific,
-            [(typeof(Mesh), typeof(Ray3d))] = V.MeshSpecific,
-            [(typeof(Mesh), typeof(Plane))] = V.MeshSpecific,
-            [(typeof(Mesh), typeof(Line))] = V.MeshSpecific,
-            [(typeof(Mesh), typeof(PolylineCurve))] = V.MeshSpecific,
-            [(typeof(Line), typeof(Line))] = V.Standard,
-            [(typeof(Line), typeof(BoundingBox))] = V.Standard,
-            [(typeof(Line), typeof(Plane))] = V.Standard,
-            [(typeof(Line), typeof(Sphere))] = V.Standard,
-            [(typeof(Line), typeof(Cylinder))] = V.Standard,
-            [(typeof(Line), typeof(Circle))] = V.Standard,
-            [(typeof(Plane), typeof(Plane))] = V.Standard,
-            [(typeof(ValueTuple<Plane, Plane>), typeof(Plane))] = V.Standard,
-            [(typeof(Plane), typeof(Circle))] = V.Standard,
-            [(typeof(Plane), typeof(Sphere))] = V.Standard,
-            [(typeof(Plane), typeof(BoundingBox))] = V.Standard,
-            [(typeof(Sphere), typeof(Sphere))] = V.Standard,
-            [(typeof(Circle), typeof(Circle))] = V.Standard,
-            [(typeof(Arc), typeof(Arc))] = V.Standard,
-            [(typeof(Point3d[]), typeof(Brep[]))] = V.Standard | V.Topology,
-            [(typeof(Point3d[]), typeof(Mesh[]))] = V.MeshSpecific,
-            [(typeof(Ray3d), typeof(GeometryBase[]))] = V.Standard,
-        }.ToFrozenDictionary();
-
     [Pure]
 #pragma warning disable MA0051 // Method too long - Large pattern matching switch with 30+ intersection type combinations cannot be meaningfully reduced without extraction
-    internal static Result<Intersect.IntersectionOutput> ExecutePair<T1, T2>(T1 a, T2 b, IGeometryContext ctx, Intersect.IntersectionOptions opts) where T1 : notnull where T2 : notnull {
+    internal static Result<IntersectionOutput> ExecutePair<T1, T2>(T1 a, T2 b, IGeometryContext ctx, IntersectionOptions opts) where T1 : notnull where T2 : notnull {
 #pragma warning restore MA0051
-        static Result<Intersect.IntersectionOutput> fromCurveIntersections(CurveIntersections? results, Curve? overlapSource) {
+        static Result<IntersectionOutput> fromCurveIntersections(CurveIntersections? results, Curve? overlapSource) {
 #pragma warning disable IDISP007 // Don't dispose injected - CurveIntersections created by caller and owned by this method
             using (results) {
 #pragma warning restore IDISP007
                 return results switch {
-                    null => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty), { Count: > 0 } r => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    null => ResultFactory.Create(value: IntersectionOutput.Empty), { Count: > 0 } r => ResultFactory.Create(value: new IntersectionOutput(
                                                                                                  [.. from e in r select e.PointA],
                                                                                                  overlapSource is not null ? [.. from e in r where e.IsOverlap let c = overlapSource.Trim(e.OverlapA) where c is not null select c] : [],
                                                                                                  [.. from e in r select e.ParameterA],
                                                                                                  [.. from e in r select e.ParameterB],
                                                                                                  [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 };
             }
         }
 
-        static Result<Intersect.IntersectionOutput> fromBrepIntersection((bool success, Curve[] curves, Point3d[] points) result) =>
+        static Result<IntersectionOutput> fromBrepIntersection((bool success, Curve[] curves, Point3d[] points) result) =>
             result.success switch {
-                true when result.curves.Length > 0 && result.points.Length > 0 => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. result.points], [.. result.curves], [], [], [], [])),
-                true when result.curves.Length > 0 => ResultFactory.Create(value: new Intersect.IntersectionOutput([], [.. result.curves], [], [], [], [])),
-                true when result.points.Length > 0 => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. result.points], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                true when result.curves.Length > 0 && result.points.Length > 0 => ResultFactory.Create(value: new IntersectionOutput([.. result.points], [.. result.curves], [], [], [], [])),
+                true when result.curves.Length > 0 => ResultFactory.Create(value: new IntersectionOutput([], [.. result.curves], [], [], [], [])),
+                true when result.points.Length > 0 => ResultFactory.Create(value: new IntersectionOutput([.. result.points], [], [], [], [], [])),
+                _ => ResultFactory.Create(value: IntersectionOutput.Empty),
             };
 
-        static Result<Intersect.IntersectionOutput> fromCountedPoints((int count, Point3d p1, Point3d p2, double tolerance) data) =>
+        static Result<IntersectionOutput> fromCountedPoints((int count, Point3d p1, Point3d p2, double tolerance) data) =>
             data.count switch {
-                > 1 when data.p1.DistanceTo(data.p2) > data.tolerance => ResultFactory.Create(value: new Intersect.IntersectionOutput([data.p1, data.p2], [], [], [], [], [])),
-                > 0 => ResultFactory.Create(value: new Intersect.IntersectionOutput([data.p1], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                > 1 when data.p1.DistanceTo(data.p2) > data.tolerance => ResultFactory.Create(value: new IntersectionOutput([data.p1, data.p2], [], [], [], [], [])),
+                > 0 => ResultFactory.Create(value: new IntersectionOutput([data.p1], [], [], [], [], [])),
+                _ => ResultFactory.Create(value: IntersectionOutput.Empty),
             };
 
-        static Result<Intersect.IntersectionOutput> fromCountedPointsWithParams((int count, Point3d p1, double t1, Point3d p2, double t2, double tolerance) data) =>
+        static Result<IntersectionOutput> fromCountedPointsWithParams((int count, Point3d p1, double t1, Point3d p2, double t2, double tolerance) data) =>
             data.count switch {
-                > 1 when data.p1.DistanceTo(data.p2) > data.tolerance => ResultFactory.Create(value: new Intersect.IntersectionOutput([data.p1, data.p2], [], [data.t1, data.t2], [], [], [])),
-                > 0 => ResultFactory.Create(value: new Intersect.IntersectionOutput([data.p1], [], [data.t1], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                > 1 when data.p1.DistanceTo(data.p2) > data.tolerance => ResultFactory.Create(value: new IntersectionOutput([data.p1, data.p2], [], [data.t1, data.t2], [], [], [])),
+                > 0 => ResultFactory.Create(value: new IntersectionOutput([data.p1], [], [data.t1], [], [], [])),
+                _ => ResultFactory.Create(value: IntersectionOutput.Empty),
             };
 
-        static Result<Intersect.IntersectionOutput> fromPolylines(Polyline[]? sections) =>
-            sections switch { { Length: > 0 } => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. from pl in sections from pt in pl select pt], [], [], [], [], [.. sections])),
-                null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+        static Result<IntersectionOutput> fromPolylines(Polyline[]? sections) =>
+            sections switch { { Length: > 0 } => ResultFactory.Create(value: new IntersectionOutput([.. from pl in sections from pt in pl select pt], [], [], [], [], [.. sections])),
+                null => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                _ => ResultFactory.Create(value: IntersectionOutput.Empty),
             };
 
         double tolerance = opts.Tolerance ?? ctx.AbsoluteTolerance;
 
         return (a, b, opts) switch {
             (Point3d[] pts, Brep[] breps, { ProjectionDirection: Vector3d dir }) when !dir.IsValid || dir.Length <= RhinoMath.ZeroTolerance =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidProjection),
+                ResultFactory.Create<IntersectionOutput>(error: E.Geometry.InvalidProjection),
             (Point3d[] pts, Brep[] breps, { ProjectionDirection: Vector3d dir, WithIndices: true }) =>
-                ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                ResultFactory.Create(value: new IntersectionOutput(
                     [.. RhinoIntersect.ProjectPointsToBrepsEx(breps, pts, dir, ctx.AbsoluteTolerance, out int[] ids1)],
                     [], [], [], ids1.Length > 0 ? [.. ids1] : [], [])),
             (Point3d[] pts, Brep[] breps, { ProjectionDirection: Vector3d dir }) =>
-                ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                ResultFactory.Create(value: new IntersectionOutput(
                     [.. RhinoIntersect.ProjectPointsToBreps(breps, pts, dir, ctx.AbsoluteTolerance)],
                     [], [], [], [], [])),
             (Point3d[] pts, Mesh[] meshes, { ProjectionDirection: Vector3d dir }) when !dir.IsValid || dir.Length <= RhinoMath.ZeroTolerance =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidProjection),
+                ResultFactory.Create<IntersectionOutput>(error: E.Geometry.InvalidProjection),
             (Point3d[] pts, Mesh[] meshes, { ProjectionDirection: Vector3d dir, WithIndices: true }) =>
-                ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                ResultFactory.Create(value: new IntersectionOutput(
                     [.. RhinoIntersect.ProjectPointsToMeshesEx(meshes, pts, dir, ctx.AbsoluteTolerance, out int[] ids2)],
                     [], [], [], ids2.Length > 0 ? [.. ids2] : [], [])),
             (Point3d[] pts, Mesh[] meshes, { ProjectionDirection: Vector3d dir }) =>
-                ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                ResultFactory.Create(value: new IntersectionOutput(
                     [.. RhinoIntersect.ProjectPointsToMeshes(meshes, pts, dir, ctx.AbsoluteTolerance)],
                     [], [], [], [], [])),
             (Ray3d ray, GeometryBase[] geoms, { MaxHits: int hits }) when ray.Direction.Length <= RhinoMath.ZeroTolerance =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidRay),
+                ResultFactory.Create<IntersectionOutput>(error: E.Geometry.InvalidRay),
             (Ray3d ray, GeometryBase[] geoms, { MaxHits: int hits }) when hits <= 0 =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidMaxHits),
+                ResultFactory.Create<IntersectionOutput>(error: E.Geometry.InvalidMaxHits),
             (Ray3d ray, GeometryBase[] geoms, { MaxHits: int hits }) =>
-                ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                ResultFactory.Create(value: new IntersectionOutput(
                     [.. RhinoIntersect.RayShoot(ray, geoms, hits)],
                     [], [], [], [], [])),
             (Curve ca, Curve cb, _) =>
@@ -158,62 +120,62 @@ internal static class IntersectionCore {
                 fromBrepIntersection((RhinoIntersect.SurfaceSurface(sa, sb, tolerance, out Curve[] c6, out Point3d[] p6), c6, p6)),
             (Mesh ma, Mesh mb, _) when !opts.Sorted =>
                 RhinoIntersect.MeshMeshFast(ma, mb) switch {
-                    Line[] { Length: > 0 } lines => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    Line[] { Length: > 0 } lines => ResultFactory.Create(value: new IntersectionOutput(
                         [.. from l in lines select l.From, .. from l in lines select l.To],
                         [], [], [], [], [])),
-                    null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    null => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Mesh ma, Mesh mb, { Sorted: true }) =>
                 fromPolylines(RhinoIntersect.MeshMeshAccurate(ma, mb, tolerance)),
             (Mesh ma, Ray3d rb, _) =>
                 RhinoIntersect.MeshRay(ma, rb) switch {
-                    double d when d >= 0d => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    double d when d >= 0d => ResultFactory.Create(value: new IntersectionOutput(
                         [rb.PointAt(d)], [], [d], [], [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Mesh ma, Plane pb, _) =>
                 fromPolylines(RhinoIntersect.MeshPlane(ma, pb)),
             (Mesh ma, Line lb, _) when !opts.Sorted =>
                 RhinoIntersect.MeshLine(ma, lb) switch {
-                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new IntersectionOutput(
                         [.. points], [], [], [], [], [])),
-                    null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    null => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Mesh ma, Line lb, { Sorted: true }) =>
                 RhinoIntersect.MeshLineSorted(ma, lb, out int[] ids3) switch {
-                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new IntersectionOutput(
                         [.. points], [], [], [], ids3.Length > 0 ? [.. ids3] : [], [])),
-                    _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.IntersectionFailed),
                 },
             (Mesh ma, PolylineCurve pc, { Sorted: false }) =>
                 RhinoIntersect.MeshPolyline(ma, pc, out int[] ids4) switch {
-                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new IntersectionOutput(
                         [.. points], [], [], [], ids4.Length > 0 ? [.. ids4] : [], [])),
-                    _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.IntersectionFailed),
                 },
             (Mesh ma, PolylineCurve pc, { Sorted: true }) =>
                 RhinoIntersect.MeshPolylineSorted(ma, pc, out int[] ids5) switch {
-                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    Point3d[] { Length: > 0 } points => ResultFactory.Create(value: new IntersectionOutput(
                         [.. points], [], [], [], ids5.Length > 0 ? [.. ids5] : [], [])),
-                    _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.IntersectionFailed),
                 },
             (Line la, Line lb, _) =>
                 RhinoIntersect.LineLine(la, lb, out double pa, out double pb, tolerance, finiteSegments: false)
-                    ? ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    ? ResultFactory.Create(value: new IntersectionOutput(
                         [la.PointAt(pa)], [], [pa], [pb], [], []))
-                    : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    : ResultFactory.Create(value: IntersectionOutput.Empty),
             (Line la, BoundingBox boxb, _) =>
                 RhinoIntersect.LineBox(la, boxb, tolerance, out Interval interval)
-                    ? ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    ? ResultFactory.Create(value: new IntersectionOutput(
                         [la.PointAt(interval.Min), la.PointAt(interval.Max)], [], [interval.Min, interval.Max], [], [], []))
-                    : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    : ResultFactory.Create(value: IntersectionOutput.Empty),
             (Line la, Plane pb, _) =>
                 RhinoIntersect.LinePlane(la, pb, out double param)
-                    ? ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    ? ResultFactory.Create(value: new IntersectionOutput(
                         [la.PointAt(param)], [], [param], [], [], []))
-                    : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    : ResultFactory.Create(value: IntersectionOutput.Empty),
             (Line la, Sphere sb, _) =>
                 fromCountedPoints(((int)RhinoIntersect.LineSphere(la, sb, out Point3d ps1, out Point3d ps2), ps1, ps2, tolerance)),
             (Line la, Cylinder cylb, _) =>
@@ -223,54 +185,54 @@ internal static class IntersectionCore {
             (Plane pa, Plane pb, _) =>
                 RhinoIntersect.PlanePlane(pa, pb, out Line line)
 #pragma warning disable IDISP004 // Don't ignore created IDisposable - ownership transferred to caller via result
-                    ? ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    ? ResultFactory.Create(value: new IntersectionOutput(
                         [], [new LineCurve(line)], [], [], [], []))
 #pragma warning restore IDISP004
-                    : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    : ResultFactory.Create(value: IntersectionOutput.Empty),
             (ValueTuple<Plane, Plane> planes, Plane p3, _) =>
                 RhinoIntersect.PlanePlanePlane(planes.Item1, planes.Item2, p3, out Point3d point) switch {
-                    true => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    true => ResultFactory.Create(value: new IntersectionOutput(
                         [point], [], [], [], [], [])),
-                    false => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    false => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Plane pa, Circle cb, _) =>
                 RhinoIntersect.PlaneCircle(pa, cb, out double pct1, out double pct2) switch {
-                    PlaneCircleIntersection.Tangent => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    PlaneCircleIntersection.Tangent => ResultFactory.Create(value: new IntersectionOutput(
                         [cb.PointAt(pct1)], [], [], [pct1], [], [])),
-                    PlaneCircleIntersection.Secant => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    PlaneCircleIntersection.Secant => ResultFactory.Create(value: new IntersectionOutput(
                         [cb.PointAt(pct1), cb.PointAt(pct2)], [], [], [pct1, pct2], [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Plane pa, Sphere sb, _) =>
                 ((int)RhinoIntersect.PlaneSphere(pa, sb, out Circle psc)) switch {
 #pragma warning disable IDISP004 // Don't ignore created IDisposable - ownership transferred to caller via result
-                    1 => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    1 => ResultFactory.Create(value: new IntersectionOutput(
                         [], [new ArcCurve(psc)], [], [], [], [])),
 #pragma warning restore IDISP004
-                    2 => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    2 => ResultFactory.Create(value: new IntersectionOutput(
                         [psc.Center], [], [], [], [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Plane pa, BoundingBox boxb, _) =>
                 RhinoIntersect.PlaneBoundingBox(pa, boxb, out Polyline poly) && poly?.Count > 0
-                    ? ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    ? ResultFactory.Create(value: new IntersectionOutput(
                         [.. from pt in poly select pt], [], [], [], [], [poly]))
-                    : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    : ResultFactory.Create(value: IntersectionOutput.Empty),
             (Sphere sa, Sphere sb, _) =>
                 ((int)RhinoIntersect.SphereSphere(sa, sb, out Circle ssc)) switch {
 #pragma warning disable IDISP004 // Don't ignore created IDisposable - ownership transferred to caller via result
-                    1 => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    1 => ResultFactory.Create(value: new IntersectionOutput(
                         [], [new ArcCurve(ssc)], [], [], [], [])),
 #pragma warning restore IDISP004
-                    2 => ResultFactory.Create(value: new Intersect.IntersectionOutput(
+                    2 => ResultFactory.Create(value: new IntersectionOutput(
                         [ssc.Center], [], [], [], [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => ResultFactory.Create(value: IntersectionOutput.Empty),
                 },
             (Circle ca, Circle cb, _) =>
                 fromCountedPoints(((int)RhinoIntersect.CircleCircle(ca, cb, out Point3d ccp1, out Point3d ccp2), ccp1, ccp2, tolerance)),
             (Arc aa, Arc ab, _) =>
                 fromCountedPoints(((int)RhinoIntersect.ArcArc(aa, ab, out Point3d aap1, out Point3d aap2), aap1, aap2, tolerance)),
-            _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.UnsupportedIntersection),
+            _ => ResultFactory.Create<IntersectionOutput>(error: E.Geometry.UnsupportedIntersection),
         };
     }
 }

--- a/libs/rhino/intersection/IntersectionData.cs
+++ b/libs/rhino/intersection/IntersectionData.cs
@@ -1,0 +1,45 @@
+using System.Collections.Frozen;
+using Arsenal.Core.Validation;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Intersection;
+
+/// <summary>Configuration data for intersection algorithms with type pair validation dispatch.</summary>
+internal static class IntersectionData {
+    /// <summary>Validation configuration mapping geometry type pairs to validation modes for intersection operations.</summary>
+    internal static readonly FrozenDictionary<(Type TypeA, Type TypeB), V> ValidationConfig =
+        new Dictionary<(Type, Type), V> {
+            [(typeof(Curve), typeof(Curve))] = V.Standard | V.Degeneracy,
+            [(typeof(Curve), typeof(Surface))] = V.Standard,
+            [(typeof(Curve), typeof(Brep))] = V.Standard | V.Topology,
+            [(typeof(Curve), typeof(BrepFace))] = V.Standard | V.Topology,
+            [(typeof(Curve), typeof(Plane))] = V.Standard | V.Degeneracy,
+            [(typeof(Curve), typeof(Line))] = V.Standard | V.Degeneracy,
+            [(typeof(Brep), typeof(Brep))] = V.Standard | V.Topology,
+            [(typeof(Brep), typeof(Plane))] = V.Standard | V.Topology,
+            [(typeof(Brep), typeof(Surface))] = V.Standard | V.Topology,
+            [(typeof(Surface), typeof(Surface))] = V.Standard,
+            [(typeof(Mesh), typeof(Mesh))] = V.MeshSpecific,
+            [(typeof(Mesh), typeof(Ray3d))] = V.MeshSpecific,
+            [(typeof(Mesh), typeof(Plane))] = V.MeshSpecific,
+            [(typeof(Mesh), typeof(Line))] = V.MeshSpecific,
+            [(typeof(Mesh), typeof(PolylineCurve))] = V.MeshSpecific,
+            [(typeof(Line), typeof(Line))] = V.Standard,
+            [(typeof(Line), typeof(BoundingBox))] = V.Standard,
+            [(typeof(Line), typeof(Plane))] = V.Standard,
+            [(typeof(Line), typeof(Sphere))] = V.Standard,
+            [(typeof(Line), typeof(Cylinder))] = V.Standard,
+            [(typeof(Line), typeof(Circle))] = V.Standard,
+            [(typeof(Plane), typeof(Plane))] = V.Standard,
+            [(typeof(ValueTuple<Plane, Plane>), typeof(Plane))] = V.Standard,
+            [(typeof(Plane), typeof(Circle))] = V.Standard,
+            [(typeof(Plane), typeof(Sphere))] = V.Standard,
+            [(typeof(Plane), typeof(BoundingBox))] = V.Standard,
+            [(typeof(Sphere), typeof(Sphere))] = V.Standard,
+            [(typeof(Circle), typeof(Circle))] = V.Standard,
+            [(typeof(Arc), typeof(Arc))] = V.Standard,
+            [(typeof(Point3d[]), typeof(Brep[]))] = V.Standard | V.Topology,
+            [(typeof(Point3d[]), typeof(Mesh[]))] = V.MeshSpecific,
+            [(typeof(Ray3d), typeof(GeometryBase[]))] = V.Standard,
+        }.ToFrozenDictionary();
+}

--- a/libs/rhino/intersection/IntersectionOptions.cs
+++ b/libs/rhino/intersection/IntersectionOptions.cs
@@ -1,0 +1,12 @@
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Intersection;
+
+/// <summary>Type-safe optional parameters for intersection operations.</summary>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+public readonly record struct IntersectionOptions(
+    double? Tolerance = null,
+    Vector3d? ProjectionDirection = null,
+    int? MaxHits = null,
+    bool WithIndices = false,
+    bool Sorted = false);

--- a/libs/rhino/intersection/IntersectionOutput.cs
+++ b/libs/rhino/intersection/IntersectionOutput.cs
@@ -1,0 +1,15 @@
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Intersection;
+
+/// <summary>Unified intersection output with zero nullable fields.</summary>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+public readonly record struct IntersectionOutput(
+    IReadOnlyList<Point3d> Points,
+    IReadOnlyList<Curve> Curves,
+    IReadOnlyList<double> ParametersA,
+    IReadOnlyList<double> ParametersB,
+    IReadOnlyList<int> FaceIndices,
+    IReadOnlyList<Polyline> Sections) {
+    public static readonly IntersectionOutput Empty = new([], [], [], [], [], []);
+}

--- a/libs/rhino/spatial/Spatial.cs
+++ b/libs/rhino/spatial/Spatial.cs
@@ -22,7 +22,7 @@ public static class Spatial {
         TQuery query,
         IGeometryContext context,
         bool enableDiagnostics = false) where TInput : notnull where TQuery : notnull =>
-        SpatialCore.AlgorithmConfig.TryGetValue((typeof(TInput), typeof(TQuery)), out (V mode, int bufferSize) config) switch {
+        SpatialData.AlgorithmConfig.TryGetValue((typeof(TInput), typeof(TQuery)), out (V mode, int bufferSize) config) switch {
             true => UnifiedOperation.Apply(
                 input: input,
                 operation: (Func<TInput, Result<IReadOnlyList<int>>>)(item => SpatialCore.ExecuteAlgorithm(item, query, context, config.bufferSize)),

--- a/libs/rhino/spatial/SpatialCore.cs
+++ b/libs/rhino/spatial/SpatialCore.cs
@@ -12,39 +12,6 @@ namespace Arsenal.Rhino.Spatial;
 
 /// <summary>Internal spatial computation algorithms with RTree-backed operations and type-based dispatch.</summary>
 internal static class SpatialCore {
-    /// <summary>RTree factory configuration mapping source types to construction strategies for optimal tree structure.</summary>
-    internal static readonly FrozenDictionary<Type, Func<object, RTree>> TreeFactories =
-        new Dictionary<Type, Func<object, RTree>> {
-            [typeof(Point3d[])] = s => RTree.CreateFromPointArray((Point3d[])s) ?? new RTree(),
-            [typeof(PointCloud)] = s => RTree.CreatePointCloudTree((PointCloud)s) ?? new RTree(),
-            [typeof(Mesh)] = s => RTree.CreateMeshFaceTree((Mesh)s) ?? new RTree(),
-            [typeof(Curve[])] = s => BuildGeometryArrayTree((Curve[])s),
-            [typeof(Surface[])] = s => BuildGeometryArrayTree((Surface[])s),
-            [typeof(Brep[])] = s => BuildGeometryArrayTree((Brep[])s),
-        }.ToFrozenDictionary();
-
-    /// <summary>Algorithm configuration mapping input/query type pairs to validation modes and buffer strategies.</summary>
-    internal static readonly FrozenDictionary<(Type Input, Type Query), (V Mode, int BufferSize)> AlgorithmConfig =
-        new Dictionary<(Type, Type), (V, int)> {
-            [(typeof(Point3d[]), typeof(Sphere))] = (V.None, 2048),
-            [(typeof(Point3d[]), typeof(BoundingBox))] = (V.None, 2048),
-            [(typeof(Point3d[]), typeof((Point3d[], int)))] = (V.None, 2048),
-            [(typeof(Point3d[]), typeof((Point3d[], double)))] = (V.None, 2048),
-            [(typeof(PointCloud), typeof(Sphere))] = (V.Degeneracy, 2048),
-            [(typeof(PointCloud), typeof(BoundingBox))] = (V.Degeneracy, 2048),
-            [(typeof(PointCloud), typeof((Point3d[], int)))] = (V.Degeneracy, 2048),
-            [(typeof(PointCloud), typeof((Point3d[], double)))] = (V.Degeneracy, 2048),
-            [(typeof(Mesh), typeof(Sphere))] = (V.MeshSpecific, 2048),
-            [(typeof(Mesh), typeof(BoundingBox))] = (V.MeshSpecific, 2048),
-            [(typeof(ValueTuple<Mesh, Mesh>), typeof(double))] = (V.MeshSpecific, 4096),
-            [(typeof(Curve[]), typeof(Sphere))] = (V.Degeneracy, 2048),
-            [(typeof(Curve[]), typeof(BoundingBox))] = (V.Degeneracy, 2048),
-            [(typeof(Surface[]), typeof(Sphere))] = (V.BoundingBox, 2048),
-            [(typeof(Surface[]), typeof(BoundingBox))] = (V.BoundingBox, 2048),
-            [(typeof(Brep[]), typeof(Sphere))] = (V.Topology, 2048),
-            [(typeof(Brep[]), typeof(BoundingBox))] = (V.Topology, 2048),
-        }.ToFrozenDictionary();
-
     /// <summary>Executes spatial algorithm based on input/query type patterns with RTree-backed operations.</summary>
     [Pure]
     internal static Result<IReadOnlyList<int>> ExecuteAlgorithm<TInput, TQuery>(
@@ -166,18 +133,8 @@ internal static class SpatialCore {
     /// <summary>Retrieves or constructs RTree for geometry with automatic caching using ConditionalWeakTable.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<RTree> GetTree<T>(T source) where T : notnull =>
-        TreeFactories.TryGetValue(typeof(T), out Func<object, RTree>? factory) switch {
+        SpatialData.TreeFactories.TryGetValue(typeof(T), out Func<object, RTree>? factory) switch {
             true => ResultFactory.Create(value: Spatial.TreeCache.GetValue(key: source, createValueCallback: _ => factory(source!))),
             false => ResultFactory.Create<RTree>(error: E.Spatial.UnsupportedTypeCombo.WithContext($"Type: {typeof(T).Name}")),
         };
-
-    /// <summary>Constructs RTree from geometry array by inserting bounding boxes with index tracking.</summary>
-    [Pure]
-    private static RTree BuildGeometryArrayTree<T>(T[] geometries) where T : GeometryBase {
-        RTree tree = new();
-        for (int i = 0; i < geometries.Length; i++) {
-            _ = tree.Insert(geometries[i].GetBoundingBox(accurate: true), i);
-        }
-        return tree;
-    }
 }

--- a/libs/rhino/spatial/SpatialData.cs
+++ b/libs/rhino/spatial/SpatialData.cs
@@ -1,0 +1,50 @@
+using System.Collections.Frozen;
+using Arsenal.Core.Validation;
+using Rhino.Geometry;
+
+namespace Arsenal.Rhino.Spatial;
+
+/// <summary>Configuration data for spatial indexing algorithms with type-based dispatch tables.</summary>
+internal static class SpatialData {
+    /// <summary>RTree factory configuration mapping source types to construction strategies for optimal tree structure.</summary>
+    internal static readonly FrozenDictionary<Type, Func<object, RTree>> TreeFactories =
+        new Dictionary<Type, Func<object, RTree>> {
+            [typeof(Point3d[])] = s => RTree.CreateFromPointArray((Point3d[])s) ?? new RTree(),
+            [typeof(PointCloud)] = s => RTree.CreatePointCloudTree((PointCloud)s) ?? new RTree(),
+            [typeof(Mesh)] = s => RTree.CreateMeshFaceTree((Mesh)s) ?? new RTree(),
+            [typeof(Curve[])] = s => BuildGeometryArrayTree((Curve[])s),
+            [typeof(Surface[])] = s => BuildGeometryArrayTree((Surface[])s),
+            [typeof(Brep[])] = s => BuildGeometryArrayTree((Brep[])s),
+        }.ToFrozenDictionary();
+
+    /// <summary>Algorithm configuration mapping input/query type pairs to validation modes and buffer strategies.</summary>
+    internal static readonly FrozenDictionary<(Type Input, Type Query), (V Mode, int BufferSize)> AlgorithmConfig =
+        new Dictionary<(Type, Type), (V, int)> {
+            [(typeof(Point3d[]), typeof(Sphere))] = (V.None, 2048),
+            [(typeof(Point3d[]), typeof(BoundingBox))] = (V.None, 2048),
+            [(typeof(Point3d[]), typeof((Point3d[], int)))] = (V.None, 2048),
+            [(typeof(Point3d[]), typeof((Point3d[], double)))] = (V.None, 2048),
+            [(typeof(PointCloud), typeof(Sphere))] = (V.Degeneracy, 2048),
+            [(typeof(PointCloud), typeof(BoundingBox))] = (V.Degeneracy, 2048),
+            [(typeof(PointCloud), typeof((Point3d[], int)))] = (V.Degeneracy, 2048),
+            [(typeof(PointCloud), typeof((Point3d[], double)))] = (V.Degeneracy, 2048),
+            [(typeof(Mesh), typeof(Sphere))] = (V.MeshSpecific, 2048),
+            [(typeof(Mesh), typeof(BoundingBox))] = (V.MeshSpecific, 2048),
+            [(typeof(ValueTuple<Mesh, Mesh>), typeof(double))] = (V.MeshSpecific, 4096),
+            [(typeof(Curve[]), typeof(Sphere))] = (V.Degeneracy, 2048),
+            [(typeof(Curve[]), typeof(BoundingBox))] = (V.Degeneracy, 2048),
+            [(typeof(Surface[]), typeof(Sphere))] = (V.BoundingBox, 2048),
+            [(typeof(Surface[]), typeof(BoundingBox))] = (V.BoundingBox, 2048),
+            [(typeof(Brep[]), typeof(Sphere))] = (V.Topology, 2048),
+            [(typeof(Brep[]), typeof(BoundingBox))] = (V.Topology, 2048),
+        }.ToFrozenDictionary();
+
+    /// <summary>Constructs RTree from geometry array by inserting bounding boxes with index tracking.</summary>
+    private static RTree BuildGeometryArrayTree<T>(T[] geometries) where T : GeometryBase {
+        RTree tree = new();
+        for (int i = 0; i < geometries.Length; i++) {
+            _ = tree.Insert(geometries[i].GetBoundingBox(accurate: true), i);
+        }
+        return tree;
+    }
+}


### PR DESCRIPTION
Establish unified 3-file pattern across spatial, extraction, and intersection folders:
- Main API file (public interface)
- Core engine file (internal implementation)
- Data file (configuration and validation dispatch)

Changes:
- spatial/: Add SpatialData.cs with FrozenDicts for tree factories and algorithm config
- extraction/: Add ExtractionData.cs with validation config FrozenDict
- intersection/: Add IntersectionData.cs + extract IntersectionOptions.cs and IntersectionOutput.cs (CA1050 compliance)

All folders now follow orientation/ exemplar pattern with clean separation of concerns. No functional changes - pure architectural refactor for consistency and maintainability.