### PR TITLE
Review TopologyCompute.cs logic and implementation

### DIFF
--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -12,41 +12,53 @@ internal static class TopologyCompute {
     internal static Result<(double[] EdgeGaps, (int EdgeA, int EdgeB, double Distance)[] NearMisses, byte[] SuggestedRepairs)> Diagnose(
         Brep brep,
         IGeometryContext context) =>
-        !brep.IsValid
-            ? ResultFactory.Create<(double[], (int, int, double)[], byte[])>(error: E.Validation.GeometryInvalid)
-            : !brep.IsValidTopology(out string log)
-                ? ResultFactory.Create<(double[], (int, int, double)[], byte[])>(
-                    error: E.Topology.DiagnosisFailed.WithContext($"Topology validation failed: {log}"))
+        !brep.IsValidTopology(out string topologyLog)
+            ? ResultFactory.Create<(double[], (int, int, double)[], byte[])>(
+                error: E.Topology.DiagnosisFailed.WithContext($"Topology validation failed: {topologyLog}"))
+            : !brep.IsValid
+                ? ResultFactory.Create<(double[], (int, int, double)[], byte[])>(error: E.Validation.GeometryInvalid)
                 : ((Func<Result<(double[], (int, int, double)[], byte[])>>)(() => {
-                    double[] gaps = [.. Enumerable.Range(0, brep.Edges.Count)
+                    (int Index, Point3d Start, Point3d End)[] nakedEdges = [.. Enumerable.Range(0, brep.Edges.Count)
                         .Where(i => brep.Edges[i].Valence == EdgeAdjacency.Naked && brep.Edges[i].EdgeCurve is not null)
-                        .Select(i => brep.Edges[i].PointAtStart.DistanceTo(brep.Edges[i].PointAtEnd)),
+                        .Select(i => (Index: i, Start: brep.Edges[i].PointAtStart, End: brep.Edges[i].PointAtEnd)),
                     ];
 
-                    int nakedEdgeCount = brep.Edges.Count(e => e.Valence == EdgeAdjacency.Naked);
+                    double[] gaps = nakedEdges.Length > 0
+                        ? [.. nakedEdges.SelectMany(e1 => nakedEdges
+                            .Where(e2 => e2.Index != e1.Index)
+                            .Select(e2 => Math.Min(e1.Start.DistanceTo(e2.Start), Math.Min(e1.Start.DistanceTo(e2.End), Math.Min(e1.End.DistanceTo(e2.Start), e1.End.DistanceTo(e2.End)))))
+                            .Where(dist => dist > context.AbsoluteTolerance && dist < context.AbsoluteTolerance * TopologyConfig.NearMissMultiplier)
+                            .OrderBy(dist => dist)
+                            .Take(1)),
+                        ]
+                        : [];
+
+                    int nakedEdgeCount = nakedEdges.Length;
                     int nonManifoldEdgeCount = brep.Edges.Count(e => e.Valence == EdgeAdjacency.NonManifold);
 
-                    (int EdgeA, int EdgeB, double Distance)[] nearMisses = brep.Edges.Count < 100
-                        ? [.. (from i in Enumerable.Range(0, brep.Edges.Count)
-                               from j in Enumerable.Range(i + 1, brep.Edges.Count - i - 1)
-                               where brep.Edges[i].EdgeCurve is not null && brep.Edges[j].EdgeCurve is not null
-                               let result = brep.Edges[i].EdgeCurve.ClosestPoints(brep.Edges[j].EdgeCurve, out Point3d ptA, out Point3d ptB)
+                    (int EdgeA, int EdgeB, double Distance)[] nearMisses = nakedEdges.Length < TopologyConfig.MaxEdgesForNearMissAnalysis
+                        ? [.. (from i in Enumerable.Range(0, nakedEdges.Length)
+                               from j in Enumerable.Range(i + 1, nakedEdges.Length - i - 1)
+                               let edgeI = brep.Edges[nakedEdges[i].Index]
+                               let edgeJ = brep.Edges[nakedEdges[j].Index]
+                               where edgeI.EdgeCurve is not null && edgeJ.EdgeCurve is not null
+                               let result = edgeI.EdgeCurve.ClosestPoints(edgeJ.EdgeCurve, out Point3d ptA, out Point3d ptB)
                                ? (Success: true, Distance: ptA.DistanceTo(ptB))
                                : (Success: false, Distance: double.MaxValue)
                                where result.Success && result.Distance < context.AbsoluteTolerance * TopologyConfig.NearMissMultiplier && result.Distance > context.AbsoluteTolerance
-                               select (EdgeA: i, EdgeB: j, result.Distance)),
+                               select (EdgeA: nakedEdges[i].Index, EdgeB: nakedEdges[j].Index, result.Distance)),
                         ]
                         : [];
 
                     byte[] repairs = (nakedEdgeCount, nonManifoldEdgeCount, nearMisses.Length) switch {
-                        ( > 0, > 0, > 0) => [0, 1, 2, 3,],
-                        ( > 0, > 0, _) => [0, 1, 2,],
-                        ( > 0, _, > 0) => [0, 1, 3,],
-                        (_, > 0, > 0) => [2, 3,],
-                        ( > 0, _, _) => [0, 1,],
-                        (_, > 0, _) => [2,],
-                        (_, _, > 0) => [3,],
-                        _ => [0,],
+                        ( > 0, > 0, > 0) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin, TopologyConfig.StrategyAggressiveJoin, TopologyConfig.StrategyCombined,],
+                        ( > 0, > 0, _) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin, TopologyConfig.StrategyAggressiveJoin,],
+                        ( > 0, _, > 0) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin, TopologyConfig.StrategyCombined,],
+                        (_, > 0, > 0) => [TopologyConfig.StrategyAggressiveJoin, TopologyConfig.StrategyCombined,],
+                        ( > 0, _, _) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin,],
+                        (_, > 0, _) => [TopologyConfig.StrategyAggressiveJoin,],
+                        (_, _, > 0) => [TopologyConfig.StrategyCombined,],
+                        _ => [],
                     };
 
                     return ResultFactory.Create<(double[], (int, int, double)[], byte[])>(value: (gaps, nearMisses, repairs));
@@ -57,46 +69,51 @@ internal static class TopologyCompute {
         Brep brep,
         byte maxStrategy,
         IGeometryContext context) =>
-        !brep.IsValid
-            ? ResultFactory.Create<(Brep, byte, bool)>(error: E.Validation.GeometryInvalid)
-            : ((Func<Result<(Brep, byte, bool)>>)(() => {
-                static Brep? DisposeReturningNull(Brep b) { b.Dispose(); return null; }
-                int originalNakedEdges = brep.Edges.Count(e => e.Valence == EdgeAdjacency.Naked);
+        !brep.IsValidTopology(out string _)
+            ? ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.DiagnosisFailed.WithContext("Topology invalid before healing"))
+            : !brep.IsValid
+                ? ResultFactory.Create<(Brep, byte, bool)>(error: E.Validation.GeometryInvalid)
+                : ((Func<Result<(Brep, byte, bool)>>)(() => {
+                    int originalNakedEdges = brep.Edges.Count(e => e.Valence == EdgeAdjacency.Naked);
 
-                (byte Strategy, Brep? Healed, int NakedEdges)[] attempts = [.. Enumerable.Range(0, Math.Min(maxStrategy + 1, 4))
-                    .Select(s => {
-                        byte strategy = (byte)s;
-                        Brep copy = brep.DuplicateBrep();
-                        bool success = strategy switch {
-                            0 => copy.Repair(TopologyConfig.HealingToleranceMultipliers[0] * context.AbsoluteTolerance),
-                            1 => copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[1] * context.AbsoluteTolerance) > 0,
-                            2 => copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[2] * context.AbsoluteTolerance) > 0,
-                            _ => copy.Repair(TopologyConfig.HealingToleranceMultipliers[0] * context.AbsoluteTolerance) && copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[1] * context.AbsoluteTolerance) > 0,
-                        };
-                        bool isValid = success && copy.IsValidTopology(out string _);
-                        int nakedEdges = isValid ? copy.Edges.Count(e => e.Valence == EdgeAdjacency.Naked) : int.MaxValue;
-                        Brep? result = isValid && nakedEdges < originalNakedEdges ? copy : DisposeReturningNull(copy);
-                        return (Strategy: strategy, Healed: result, NakedEdges: nakedEdges);
-                    }),
-                ];
+                    (byte Strategy, Brep? Healed, int NakedEdges)[] attempts = [.. Enumerable.Range(0, Math.Min(maxStrategy + 1, 4))
+                        .Select(s => {
+                            byte strategy = (byte)s;
+                            Brep copy = brep.DuplicateBrep();
+                            bool success = strategy switch {
+                                0 => copy.Repair(TopologyConfig.HealingToleranceMultipliers[0] * context.AbsoluteTolerance),
+                                1 => copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[1] * context.AbsoluteTolerance) > 0,
+                                2 => copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[2] * context.AbsoluteTolerance) > 0,
+                                _ => copy.Repair(TopologyConfig.HealingToleranceMultipliers[0] * context.AbsoluteTolerance) && copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[1] * context.AbsoluteTolerance) > 0,
+                            };
+                            bool isValid = success && copy.IsValidTopology(out string _);
+                            int nakedEdges = isValid ? copy.Edges.Count(e => e.Valence == EdgeAdjacency.Naked) : int.MaxValue;
+                            Brep? result = isValid && nakedEdges < originalNakedEdges
+                                ? copy
+                                : ((Func<Brep?>)(() => { copy.Dispose(); return null; }))();
+                            return (Strategy: strategy, Healed: result, NakedEdges: nakedEdges);
+                        }),
+                    ];
 
-                (byte strategy, Brep? healed, int nakedEdges) = attempts.Where(a => a.Healed is not null).OrderBy(a => a.NakedEdges).FirstOrDefault();
-                return healed is not null
-                    ? ResultFactory.Create<(Brep, byte, bool)>(value: (healed, strategy, nakedEdges < originalNakedEdges))
-                    : ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.HealingFailed.WithContext($"All {attempts.Length} strategies failed"));
-            }))();
+                    (byte strategy, Brep? healed, int nakedEdges) = attempts.Where(a => a.Healed is not null).OrderBy(a => a.NakedEdges).FirstOrDefault();
+                    return healed is not null
+                        ? ResultFactory.Create<(Brep, byte, bool)>(value: (healed, strategy, nakedEdges < originalNakedEdges))
+                        : ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.HealingFailed.WithContext($"All {attempts.Length} strategies failed"));
+                }))();
 
     [Pure]
     internal static Result<(int Genus, (int LoopIndex, bool IsHole)[] Loops, bool IsSolid, int HandleCount)> ExtractFeatures(
         Brep brep,
         IGeometryContext context) =>
-        !brep.IsValid
-            ? ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Validation.GeometryInvalid)
-            : (brep.Vertices.Count, brep.Edges.Count, brep.Faces.Count, brep.IsSolid && brep.IsManifold, brep.Loops.Select((l, i) => ((Func<(int LoopIndex, bool IsHole)>)(() => { using Curve? c = l.To3dCurve(); return (LoopIndex: i, IsHole: l.LoopType == BrepLoopType.Inner && (c?.GetLength() ?? 0.0) > context.AbsoluteTolerance); }))()).ToArray()) switch {
-                (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 && solid && (e - v - f + 2) / 2 is int genus && genus >= 0 =>
-                    ResultFactory.Create(value: (Genus: genus, Loops: loops, solid, HandleCount: genus)),
-                (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 =>
-                    ResultFactory.Create(value: (Genus: 0, Loops: loops, solid, HandleCount: 0)),
-                _ => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),
-            };
+        !brep.IsValidTopology(out string _)
+            ? ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.DiagnosisFailed.WithContext("Topology invalid for feature extraction"))
+            : !brep.IsValid
+                ? ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Validation.GeometryInvalid)
+                : (brep.Vertices.Count, brep.Edges.Count, brep.Faces.Count, brep.IsSolid && brep.IsManifold, brep.Loops.Select((l, i) => ((Func<(int LoopIndex, bool IsHole)>)(() => { using Curve? c = l.To3dCurve(); return (LoopIndex: i, IsHole: l.LoopType == BrepLoopType.Inner && (c?.GetLength() ?? 0.0) > context.AbsoluteTolerance); }))()).ToArray()) switch {
+                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 && solid && (e - v - f + 2) / 2 is int genus && genus >= 0 =>
+                        ResultFactory.Create(value: (Genus: genus, Loops: loops, solid, HandleCount: genus)),
+                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 =>
+                        ResultFactory.Create(value: (Genus: 0, Loops: loops, solid, HandleCount: 0)),
+                    _ => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),
+                };
 }

--- a/libs/rhino/topology/TopologyConfig.cs
+++ b/libs/rhino/topology/TopologyConfig.cs
@@ -38,8 +38,23 @@ internal static class TopologyConfig {
     /// <summary>Near-miss proximity multiplier: 100× tolerance.</summary>
     internal const double NearMissMultiplier = 100.0;
 
+    /// <summary>Maximum edge count for O(n²) near-miss detection. Above this, skip near-miss analysis for performance.</summary>
+    internal const int MaxEdgesForNearMissAnalysis = 100;
+
     /// <summary>Minimum loop length for hole detection.</summary>
     internal const double MinLoopLength = 1e-6;
+
+    /// <summary>Healing strategy: Conservative Repair with 0.1× tolerance.</summary>
+    internal const byte StrategyConservativeRepair = 0;
+
+    /// <summary>Healing strategy: Moderate JoinNakedEdges with 1.0× tolerance.</summary>
+    internal const byte StrategyModerateJoin = 1;
+
+    /// <summary>Healing strategy: Aggressive JoinNakedEdges with 10.0× tolerance.</summary>
+    internal const byte StrategyAggressiveJoin = 2;
+
+    /// <summary>Healing strategy: Combined Repair + JoinNakedEdges.</summary>
+    internal const byte StrategyCombined = 3;
 
     /// <summary>Healing strategy tolerance multipliers: [Conservative=0.1×, Moderate=1.0×, Aggressive=10.0×].</summary>
     internal static readonly double[] HealingToleranceMultipliers = [0.1, 1.0, 10.0,];


### PR DESCRIPTION
Executive Summary
After deep analysis of TopologyCompute.cs against RhinoCommon SDK documentation, topology theory, and project coding standards, I've identified 7 critical issues and several optimization opportunities. The Euler characteristic formula is mathematically correct, but there are fundamental logic flaws in edge gap computation and validation ordering.

🔴 CRITICAL ISSUES (Must Fix)
1. LOGIC FLAW: Edge Gap Computation (Line 21-24)
Current Code:

double[] gaps = [.. Enumerable.Range(0, brep.Edges.Count)
    .Where(i => brep.Edges[i].Valence == EdgeAdjacency.Naked && brep.Edges[i].EdgeCurve is not null)
    .Select(i => brep.Edges[i].PointAtStart.DistanceTo(brep.Edges[i].PointAtEnd)),
];
Problem: This computes the distance from start to end of the SAME edge. For closed naked edges (like boundary loops), this is always 0.0. Edge gaps should measure distances between ENDPOINTS of DIFFERENT edges that should be joined.

Correct Algorithm: For each naked edge endpoint, find the nearest OTHER naked edge endpoint and record that distance if > tolerance.

Severity: High - produces meaningless gap data for closed boundaries.

2. API VIOLATION: Validation Order (Lines 15-17, 60, 93)
Current Code:

!brep.IsValid
    ? ResultFactory.Create<(double[], (int, int, double)[], byte[])>(error: E.Validation.GeometryInvalid)
    : !brep.IsValidTopology(out string log)
Problem: Per RhinoCommon API documentation: "The value of brep.IsValidTopology() must be True before brep.IsValidGeometry() [IsValid] can be safely called."

Fix: Reverse the order - check IsValidTopology() FIRST, then IsValid.

Reference: https://developer.rhino3d.com/api/RhinoCommon/html/M_Rhino_Geometry_Brep_IsValidTopology.htm

Severity: High - violates SDK contract, could cause undefined behavior.

3. CODING STANDARD VIOLATION: Helper Method (Line 63)
Current Code:

static Brep? DisposeReturningNull(Brep b) { b.Dispose(); return null; }
Problem: Per CLAUDE.md: "NO helper methods or 'Extract Method' refactoring - Improve the logic algorithmically instead (hard 300 LOC limit per member)."

Fix: Inline at usage sites (line 78):

Brep? result = isValid && nakedEdges < originalNakedEdges
    ? copy
    : ((Func<Brep?>)(() => { copy.Dispose(); return null; }))();
Severity: Medium - violates project standards but doesn't affect functionality.

4. ARBITRARY CONSTANT: Edge Count Threshold (Line 29)
Current Code:

(int EdgeA, int EdgeB, double Distance)[] nearMisses = brep.Edges.Count < 100
Problem: Magic number 100 with no justification. This creates O(n²) near-miss computation, but the threshold is arbitrary.

Fix: Add to TopologyConfig.cs:

/// <summary>Maximum edge count for O(n²) near-miss detection. Above this, skip near-miss analysis for performance.</summary>
internal const int MaxEdgesForNearMissAnalysis = 100;
Severity: Medium - arbitrary threshold without documentation.

5. INEFFICIENCY: Near-Miss Checks All Edges (Line 30-32)
Current Code:

from i in Enumerable.Range(0, brep.Edges.Count)
from j in Enumerable.Range(i + 1, brep.Edges.Count - i - 1)
where brep.Edges[i].EdgeCurve is not null && brep.Edges[j].EdgeCurve is not null
Problem: Checks ALL edge pairs, including interior/manifold edges. Only NAKED edges are candidates for joining.

Fix: Filter to naked edges first:

int[] nakedIndices = [.. Enumerable.Range(0, brep.Edges.Count)
    .Where(i => brep.Edges[i].Valence == EdgeAdjacency.Naked && brep.Edges[i].EdgeCurve is not null),
];
(int EdgeA, int EdgeB, double Distance)[] nearMisses = nakedIndices.Length < TopologyConfig.MaxEdgesForNearMissAnalysis
    ? [.. (from i in Enumerable.Range(0, nakedIndices.Length)
           from j in Enumerable.Range(i + 1, nakedIndices.Length - i - 1)
Severity: Medium - performance issue for complex geometry.

6. UNCLEAR MAGIC NUMBERS: Repair Strategies (Line 41-50)
Current Code:

byte[] repairs = (nakedEdgeCount, nonManifoldEdgeCount, nearMisses.Length) switch {
    ( > 0, > 0, > 0) => [0, 1, 2, 3,],
    // ... using 0, 1, 2, 3 without documentation
Problem: Strategies are identified by bare bytes 0-3 with no inline documentation. Must cross-reference Heal method to understand meaning.

Fix: Add constants to TopologyConfig.cs:

/// <summary>Healing strategy: Conservative Repair with 0.1× tolerance.</summary>
internal const byte StrategyConservativeRepair = 0;
/// <summary>Healing strategy: Moderate JoinNakedEdges with 1.0× tolerance.</summary>
internal const byte StrategyModerateJoin = 1;
/// <summary>Healing strategy: Aggressive JoinNakedEdges with 10.0× tolerance.</summary>
internal const byte StrategyAggressiveJoin = 2;
/// <summary>Healing strategy: Combined Repair + JoinNakedEdges.</summary>
internal const byte StrategyCombined = 3;
Then use: [StrategyConservativeRepair, StrategyModerateJoin,] etc.

Severity: Low - readability issue.

7. LOGIC ERROR: Default Repair Suggestion (Line 49)
Current Code:

byte[] repairs = (nakedEdgeCount, nonManifoldEdgeCount, nearMisses.Length) switch {
    // ... all specific cases
    _ => [0,],  // Default: always suggest strategy 0
};
Problem: Default case (0, 0, 0) means NO problems detected, yet suggests strategy 0 (Repair). Should return empty array.

Fix:

_ => [],  // No problems detected, no repairs needed
Severity: Low - logic inconsistency but doesn't break anything.

✅ THINGS THAT ARE CORRECT
Euler Characteristic Formula (Line 96)
(e - v - f + 2) / 2 is int genus && genus >= 0
Analysis: This is mathematically correct for closed solid manifolds:

Euler formula: χ = V - E + F
For closed surface: χ = 2 - 2g
Therefore: V - E + F = 2 - 2g
Solving for genus: g = (E - V - F + 2) / 2 ✓
Reference: Euler-Poincaré characteristic for 3D solids.

SDK Usage
Brep.IsValidTopology(out string log) - Correct usage with logging ✓
Curve.ClosestPoints(otherCurve, out Point3d, out Point3d) - Correct bool return + out params ✓
Brep.Repair(tolerance) - Returns bool ✓
Brep.JoinNakedEdges(tolerance) - Returns int (join count) ✓
BrepLoop.To3dCurve() with using - Correct disposal ✓
Memory Management
copy.Dispose() called when healing fails ✓
using Curve? c = l.To3dCurve() for loop curves ✓
Progressive Healing Design
Multiple tolerance strategies with rollback ✓
Only keeps results that IMPROVE geometry (nakedEdges < originalNakedEdges) ✓
int.MaxValue sentinel for failed attempts ✓
🟡 OPTIMIZATION OPPORTUNITIES
1. NearMissMultiplier Value
Current: 100.0 (TopologyConfig.cs:39)

Question: Is 100× tolerance appropriate for "near-miss" detection? This could be 0.1mm to 10mm for typical models.

Recommendation: Consider reducing to 10.0-50.0× or make it configurable based on geometry scale.

2. Missing Edge Topology Checks
Current: Only checks naked and non-manifold edges.

Gap: Doesn't detect:

Degenerate edges (zero length)
Twisted/self-intersecting edges
Edges with invalid curvature
Potential Enhancement: Add checks using:

BrepEdge.IsValid
BrepEdge.Tolerance
Curvature analysis
3. Loop Classification
Current Line 95:

(LoopIndex: i, IsHole: l.LoopType == BrepLoopType.Inner && (c?.GetLength() ?? 0.0) > context.AbsoluteTolerance)
Question: Should also check BrepLoopType.Outer for completeness? Currently only classifies Inner loops as potential holes.

📋 CODING STANDARDS COMPLIANCE
✅ Correct:
No var usage ✓
Named parameters (error:, value:) ✓
Trailing commas in multi-line collections ✓
Expression-based (ternary, switch expressions) ✓
File-scoped namespace ✓
K&R brace style ✓
Target-typed new() for Results ✓
[Pure] attributes on methods ✓
❌ Violations:
Helper method DisposeReturningNull (Issue #3)
🎯 PRIORITY RECOMMENDATIONS
High Priority (Fix Immediately):
Fix edge gap computation algorithm (Issue #1)
Reverse validation order to call IsValidTopology() first (Issue #2)
Inline helper method DisposeReturningNull (Issue #3)
Medium Priority (Next Iteration):
Add MaxEdgesForNearMissAnalysis constant to TopologyConfig (Issue #4)
Filter near-miss analysis to naked edges only (Issue #5)
Low Priority (Code Clarity):
Add strategy constants to TopologyConfig (Issue #6)
Fix default repair suggestion to return empty array (Issue #7)
Review NearMissMultiplier value appropriateness
📊 LINE COUNT ANALYSIS
Diagnose: 42 lines (within 300 LOC limit ✓)
Heal: 32 lines (within 300 LOC limit ✓)
ExtractFeatures: 12 lines (within 300 LOC limit ✓)
Total: 102 lines (well within limits)
🔍 DEEP SDK RESEARCH FINDINGS
From RhinoCommon API documentation research:

Brep.IsValidTopology(): Must be called before IsValid. Can be called at any time. Outputs log suitable for debugging.

Curve.ClosestPoints(): Returns bool indicating success. Outputs two Point3d parameters for closest points on each curve.

Brep.Repair(): Returns bool. Attempts to fix problematic Breps. Uses tolerance parameter.

Brep.JoinNakedEdges(): Returns int (number of joins made). Only affects naked edges within tolerance.

Euler Characteristic: For closed orientable surface: χ = 2 - 2g. For Brep with handles/holes: g = (E - V - F + 2) / 2.