### PR TITLE
Refine rhino intersection result handling

### DIFF
--- a/libs/rhino/intersection/Intersect.cs
+++ b/libs/rhino/intersection/Intersect.cs
@@ -41,8 +41,8 @@ public static class Intersect {
         bool enableDiagnostics = false) where T1 : notnull where T2 : notnull {
         IntersectionOptions opts = options ?? new();
         (Type t1, Type t2) = (typeof(T1), typeof(T2));
-        Type elem = t1 is { IsGenericType: true } t && t.GetGenericTypeDefinition() == typeof(IReadOnlyList<>) ? t.GetGenericArguments()[0] : t1;
-        V mode = IntersectionConfig.ValidationModes.TryGetValue((t1, t2), out V m1) ? m1 : IntersectionConfig.ValidationModes.TryGetValue((elem, t2), out V m2) ? m2 : V.None;
+        Type elem = t1 is { IsGenericType: true } generic && generic.GetGenericTypeDefinition() == typeof(IReadOnlyList<>) ? generic.GetGenericArguments()[0] : t1;
+        V mode = IntersectionConfig.ValidationModes.GetValueOrDefault((t1, t2), IntersectionConfig.ValidationModes.GetValueOrDefault((elem, t2), V.None));
 
         return UnifiedOperation.Apply(
             geometryA,

--- a/libs/rhino/intersection/IntersectionCore.cs
+++ b/libs/rhino/intersection/IntersectionCore.cs
@@ -12,27 +12,32 @@ namespace Arsenal.Rhino.Intersection;
 
 /// <summary>RhinoCommon intersection dispatch with FrozenDictionary-based type resolution and inline result transformation.</summary>
 internal static class IntersectionCore {
+    private static readonly Result<Intersect.IntersectionOutput> Empty = ResultFactory.Create(value: Intersect.IntersectionOutput.Empty);
+    private static readonly Result<Intersect.IntersectionOutput> IntersectionFailed = ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed);
+    private static readonly Result<Intersect.IntersectionOutput> InvalidProjection = ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidProjection);
+    private static readonly Result<Intersect.IntersectionOutput> InvalidRay = ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidRay);
+    private static readonly Result<Intersect.IntersectionOutput> InvalidMaxHits = ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidMaxHits);
     private static readonly FrozenDictionary<(Type, Type), Func<object, object, double, Intersect.IntersectionOptions, Result<Intersect.IntersectionOutput>>> _dispatch =
         new Dictionary<(Type, Type), Func<object, object, double, Intersect.IntersectionOptions, Result<Intersect.IntersectionOutput>>> {
             [(typeof(Curve), typeof(Curve))] = (a, b, tol, _) => {
                 (Curve ca, Curve cb) = ((Curve)a, (Curve)b);
                 using CurveIntersections? r = ReferenceEquals(ca, cb) ? RhinoIntersect.CurveSelf(ca, tol) : RhinoIntersect.CurveCurve(ca, cb, tol, tol);
                 return r switch {
-                    null => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    null => Empty,
                     { Count: > 0 } => ResultFactory.Create(value: new Intersect.IntersectionOutput(
                         [.. from e in r select e.PointA],
                         [.. from e in r where e.IsOverlap let c = ca.Trim(e.OverlapA) where c is not null select c],
                         [.. from e in r select e.ParameterA],
                         [.. from e in r select e.ParameterB],
                         [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => Empty,
                 };
             },
             [(typeof(Curve), typeof(BrepFace))] = (a, b, tol, _) => (RhinoIntersect.CurveBrepFace((Curve)a, (BrepFace)b, tol, out Curve[] c, out Point3d[] p), c, p) switch {
                 (true, { Length: > 0 }, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, c, [], [], [], [])),
                 (true, { Length: > 0 }, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], c, [], [], [], [])),
                 (true, _, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Curve), typeof(Surface))] = (a, b, tol, _) => {
                 using CurveIntersections? r = RhinoIntersect.CurveSurface((Curve)a, (Surface)b, tol, overlapTolerance: tol);
@@ -43,7 +48,7 @@ internal static class IntersectionCore {
                         [.. from e in r select e.ParameterA],
                         [.. from e in r select e.ParameterB],
                         [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => Empty,
                 };
             },
             [(typeof(Curve), typeof(Plane))] = (a, b, tol, _) => {
@@ -55,7 +60,7 @@ internal static class IntersectionCore {
                         [.. from e in r select e.ParameterA],
                         [.. from e in r select e.ParameterB],
                         [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => Empty,
                 };
             },
             [(typeof(Curve), typeof(Line))] = (a, b, tol, _) => {
@@ -67,142 +72,142 @@ internal static class IntersectionCore {
                         [.. from e in r select e.ParameterA],
                         [.. from e in r select e.ParameterB],
                         [], [])),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    _ => Empty,
                 };
             },
             [(typeof(Curve), typeof(Brep))] = (a, b, tol, _) => (RhinoIntersect.CurveBrep((Curve)a, (Brep)b, tol, out Curve[] c, out Point3d[] p), c, p) switch {
                 (true, { Length: > 0 }, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, c, [], [], [], [])),
                 (true, { Length: > 0 }, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], c, [], [], [], [])),
                 (true, _, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Brep), typeof(Brep))] = (a, b, tol, _) => (RhinoIntersect.BrepBrep((Brep)a, (Brep)b, tol, out Curve[] c, out Point3d[] p), c, p) switch {
                 (true, { Length: > 0 }, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, c, [], [], [], [])),
                 (true, { Length: > 0 }, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], c, [], [], [], [])),
                 (true, _, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Brep), typeof(Plane))] = (a, b, tol, _) => (RhinoIntersect.BrepPlane((Brep)a, (Plane)b, tol, out Curve[] c, out Point3d[] p), c, p) switch {
                 (true, { Length: > 0 }, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, c, [], [], [], [])),
                 (true, { Length: > 0 }, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], c, [], [], [], [])),
                 (true, _, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Brep), typeof(Surface))] = (a, b, tol, _) => (RhinoIntersect.BrepSurface((Brep)a, (Surface)b, tol, out Curve[] c, out Point3d[] p), c, p) switch {
                 (true, { Length: > 0 }, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, c, [], [], [], [])),
                 (true, { Length: > 0 }, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], c, [], [], [], [])),
                 (true, _, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Surface), typeof(Surface))] = (a, b, tol, _) => (RhinoIntersect.SurfaceSurface((Surface)a, (Surface)b, tol, out Curve[] c, out Point3d[] p), c, p) switch {
                 (true, { Length: > 0 }, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, c, [], [], [], [])),
                 (true, { Length: > 0 }, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], c, [], [], [], [])),
                 (true, _, { Length: > 0 }) => ResultFactory.Create(value: new Intersect.IntersectionOutput(p, [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Mesh), typeof(Mesh))] = (a, b, tol, opts) => opts.Sorted switch {
                 true => RhinoIntersect.MeshMeshAccurate((Mesh)a, (Mesh)b, tol) switch {
                     Polyline[] { Length: > 0 } pl => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. from p in pl from pt in p select pt], [], [], [], [], [.. pl])),
-                    null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    null => IntersectionFailed,
+                    _ => Empty,
                 },
                 false => RhinoIntersect.MeshMeshFast((Mesh)a, (Mesh)b) switch {
                     Line[] { Length: > 0 } lines => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. from l in lines select l.From, .. from l in lines select l.To], [], [], [], [], [])),
-                    null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    null => IntersectionFailed,
+                    _ => Empty,
                 },
             },
             [(typeof(Mesh), typeof(Ray3d))] = (a, b, _, _) => RhinoIntersect.MeshRay((Mesh)a, (Ray3d)b) switch {
                 double d when d >= 0d => ResultFactory.Create(value: new Intersect.IntersectionOutput([((Ray3d)b).PointAt(d)], [], [d], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Mesh), typeof(Plane))] = (a, b, _, _) => RhinoIntersect.MeshPlane((Mesh)a, (Plane)b) switch {
                 Polyline[] { Length: > 0 } pl => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. from p in pl from pt in p select pt], [], [], [], [], [.. pl])),
-                null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                null => IntersectionFailed,
+                _ => Empty,
             },
             [(typeof(Mesh), typeof(Line))] = (a, b, _, opts) => opts.Sorted switch {
                 true => (RhinoIntersect.MeshLineSorted((Mesh)a, (Line)b, out int[] ids), ids) switch {
                     (Point3d[] { Length: > 0 } pts, int[] indices) => ResultFactory.Create(value: new Intersect.IntersectionOutput(pts, [], [], [], indices, [])),
-                    _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => IntersectionFailed,
                 },
                 false => RhinoIntersect.MeshLine((Mesh)a, (Line)b) switch {
                     Point3d[] { Length: > 0 } pts => ResultFactory.Create(value: new Intersect.IntersectionOutput(pts, [], [], [], [], [])),
-                    null => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
-                    _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                    null => IntersectionFailed,
+                    _ => Empty,
                 },
             },
             [(typeof(Mesh), typeof(PolylineCurve))] = (a, b, _, opts) => opts.Sorted switch {
                 true => (RhinoIntersect.MeshPolylineSorted((Mesh)a, (PolylineCurve)b, out int[] ids), ids) switch {
                     (Point3d[] { Length: > 0 } pts, int[] indices) => ResultFactory.Create(value: new Intersect.IntersectionOutput(pts, [], [], [], indices, [])),
-                    _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => IntersectionFailed,
                 },
                 false => (RhinoIntersect.MeshPolyline((Mesh)a, (PolylineCurve)b, out int[] ids), ids) switch {
                     (Point3d[] { Length: > 0 } pts, int[] indices) => ResultFactory.Create(value: new Intersect.IntersectionOutput(pts, [], [], [], indices, [])),
-                    _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.IntersectionFailed),
+                    _ => IntersectionFailed,
                 },
             },
             [(typeof(Line), typeof(Line))] = (a, b, tol, _) => RhinoIntersect.LineLine((Line)a, (Line)b, out double pa, out double pb, tol, finiteSegments: false)
                 ? ResultFactory.Create(value: new Intersect.IntersectionOutput([((Line)a).PointAt(pa)], [], [pa], [pb], [], []))
-                : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                : Empty,
             [(typeof(Line), typeof(BoundingBox))] = (a, b, tol, _) => RhinoIntersect.LineBox((Line)a, (BoundingBox)b, tol, out Interval interval)
                 ? ResultFactory.Create(value: new Intersect.IntersectionOutput([((Line)a).PointAt(interval.Min), ((Line)a).PointAt(interval.Max)], [], [interval.Min, interval.Max], [], [], []))
-                : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                : Empty,
             [(typeof(Line), typeof(Plane))] = (a, b, _, _) => RhinoIntersect.LinePlane((Line)a, (Plane)b, out double param)
                 ? ResultFactory.Create(value: new Intersect.IntersectionOutput([((Line)a).PointAt(param)], [], [param], [], [], []))
-                : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                : Empty,
             [(typeof(Line), typeof(Sphere))] = (a, b, tol, _) => ((int)RhinoIntersect.LineSphere((Line)a, (Sphere)b, out Point3d p1, out Point3d p2), p1, p2, tol) switch {
                 (> 1, var pt1, var pt2, double t) when pt1.DistanceTo(pt2) > t => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1, pt2], [], [], [], [], [])),
                 (> 0, var pt1, _, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Line), typeof(Cylinder))] = (a, b, tol, _) => ((int)RhinoIntersect.LineCylinder((Line)a, (Cylinder)b, out Point3d p1, out Point3d p2), p1, p2, tol) switch {
                 (> 1, var pt1, var pt2, double t) when pt1.DistanceTo(pt2) > t => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1, pt2], [], [], [], [], [])),
                 (> 0, var pt1, _, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Line), typeof(Circle))] = (a, b, tol, _) => ((int)RhinoIntersect.LineCircle((Line)a, (Circle)b, out double t1, out Point3d p1, out double t2, out Point3d p2), p1, t1, p2, t2, tol) switch {
                 (> 1, var pt1, double ta, var pt2, double tb, double t) when pt1.DistanceTo(pt2) > t => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1, pt2], [], [ta, tb], [], [], [])),
                 (> 0, var pt1, double ta, _, _, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1], [], [ta], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Plane), typeof(Plane))] = (a, b, _, _) => RhinoIntersect.PlanePlane((Plane)a, (Plane)b, out Line line)
                 ? ResultFactory.Create(value: new Intersect.IntersectionOutput([], [new LineCurve(line)], [], [], [], []))
-                : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                : Empty,
             [(typeof(ValueTuple<Plane, Plane>), typeof(Plane))] = (a, b, _, _) => {
                 ValueTuple<Plane, Plane> planes = (ValueTuple<Plane, Plane>)a;
                 return RhinoIntersect.PlanePlanePlane(planes.Item1, planes.Item2, (Plane)b, out Point3d point)
                     ? ResultFactory.Create(value: new Intersect.IntersectionOutput([point], [], [], [], [], []))
-                    : ResultFactory.Create(value: Intersect.IntersectionOutput.Empty);
+                    : Empty;
             },
             [(typeof(Plane), typeof(Circle))] = (a, b, _, _) => RhinoIntersect.PlaneCircle((Plane)a, (Circle)b, out double t1, out double t2) switch {
                 PlaneCircleIntersection.Tangent => ResultFactory.Create(value: new Intersect.IntersectionOutput([((Circle)b).PointAt(t1)], [], [], [t1], [], [])),
                 PlaneCircleIntersection.Secant => ResultFactory.Create(value: new Intersect.IntersectionOutput([((Circle)b).PointAt(t1), ((Circle)b).PointAt(t2)], [], [], [t1, t2], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Plane), typeof(Sphere))] = (a, b, _, _) => ((int)RhinoIntersect.PlaneSphere((Plane)a, (Sphere)b, out Circle c), c) switch {
                 (1, Circle circle) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], [new ArcCurve(circle)], [], [], [], [])),
                 (2, Circle circle) => ResultFactory.Create(value: new Intersect.IntersectionOutput([circle.Center], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Plane), typeof(BoundingBox))] = (a, b, _, _) => (RhinoIntersect.PlaneBoundingBox((Plane)a, (BoundingBox)b, out Polyline poly), poly) switch {
                 (true, Polyline { Count: > 0 } pl) => ResultFactory.Create(value: new Intersect.IntersectionOutput([.. from pt in pl select pt], [], [], [], [], [pl])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Sphere), typeof(Sphere))] = (a, b, _, _) => ((int)RhinoIntersect.SphereSphere((Sphere)a, (Sphere)b, out Circle c), c) switch {
                 (1, Circle circle) => ResultFactory.Create(value: new Intersect.IntersectionOutput([], [new ArcCurve(circle)], [], [], [], [])),
                 (2, Circle circle) => ResultFactory.Create(value: new Intersect.IntersectionOutput([circle.Center], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Circle), typeof(Circle))] = (a, b, tol, _) => ((int)RhinoIntersect.CircleCircle((Circle)a, (Circle)b, out Point3d p1, out Point3d p2), p1, p2, tol) switch {
                 (> 1, var pt1, var pt2, double t) when pt1.DistanceTo(pt2) > t => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1, pt2], [], [], [], [], [])),
                 (> 0, var pt1, _, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
             [(typeof(Arc), typeof(Arc))] = (a, b, tol, _) => ((int)RhinoIntersect.ArcArc((Arc)a, (Arc)b, out Point3d p1, out Point3d p2), p1, p2, tol) switch {
                 (> 1, var pt1, var pt2, double t) when pt1.DistanceTo(pt2) > t => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1, pt2], [], [], [], [], [])),
                 (> 0, var pt1, _, _) => ResultFactory.Create(value: new Intersect.IntersectionOutput([pt1], [], [], [], [], [])),
-                _ => ResultFactory.Create(value: Intersect.IntersectionOutput.Empty),
+                _ => Empty,
             },
         }.ToFrozenDictionary();
 
@@ -223,7 +228,7 @@ internal static class IntersectionCore {
 
         return (a, b, opts) switch {
             (Point3d[] pts, Brep[] breps, { ProjectionDirection: Vector3d dir }) when !dir.IsValid || dir.Length <= RhinoMath.ZeroTolerance =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidProjection),
+                InvalidProjection,
             (Point3d[] pts, Brep[] breps, { ProjectionDirection: Vector3d dir, WithIndices: true }) =>
                 ResultFactory.Create(value: new Intersect.IntersectionOutput(
                     RhinoIntersect.ProjectPointsToBrepsEx(breps, pts, dir, tolerance, out int[] ids1),
@@ -233,7 +238,7 @@ internal static class IntersectionCore {
                     RhinoIntersect.ProjectPointsToBreps(breps, pts, dir, tolerance),
                     [], [], [], [], [])),
             (Point3d[] pts, Mesh[] meshes, { ProjectionDirection: Vector3d dir }) when !dir.IsValid || dir.Length <= RhinoMath.ZeroTolerance =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidProjection),
+                InvalidProjection,
             (Point3d[] pts, Mesh[] meshes, { ProjectionDirection: Vector3d dir, WithIndices: true }) =>
                 ResultFactory.Create(value: new Intersect.IntersectionOutput(
                     RhinoIntersect.ProjectPointsToMeshesEx(meshes, pts, dir, tolerance, out int[] ids2),
@@ -243,9 +248,9 @@ internal static class IntersectionCore {
                     RhinoIntersect.ProjectPointsToMeshes(meshes, pts, dir, tolerance),
                     [], [], [], [], [])),
             (Ray3d ray, GeometryBase[] geoms, { MaxHits: int hits }) when ray.Direction.Length <= RhinoMath.ZeroTolerance =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidRay),
+                InvalidRay,
             (Ray3d ray, GeometryBase[] geoms, { MaxHits: int hits }) when hits <= 0 =>
-                ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidMaxHits),
+                InvalidMaxHits,
             (Ray3d ray, GeometryBase[] geoms, { MaxHits: int hits }) =>
                 ResultFactory.Create(value: new Intersect.IntersectionOutput(
                     RhinoIntersect.RayShoot(ray, geoms, hits),


### PR DESCRIPTION
## Summary
- use FrozenDictionary.GetValueOrDefault in the Rhino intersection entry point to simplify validation mode lookup
- centralize reusable intersection Result instances to cut duplication while keeping behaviour intact

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69101e75ef548321be02623eb9758ca9)