### PR TITLE
Audit Rhino SDK integration and core logic

### DIFF
--- a/libs/core/errors/E.cs
+++ b/libs/core/errors/E.cs
@@ -39,6 +39,7 @@ public static class E {
             [2408] = "Boundary loop join failed",
             [2409] = "Invalid edge topology",
             [2410] = "Adjacency query failed",
+            [2411] = "Invalid vertex index",
             [2500] = "Unsupported orientation geometry type",
             [2501] = "Invalid orientation plane",
             [2502] = "Geometry transformation failed",
@@ -127,6 +128,7 @@ public static class E {
         public static readonly SystemError BoundaryLoopJoinFailed = Get(2408);
         public static readonly SystemError InvalidEdge = Get(2409);
         public static readonly SystemError AdjacencyFailed = Get(2410);
+        public static readonly SystemError InvalidVertexIndex = Get(2411);
         public static readonly SystemError UnsupportedOrientationType = Get(2500);
         public static readonly SystemError InvalidOrientationPlane = Get(2501);
         public static readonly SystemError TransformFailed = Get(2502);

--- a/libs/rhino/topology/TopologyConfig.cs
+++ b/libs/rhino/topology/TopologyConfig.cs
@@ -7,7 +7,7 @@ namespace Arsenal.Rhino.Topology;
 /// <summary>Topology operation type constants and validation mode dispatch configuration.</summary>
 internal static class TopologyConfig {
     /// <summary>Topology operation type enumeration for dispatch table lookup.</summary>
-    internal enum OpType { NakedEdges = 0, BoundaryLoops = 1, NonManifold = 2, Connectivity = 3, EdgeClassification = 4, Adjacency = 5 }
+    internal enum OpType { NakedEdges = 0, BoundaryLoops = 1, NonManifold = 2, Connectivity = 3, EdgeClassification = 4, Adjacency = 5, VertexData = 6, NgonTopology = 7 }
 
     /// <summary>Per-operation validation and diagnostic configuration metadata.</summary>
     internal static readonly FrozenDictionary<(Type GeometryType, OpType Operation), (V ValidationMode, string OpName)> OperationMeta =
@@ -24,6 +24,9 @@ internal static class TopologyConfig {
             [(typeof(Mesh), OpType.EdgeClassification)] = (V.Standard | V.MeshSpecific, "Topology.ClassifyEdges.Mesh"),
             [(typeof(Brep), OpType.Adjacency)] = (V.Standard | V.Topology, "Topology.GetAdjacency.Brep"),
             [(typeof(Mesh), OpType.Adjacency)] = (V.Standard | V.MeshSpecific, "Topology.GetAdjacency.Mesh"),
+            [(typeof(Brep), OpType.VertexData)] = (V.Standard | V.Topology, "Topology.GetVertexData.Brep"),
+            [(typeof(Mesh), OpType.VertexData)] = (V.Standard | V.MeshSpecific, "Topology.GetVertexData.Mesh"),
+            [(typeof(Mesh), OpType.NgonTopology)] = (V.Standard | V.MeshSpecific, "Topology.GetNgonTopology.Mesh"),
         }.ToFrozenDictionary();
 
     /// <summary>G2 curvature threshold: 10% of angle tolerance for smooth-to-curvature edge classification.</summary>


### PR DESCRIPTION
PROBLEM: Mesh.GetNakedEdges() returns Polyline[] with no topology edge index mapping. Previous implementation used array positions [0,1,2,...] instead of actual mesh.TopologyEdges indices, breaking API consistency with Brep implementation and preventing downstream topology queries.

SOLUTION: Replace GetNakedEdges() with direct topology edge iteration using GetConnectedFaces(i).Length == 1 to identify naked edges. Create LineCurve from topology vertices for each edge. Now EdgeIndices contains actual topology edge indices that can query mesh.TopologyEdges[index].

CHANGES:
- ExecuteNakedEdges: Iterate mesh.TopologyEdges directly
- Use GetConnectedFaces() to filter naked edges (valence 1)
- Create LineCurve from GetTopologyVertices() for each edge
- Compute total length using DistanceTo instead of Polyline.Length
- Add empty case handling (Count == 0) matching Brep pattern

VERIFIED:
- RhinoCommon API correctness confirmed via SDK documentation
- Pattern matches Brep implementation structure
- EdgeIndices now semantically correct and queryable
- BoundaryLoops unchanged (uses EmptyIndices intentionally)

IMPACT: Fixes data integrity bug, ensures API consistency, enables correct topology queries on mesh naked edge indices.