### PR TITLE
Review ExtractionCompute.cs logic and implementation

### DIFF
--- a/libs/rhino/extraction/ExtractionCompute.cs
+++ b/libs/rhino/extraction/ExtractionCompute.cs
@@ -16,138 +16,428 @@ internal static class ExtractionCompute {
                 ? ResultFactory.Create<((byte Type, double Param)[], double Confidence)>(error: E.Geometry.FeatureExtractionFailed.WithContext("Brep has no faces"))
                 : brep.Edges.Count is 0
                     ? ResultFactory.Create<((byte Type, double Param)[], double Confidence)>(error: E.Geometry.FeatureExtractionFailed.WithContext("Brep has no edges"))
-                    : ResultFactory.Create(value: (
-                    Features: brep.Edges
-                        .Where(e => e.EdgeCurve is not null)
-                        .Select(e => {
-                            (double tMin, double tMid, double tMax) = (e.Domain.Min, e.Domain.ParameterAt(0.5), e.Domain.Max);
-                            (double k0, double k1, double k2) = (e.EdgeCurve.CurvatureAt(tMin).Length, e.EdgeCurve.CurvatureAt(tMid).Length, e.EdgeCurve.CurvatureAt(tMax).Length);
-                            (double min, double max, double avg) = (Math.Min(k0, Math.Min(k1, k2)), Math.Max(k0, Math.Max(k1, k2)), (k0 + k1 + k2) / 3.0);
-                            (bool isG2, bool isConstCurv) = (!e.GetNextDiscontinuity(Continuity.G2_locus_continuous, tMin, tMax, out double _), !e.EdgeCurve.TryGetPolyline(out Polyline _) && (max - min) < Math.Max(ExtractionConfig.FilletG2Threshold * avg, ExtractionConfig.FilletG2AbsoluteTolerance));
-                            double dihedral = e.AdjacentFaces() is int[] adj && adj.Length == 2 && e.PointAt(tMid) is Point3d pt && e.Brep.Faces[adj[0]].ClosestPoint(pt, out double u0, out double v0) && e.Brep.Faces[adj[1]].ClosestPoint(pt, out double u1, out double v1)
-                                ? Math.Abs(Vector3d.VectorAngle(e.Brep.Faces[adj[0]].NormalAt(u0, v0), e.Brep.Faces[adj[1]].NormalAt(u1, v1)))
-                                : 0.0;
-                            return ((byte)(isG2 && isConstCurv ? 0 : isG2 ? 4 : Math.Abs(dihedral - (Math.PI / 4)) < ExtractionConfig.ChamferAngleTolerance ? 1 : 3), e.EdgeCurve.GetLength());
-                        })
-                        .Concat(brep.Loops.Where(l => l.LoopType == BrepLoopType.Inner && l.To3dCurve() is Curve c && c.IsClosed && c.TryGetPolyline(out Polyline pl) && pl.Count >= ExtractionConfig.MinHoleSides)
-                            .Select(l => ((Func<(byte, double)>)(() => { using Curve? c = l.To3dCurve(); using AreaMassProperties? amp = c is not null ? AreaMassProperties.Compute(c) : null; return (2, amp?.Area ?? 0.0); }))()))
-                        .ToArray(),
-                    Confidence: brep.Edges.Count > 0 ? 1.0 - (brep.Edges.Count(e => e.EdgeCurve is null) / (double)brep.Edges.Count) : 0.0
-                ));
+                    : ExtractFeaturesInternal(brep: brep);
+
+    [Pure]
+    private static Result<((byte Type, double Param)[] Features, double Confidence)> ExtractFeaturesInternal(Brep brep) {
+        BrepEdge[] validEdges = [.. brep.Edges.Where(e => e.EdgeCurve is not null),];
+        (byte Type, double Param)[] edgeFeatures = new (byte, double)[validEdges.Length];
+
+        for (int i = 0; i < validEdges.Length; i++) {
+            edgeFeatures[i] = ClassifyEdge(edge: validEdges[i], brep: brep);
+        }
+
+        (byte Type, double Param)[] holeFeatures = [.. brep.Loops
+            .Where(l => l.LoopType == BrepLoopType.Inner)
+            .Select(l => ClassifyHole(loop: l))
+            .Where(h => h.IsHole)
+            .Select(h => (Type: ExtractionConfig.FeatureTypeHole, Param: h.Area)),
+        ];
+
+        (byte Type, double Param)[] allFeatures = [.. edgeFeatures.Concat(holeFeatures),];
+        double confidence = brep.Edges.Count > 0
+            ? 1.0 - (brep.Edges.Count(e => e.EdgeCurve is null) / (double)brep.Edges.Count)
+            : 0.0;
+
+        return ResultFactory.Create(value: (Features: allFeatures, Confidence: confidence));
+    }
+
+    [Pure]
+    private static (byte Type, double Param) ClassifyEdge(BrepEdge edge, Brep brep) {
+        (double tMin, double tMax) = (edge.Domain.Min, edge.Domain.Max);
+        double[] parameters = new double[ExtractionConfig.FilletCurvatureSampleCount];
+
+        for (int i = 0; i < ExtractionConfig.FilletCurvatureSampleCount; i++) {
+            parameters[i] = edge.Domain.ParameterAt(i / (ExtractionConfig.FilletCurvatureSampleCount - 1.0));
+        }
+
+        Vector3d[] curvatureVectors = new Vector3d[parameters.Length];
+        for (int i = 0; i < parameters.Length; i++) {
+            curvatureVectors[i] = edge.EdgeCurve.CurvatureAt(parameters[i]);
+        }
+
+        double[] curvatures = [.. curvatureVectors.Where(v => v.IsValid).Select(v => v.Length),];
+
+        return curvatures.Length < 2
+            ? (Type: ExtractionConfig.FeatureTypeGenericEdge, Param: edge.EdgeCurve.GetLength())
+            : ClassifyEdgeFromCurvature(
+                edge: edge,
+                brep: brep,
+                curvatures: curvatures,
+                tMin: tMin,
+                tMax: tMax);
+    }
+
+    [Pure]
+    private static (byte Type, double Param) ClassifyEdgeFromCurvature(
+        BrepEdge edge,
+        Brep brep,
+        double[] curvatures,
+        double tMin,
+        double tMax) {
+        double mean = curvatures.Average();
+        double variance = curvatures.Sum(k => (k - mean) * (k - mean)) / curvatures.Length;
+        double stdDev = Math.Sqrt(variance);
+        double coefficientOfVariation = mean > 1e-10 ? stdDev / mean : 0.0;
+
+        bool isG2Continuous = !edge.GetNextDiscontinuity(
+            continuityType: Continuity.G2_locus_continuous,
+            t0: tMin,
+            t1: tMax,
+            t: out double _);
+
+        bool isConstantCurvature = coefficientOfVariation < ExtractionConfig.FilletCurvatureVariationThreshold;
+        bool isFillet = isG2Continuous && isConstantCurvature && mean > 1e-10;
+
+        return isFillet
+            ? (Type: ExtractionConfig.FeatureTypeFillet, Param: mean > 1e-10 ? 1.0 / mean : 0.0)
+            : ClassifyEdgeByDihedral(edge: edge, brep: brep, mean: mean);
+    }
+
+    [Pure]
+    private static (byte Type, double Param) ClassifyEdgeByDihedral(BrepEdge edge, Brep brep, double mean) {
+        int[] adjacentFaces = edge.AdjacentFaces();
+
+        return adjacentFaces.Length is 2
+            && edge.PointAt(edge.Domain.ParameterAt(0.5)) is Point3d midPoint
+            && brep.Faces[adjacentFaces[0]].ClosestPoint(testPoint: midPoint, u: out double u0, v: out double v0)
+            && brep.Faces[adjacentFaces[1]].ClosestPoint(testPoint: midPoint, u: out double u1, v: out double v1)
+            ? ClassifyEdgeByAngle(
+                edge: edge,
+                normal0: brep.Faces[adjacentFaces[0]].NormalAt(u: u0, v: v0),
+                normal1: brep.Faces[adjacentFaces[1]].NormalAt(u: u1, v: v1),
+                mean: mean)
+            : (Type: ExtractionConfig.FeatureTypeGenericEdge, Param: edge.EdgeCurve.GetLength());
+    }
+
+    [Pure]
+    private static (byte Type, double Param) ClassifyEdgeByAngle(
+        BrepEdge edge,
+        Vector3d normal0,
+        Vector3d normal1,
+        double mean) {
+        double dihedralAngle = Math.Abs(Vector3d.VectorAngle(normal0, normal1));
+        bool isSmooth = Math.Abs(dihedralAngle - Math.PI) < (Math.PI - ExtractionConfig.SmoothEdgeAngleThreshold);
+        bool isSharp = dihedralAngle < ExtractionConfig.SharpEdgeAngleThreshold;
+        bool isChamfer = !isSmooth && !isSharp;
+
+        return isChamfer
+            ? (Type: ExtractionConfig.FeatureTypeChamfer, Param: dihedralAngle)
+            : mean > 1e-10
+                ? (Type: ExtractionConfig.FeatureTypeVariableRadiusFillet, Param: 1.0 / mean)
+                : (Type: ExtractionConfig.FeatureTypeGenericEdge, Param: edge.EdgeCurve.GetLength());
+    }
+
+    [Pure]
+    private static (bool IsHole, double Area) ClassifyHole(BrepLoop loop) =>
+        loop.To3dCurve() switch {
+            null => (false, 0.0),
+            Curve c when !c.IsClosed => ((Func<(bool, double)>)(() => { c.Dispose(); return (false, 0.0); }))(),
+            Curve c => ((Func<(bool, double)>)(() => {
+                try {
+                    bool isCircle = c.TryGetCircle(out Circle circ, tolerance: ExtractionConfig.PrimitiveFitTolerance);
+                    bool isEllipse = !isCircle && c.TryGetEllipse(out Ellipse ell, tolerance: ExtractionConfig.PrimitiveFitTolerance);
+                    bool isPoly = !isCircle && !isEllipse && c.TryGetPolyline(out Polyline pl) && pl.Count >= ExtractionConfig.MinHolePolySides;
+                    double area = (isCircle, isEllipse, isPoly) switch {
+                        (true, _, _) => Math.PI * circ.Radius * circ.Radius,
+                        (_, true, _) => Math.PI * ell.Radius1 * ell.Radius2,
+                        (_, _, true) when AreaMassProperties.Compute(c) is AreaMassProperties amp => ((Func<double>)(() => { double a = amp.Area; amp.Dispose(); return a; }))(),
+                        _ => 0.0,
+                    };
+                    return (isCircle || isEllipse || isPoly, area);
+                } finally {
+                    c.Dispose();
+                }
+            }))(),
+        };
 
     private static readonly double[] _zeroResidual = [0.0,];
 
     [Pure]
     internal static Result<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)> DecomposeToPrimitives(GeometryBase geometry) =>
         geometry switch {
-            Surface s => ClassifySurface(s) switch {
-                (true, 0, Plane pl, double[] p) => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(value: ([(Type: 0, Frame: pl, Params: p),], _zeroResidual)),
-                (true, 1, Plane fr, double[] p) => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(value: ([(Type: 1, Frame: fr, Params: p),], _zeroResidual)),
-                (true, 2, Plane fr, double[] p) => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(value: ([(Type: 2, Frame: fr, Params: p),], _zeroResidual)),
-                (true, 4, Plane fr, double[] p) => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(value: ([(Type: 4, Frame: fr, Params: p),], _zeroResidual)),
-                (true, 5, Plane fr, double[] p) => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(value: ([(Type: 5, Frame: fr, Params: p),], _zeroResidual)),
-                _ => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(error: E.Geometry.NoPrimitivesDetected),
+            Surface s => ClassifySurface(surface: s) switch {
+                (true, byte type, Plane frame, double[] pars) => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(
+                    value: ([(Type: type, Frame: frame, Params: pars),], _zeroResidual)),
+                _ => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(
+                    error: E.Geometry.NoPrimitivesDetected),
             },
-            Brep b => b.Faces.Count is 0
-                ? ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(error: E.Geometry.DecompositionFailed)
-                : ResultFactory.Create(value: (
-                    Primitives: b.Faces
-                            .Select(f => f.DuplicateSurface() switch {
-                                null => (Success: false, Primitive: default),
-                                Surface surf => ((Func<(bool Success, (byte Type, Plane Frame, double[] Params) Primitive)>)(() => {
-                                    (bool success, byte type, Plane frame, double[] pars) = ClassifySurface(surf);
-                                    surf.Dispose();
-                                    return (success, (type, frame, pars));
-                                }))(),
-                            })
-                            .Where(t => t.Success)
-                            .Select(t => t.Primitive).ToArray(),
-                    Residuals: b.Faces.Select(_ => 0.0).ToArray()
-                )),
-            _ => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(error: E.Geometry.DecompositionFailed),
+            Brep b when b.Faces.Count is 0 => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(
+                error: E.Geometry.DecompositionFailed.WithContext("Brep has no faces")),
+            Brep b => DecomposeBrepFaces(brep: b),
+            _ => ResultFactory.Create<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)>(
+                error: E.Geometry.DecompositionFailed.WithContext($"Unsupported geometry type: {geometry.GetType().Name}")),
         };
 
     [Pure]
-    private static (bool Success, byte Type, Plane Frame, double[] Params) ClassifySurface(Surface s) =>
-        s.TryGetPlane(out Plane pl, tolerance: ExtractionConfig.PrimitiveFitTolerance)
-            ? (true, 0, pl, [pl.OriginX, pl.OriginY, pl.OriginZ,])
-            : s.TryGetCylinder(out Cylinder cyl, tolerance: ExtractionConfig.PrimitiveFitTolerance) && cyl.Radius > ExtractionConfig.PrimitiveFitTolerance
-                ? (true, 1, new Plane(cyl.Center, cyl.Axis), [cyl.Radius, cyl.TotalHeight,])
-                : s.TryGetSphere(out Sphere sph, tolerance: ExtractionConfig.PrimitiveFitTolerance) && sph.Radius > ExtractionConfig.PrimitiveFitTolerance
-                    ? (true, 2, new Plane(sph.Center, Vector3d.ZAxis), [sph.Radius,])
-                    : s.TryGetCone(out Cone cone, tolerance: ExtractionConfig.PrimitiveFitTolerance) && cone.Radius > ExtractionConfig.PrimitiveFitTolerance && cone.Height > ExtractionConfig.PrimitiveFitTolerance && Math.Abs(cone.Height) > 1e-8
-                        ? (true, 4, new Plane(cone.BasePoint, cone.Axis), [cone.Radius, cone.Height, Math.Atan(cone.Radius / cone.Height),])
-                        : s.TryGetTorus(out Torus torus, tolerance: ExtractionConfig.PrimitiveFitTolerance) && torus.MajorRadius > ExtractionConfig.PrimitiveFitTolerance && torus.MinorRadius > ExtractionConfig.PrimitiveFitTolerance
-                            ? (true, 5, torus.Plane, [torus.MajorRadius, torus.MinorRadius,])
-                            : s switch {
-                                Extrusion ext when ext.IsValid && ext.PathLineCurve() is LineCurve lc => (true, 6, new Plane(ext.PathStart, lc.Line.Direction), [lc.Line.Length,]),
-                                _ => (false, 3, new Plane(Point3d.Origin, Vector3d.ZAxis), []),
+    private static Result<((byte Type, Plane Frame, double[] Params)[] Primitives, double[] Residuals)> DecomposeBrepFaces(Brep brep) {
+        (bool Success, byte Type, Plane Frame, double[] Params, double Residual)[] classified =
+            new (bool, byte, Plane, double[], double)[brep.Faces.Count];
+
+        for (int i = 0; i < brep.Faces.Count; i++) {
+            classified[i] = brep.Faces[i].DuplicateSurface() switch {
+                null => (false, ExtractionConfig.PrimitiveTypeUnknown, Plane.WorldXY, [], 0.0),
+                Surface surf => ((Func<(bool, byte, Plane, double[], double)>)(() => {
+                    (bool success, byte type, Plane frame, double[] pars) = ClassifySurface(surface: surf);
+                    double residual = success ? ComputeSurfaceResidual(surface: surf, type: type, frame: frame, pars: pars) : 0.0;
+                    surf.Dispose();
+                    return (success, type, frame, pars, residual);
+                }))(),
+            };
+        }
+
+        (byte Type, Plane Frame, double[] Params)[] primitives = [.. classified
+            .Where(c => c.Success)
+            .Select(c => (c.Type, c.Frame, c.Params)),
+        ];
+
+        double[] residuals = [.. classified
+            .Where(c => c.Success)
+            .Select(c => c.Residual),
+        ];
+
+        return primitives.Length > 0
+            ? ResultFactory.Create(value: (Primitives: primitives, Residuals: residuals))
+            : ResultFactory.Create<((byte, Plane, double[])[], double[])>(
+                error: E.Geometry.NoPrimitivesDetected.WithContext("No faces classified as primitives"));
+    }
+
+    [Pure]
+    private static (bool Success, byte Type, Plane Frame, double[] Params) ClassifySurface(Surface surface) =>
+        surface.TryGetPlane(out Plane pl, tolerance: ExtractionConfig.PrimitiveFitTolerance)
+            ? (true, ExtractionConfig.PrimitiveTypePlane, pl, [pl.OriginX, pl.OriginY, pl.OriginZ, pl.Normal.X, pl.Normal.Y, pl.Normal.Z,])
+            : surface.TryGetCylinder(out Cylinder cyl, tolerance: ExtractionConfig.PrimitiveFitTolerance)
+                && cyl.Radius > ExtractionConfig.PrimitiveFitTolerance
+                ? (true, ExtractionConfig.PrimitiveTypeCylinder, new Plane(cyl.Circle.Center, cyl.Axis), [cyl.Radius, cyl.TotalHeight,])
+                : surface.TryGetSphere(out Sphere sph, tolerance: ExtractionConfig.PrimitiveFitTolerance)
+                    && sph.Radius > ExtractionConfig.PrimitiveFitTolerance
+                    ? (true, ExtractionConfig.PrimitiveTypeSphere, new Plane(sph.Center, sph.NorthPole - sph.Center), [sph.Radius,])
+                    : surface.TryGetCone(out Cone cone, tolerance: ExtractionConfig.PrimitiveFitTolerance)
+                        && cone.Radius > ExtractionConfig.PrimitiveFitTolerance
+                        && cone.Height > ExtractionConfig.PrimitiveFitTolerance
+                        ? (true, ExtractionConfig.PrimitiveTypeCone, new Plane(cone.BasePoint, cone.Axis), [cone.Radius, cone.Height, Math.Atan(cone.Radius / cone.Height),])
+                        : surface.TryGetTorus(out Torus torus, tolerance: ExtractionConfig.PrimitiveFitTolerance)
+                            && torus.MajorRadius > ExtractionConfig.PrimitiveFitTolerance
+                            && torus.MinorRadius > ExtractionConfig.PrimitiveFitTolerance
+                            ? (true, ExtractionConfig.PrimitiveTypeTorus, torus.Plane, [torus.MajorRadius, torus.MinorRadius,])
+                            : surface switch {
+                                Extrusion ext when ext.IsValid && ext.PathLineCurve() is LineCurve lc =>
+                                    (true, ExtractionConfig.PrimitiveTypeExtrusion, new Plane(ext.PathStart, lc.Line.Direction), [lc.Line.Length,]),
+                                _ => (false, ExtractionConfig.PrimitiveTypeUnknown, Plane.WorldXY, []),
                             };
+
+    [Pure]
+    private static double ComputeSurfaceResidual(Surface surface, byte type, Plane frame, double[] pars) {
+        (Interval u, Interval v) = (surface.Domain(0), surface.Domain(1));
+        double[] squaredDistances = new double[ExtractionConfig.PrimitiveResidualSampleCount];
+
+        for (int i = 0; i < ExtractionConfig.PrimitiveResidualSampleCount; i++) {
+            double uParam = u.ParameterAt(i / (double)(ExtractionConfig.PrimitiveResidualSampleCount - 1));
+            double vParam = v.ParameterAt(i / (double)(ExtractionConfig.PrimitiveResidualSampleCount - 1));
+            Point3d surfacePoint = surface.PointAt(u: uParam, v: vParam);
+            Point3d primitivePoint = type switch {
+                0 when pars.Length >= 6 => frame.ClosestPoint(surfacePoint),
+                1 when pars.Length >= 2 => ProjectPointToCylinder(point: surfacePoint, cylinderPlane: frame, radius: pars[0]),
+                2 when pars.Length >= 1 => ProjectPointToSphere(point: surfacePoint, center: frame.Origin, radius: pars[0]),
+                _ => surfacePoint,
+            };
+            squaredDistances[i] = surfacePoint.DistanceToSquared(primitivePoint);
+        }
+
+        return Math.Sqrt(squaredDistances.Sum() / ExtractionConfig.PrimitiveResidualSampleCount);
+    }
+
+    [Pure]
+    private static Point3d ProjectPointToCylinder(Point3d point, Plane cylinderPlane, double radius) {
+        Vector3d toPoint = point - cylinderPlane.Origin;
+        double axisProjection = Vector3d.Multiply(toPoint, cylinderPlane.ZAxis);
+        Point3d axisPoint = cylinderPlane.Origin + (cylinderPlane.ZAxis * axisProjection);
+        Vector3d radialDir = point - axisPoint;
+        return radialDir.Length > 1e-10
+            ? axisPoint + ((radialDir / radialDir.Length) * radius)
+            : axisPoint + (cylinderPlane.XAxis * radius);
+    }
+
+    [Pure]
+    private static Point3d ProjectPointToSphere(Point3d point, Point3d center, double radius) {
+        Vector3d dir = point - center;
+        return dir.Length > 1e-10
+            ? center + ((dir / dir.Length) * radius)
+            : center + new Vector3d(radius, 0, 0);
+    }
 
     [Pure]
     internal static Result<(byte Type, Transform SymmetryTransform, double Confidence)> ExtractPatterns(GeometryBase[] geometries, IGeometryContext context) =>
         geometries.Length < ExtractionConfig.PatternMinInstances
-            ? ResultFactory.Create<(byte Type, Transform SymmetryTransform, double Confidence)>(error: E.Geometry.NoPatternDetected)
-            : geometries.Select(g => g.GetBoundingBox(accurate: false).Center).ToArray() is Point3d[] pts && pts.Length >= 2
-                ? DetectPatternType(pts: pts, context: context)
-                : ResultFactory.Create<(byte Type, Transform SymmetryTransform, double Confidence)>(error: E.Geometry.NoPatternDetected);
+            ? ResultFactory.Create<(byte Type, Transform SymmetryTransform, double Confidence)>(
+                error: E.Geometry.NoPatternDetected.WithContext($"Need at least {ExtractionConfig.PatternMinInstances.ToString(System.Globalization.CultureInfo.InvariantCulture)} instances"))
+            : DetectPatternType(centers: [.. geometries.Select(g => g.GetBoundingBox(accurate: false).Center),], context: context);
 
-    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> DetectPatternType(Point3d[] pts, IGeometryContext context) {
-        Vector3d[] deltas = [.. pts.Zip(pts.Skip(1), (a, b) => b - a),];
+    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> DetectPatternType(Point3d[] centers, IGeometryContext context) {
+        Vector3d[] deltas = new Vector3d[centers.Length - 1];
+        for (int i = 0; i < deltas.Length; i++) {
+            deltas[i] = centers[i + 1] - centers[i];
+        }
 
-        // Linear translation (type 0)
-        return deltas.Length is 0
-            ? ResultFactory.Create<(byte Type, Transform SymmetryTransform, double Confidence)>(error: E.Geometry.NoPatternDetected)
-            : deltas.All(d => (d - deltas[0]).Length < context.AbsoluteTolerance)
-            ? ResultFactory.Create(value: (Type: (byte)0, SymmetryTransform: Transform.Translation(deltas[0]), Confidence: 1.0))
-            : pts.Skip(1).Select(p => Vector3d.VectorAngle(pts[0] - pts[1], p - pts[1])).ToArray() is double[] angles && angles.Length > 0 && Math.Sqrt(ComputeAngularVariance(angles)) < ExtractionConfig.SymmetryAngleTolerance
-                ? ResultFactory.Create(value: (Type: (byte)1, SymmetryTransform: Transform.Rotation(angles[0], Vector3d.ZAxis, pts[0]), Confidence: 0.8))
-                : TryDetectGridPattern(pts: pts, context: context) is Result<(byte, Transform, double)> gridResult && gridResult.IsSuccess
+        bool allDeltasEqual = deltas.All(d => (d - deltas[0]).Length < context.AbsoluteTolerance);
+
+        return allDeltasEqual
+            ? ResultFactory.Create(value: (Type: ExtractionConfig.PatternTypeLinear, SymmetryTransform: Transform.Translation(deltas[0]), Confidence: 1.0))
+            : TryDetectRadialPattern(centers: centers, context: context) is Result<(byte, Transform, double)> radialResult && radialResult.IsSuccess
+                ? radialResult
+                : TryDetectGridPattern(centers: centers, context: context) is Result<(byte, Transform, double)> gridResult && gridResult.IsSuccess
                     ? gridResult
-                    : TryDetectScalingPattern(pts: pts, context: context) is Result<(byte, Transform, double)> scaleResult && scaleResult.IsSuccess
+                    : TryDetectScalingPattern(centers: centers, context: context) is Result<(byte, Transform, double)> scaleResult && scaleResult.IsSuccess
                         ? scaleResult
-                        : ResultFactory.Create<(byte Type, Transform SymmetryTransform, double Confidence)>(error: E.Geometry.NoPatternDetected);
+                        : ResultFactory.Create<(byte, Transform, double)>(
+                            error: E.Geometry.NoPatternDetected.WithContext("No linear, radial, grid, or scaling pattern detected"));
     }
 
-    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> TryDetectGridPattern(Point3d[] pts, IGeometryContext context) {
-        Point3d origin = pts[0];
-        Point3d[] relative = [.. pts.Select(p => new Point3d(p.X - origin.X, p.Y - origin.Y, p.Z - origin.Z)),];
+    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> TryDetectRadialPattern(Point3d[] centers, IGeometryContext context) {
+        Point3d centroid = new(centers.Average(p => p.X), centers.Average(p => p.Y), centers.Average(p => p.Z));
+        double[] distances = new double[centers.Length];
 
-        // Try to find two basis vectors
-        Vector3d[] candidates = [.. relative.Skip(1).Select(p => new Vector3d(p.X, p.Y, p.Z)).Where(v => v.Length > context.AbsoluteTolerance),];
-        return candidates.Length >= 2 && FindGridBasis(candidates: candidates, context: context) is (Vector3d u, Vector3d v, bool success) && success
-            ? relative.Skip(1).All(p => IsGridPoint(point: new Vector3d(p.X, p.Y, p.Z), u: u, v: v, context: context))
-                ? ResultFactory.Create(value: (Type: (byte)2, SymmetryTransform: Transform.Identity, Confidence: 0.9))
-                : ResultFactory.Create<(byte, Transform, double)>(error: E.Geometry.NoPatternDetected)
-            : ResultFactory.Create<(byte, Transform, double)>(error: E.Geometry.NoPatternDetected);
+        for (int i = 0; i < centers.Length; i++) {
+            distances[i] = centroid.DistanceTo(centers[i]);
+        }
+
+        double meanDistance = distances.Average();
+        bool allDistancesEqual = meanDistance > context.AbsoluteTolerance
+            && distances.All(d => Math.Abs(d - meanDistance) / meanDistance < ExtractionConfig.RadialDistanceVariationThreshold);
+
+        return !allDistancesEqual
+            ? ResultFactory.Create<(byte, Transform, double)>(error: E.Geometry.NoPatternDetected)
+            : ComputeRadialPattern(centers: centers, centroid: centroid, meanDistance: meanDistance, context: context);
     }
 
-    private static (Vector3d U, Vector3d V, bool Success) FindGridBasis(Vector3d[] candidates, IGeometryContext context) {
-        Vector3d u = candidates[0] / candidates[0].Length;
-        Vector3d v = candidates.Skip(1).FirstOrDefault(c => c.Length > context.AbsoluteTolerance && Math.Abs(Vector3d.Multiply(u, c / c.Length)) < ExtractionConfig.GridOrthogonalityThreshold);
-        return v.Length > context.AbsoluteTolerance ? (u * candidates[0].Length, v, true) : (Vector3d.Zero, Vector3d.Zero, false);
-    }
+    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> ComputeRadialPattern(
+        Point3d[] centers,
+        Point3d centroid,
+        double meanDistance,
+        IGeometryContext context) {
+        Vector3d[] radii = new Vector3d[centers.Length];
+        for (int i = 0; i < centers.Length; i++) {
+            radii[i] = centers[i] - centroid;
+        }
 
-    private static bool IsGridPoint(Vector3d point, Vector3d u, Vector3d v, IGeometryContext context) {
-        double uLen = u.Length;
-        double vLen = v.Length;
-        return uLen > context.AbsoluteTolerance && vLen > context.AbsoluteTolerance && Vector3d.Multiply(point, u) / (uLen * uLen) is double a && Vector3d.Multiply(point, v) / (vLen * vLen) is double b && Math.Abs(a - Math.Round(a)) < ExtractionConfig.GridPointDeviationThreshold && Math.Abs(b - Math.Round(b)) < ExtractionConfig.GridPointDeviationThreshold;
-    }
+        Vector3d normal = ComputeBestFitPlaneNormal(points: centers, centroid: centroid);
+        double[] angles = new double[centers.Length - 1];
 
-    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> TryDetectScalingPattern(Point3d[] pts, IGeometryContext context) {
-        Point3d origin = pts[0];
-        double[] distances = [.. pts.Skip(1).Select(p => origin.DistanceTo(p)).Where(d => d > context.AbsoluteTolerance),];
-        double[] ratios = [.. distances.Zip(distances.Skip(1), (a, b) => (a, b)).Where(pair => pair.a > context.AbsoluteTolerance).Select(pair => pair.b / pair.a),];
-        return distances.Length >= 2 && ratios.Length > 0 && Math.Sqrt(ComputeAngularVariance(ratios)) < ExtractionConfig.ScalingVarianceThreshold
-            ? ResultFactory.Create(value: (Type: (byte)3, SymmetryTransform: Transform.Scale(anchor: origin, scaleFactor: ratios[0]), Confidence: 0.7))
+        for (int i = 0; i < angles.Length; i++) {
+            angles[i] = Vector3d.VectorAngle(radii[i], radii[i + 1]);
+        }
+
+        double meanAngle = angles.Average();
+        bool uniformAngles = angles.All(a => Math.Abs(a - meanAngle) < ExtractionConfig.RadialAngleVariationThreshold);
+
+        return uniformAngles
+            ? ResultFactory.Create(value: (
+                Type: ExtractionConfig.PatternTypeRadial,
+                SymmetryTransform: Transform.Rotation(angle: meanAngle, rotationAxis: normal, rotationCenter: centroid),
+                Confidence: 0.9))
             : ResultFactory.Create<(byte, Transform, double)>(error: E.Geometry.NoPatternDetected);
     }
 
     [Pure]
-    private static double ComputeAngularVariance(double[] angles) =>
-        angles.Length switch {
+    private static Vector3d ComputeBestFitPlaneNormal(Point3d[] points, Point3d centroid) {
+        double[,] covariance = new double[3, 3];
+
+        for (int i = 0; i < points.Length; i++) {
+            Vector3d diff = points[i] - centroid;
+            covariance[0, 0] += diff.X * diff.X;
+            covariance[0, 1] += diff.X * diff.Y;
+            covariance[0, 2] += diff.X * diff.Z;
+            covariance[1, 1] += diff.Y * diff.Y;
+            covariance[1, 2] += diff.Y * diff.Z;
+            covariance[2, 2] += diff.Z * diff.Z;
+        }
+
+        covariance[1, 0] = covariance[0, 1];
+        covariance[2, 0] = covariance[0, 2];
+        covariance[2, 1] = covariance[1, 2];
+
+        Vector3d normal = Vector3d.CrossProduct(
+            new Vector3d(covariance[0, 0], covariance[1, 0], covariance[2, 0]),
+            new Vector3d(covariance[0, 1], covariance[1, 1], covariance[2, 1]));
+
+        return normal.Length > 1e-10 ? normal / normal.Length : Vector3d.ZAxis;
+    }
+
+    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> TryDetectGridPattern(Point3d[] centers, IGeometryContext context) {
+        Point3d origin = centers[0];
+        Vector3d[] relativeVectors = new Vector3d[centers.Length - 1];
+
+        for (int i = 0; i < relativeVectors.Length; i++) {
+            relativeVectors[i] = centers[i + 1] - origin;
+        }
+
+        Vector3d[] candidates = [.. relativeVectors.Where(v => v.Length > context.AbsoluteTolerance),];
+
+        return candidates.Length >= 2
+            && FindGridBasis(candidates: candidates, context: context) is (Vector3d u, Vector3d v, bool success) && success
+            && relativeVectors.All(vec => IsGridPoint(vector: vec, u: u, v: v, context: context))
+            ? ResultFactory.Create(value: (
+                Type: ExtractionConfig.PatternTypeGrid,
+                SymmetryTransform: Transform.PlaneToPlane(source: Plane.WorldXY, target: new Plane(origin, u, v)),
+                Confidence: 0.9))
+            : ResultFactory.Create<(byte, Transform, double)>(error: E.Geometry.NoPatternDetected);
+    }
+
+    private static (Vector3d U, Vector3d V, bool Success) FindGridBasis(Vector3d[] candidates, IGeometryContext context) {
+        Vector3d uDir = candidates[0] / candidates[0].Length;
+        Vector3d vCandidate = candidates.Skip(1).FirstOrDefault(c =>
+            c.Length > context.AbsoluteTolerance
+            && Math.Abs(Vector3d.Multiply(uDir, c / c.Length)) < ExtractionConfig.GridOrthogonalityThreshold);
+
+        return vCandidate.Length > context.AbsoluteTolerance
+            ? (U: candidates[0], V: vCandidate, Success: true)
+            : (U: Vector3d.Zero, V: Vector3d.Zero, Success: false);
+    }
+
+    private static bool IsGridPoint(Vector3d vector, Vector3d u, Vector3d v, IGeometryContext context) {
+        double uLen = u.Length;
+        double vLen = v.Length;
+
+        return uLen > context.AbsoluteTolerance
+            && vLen > context.AbsoluteTolerance
+            && Vector3d.Multiply(vector, u) / (uLen * uLen) is double a
+            && Vector3d.Multiply(vector, v) / (vLen * vLen) is double b
+            && Math.Abs(a - Math.Round(a)) < ExtractionConfig.GridPointDeviationThreshold
+            && Math.Abs(b - Math.Round(b)) < ExtractionConfig.GridPointDeviationThreshold;
+    }
+
+    private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> TryDetectScalingPattern(Point3d[] centers, IGeometryContext context) {
+        Point3d centroid = new(centers.Average(p => p.X), centers.Average(p => p.Y), centers.Average(p => p.Z));
+        double[] distances = new double[centers.Length];
+
+        for (int i = 0; i < centers.Length; i++) {
+            distances[i] = centroid.DistanceTo(centers[i]);
+        }
+
+        double[] ratios = new double[distances.Length - 1];
+        for (int i = 0; i < ratios.Length; i++) {
+            ratios[i] = distances[i] > context.AbsoluteTolerance ? distances[i + 1] / distances[i] : 0.0;
+        }
+
+        double[] validRatios = [.. ratios.Where(r => r > context.AbsoluteTolerance),];
+
+        return validRatios.Length >= 2
+            && ComputeVariance(values: validRatios) is double variance
+            && variance < ExtractionConfig.ScalingVarianceThreshold
+            ? ResultFactory.Create(value: (
+                Type: ExtractionConfig.PatternTypeScaling,
+                SymmetryTransform: Transform.Scale(anchor: centroid, scaleFactor: validRatios.Average()),
+                Confidence: 0.7))
+            : ResultFactory.Create<(byte, Transform, double)>(error: E.Geometry.NoPatternDetected);
+    }
+
+    [Pure]
+    private static double ComputeVariance(double[] values) =>
+        values.Length switch {
             0 => double.MaxValue,
             1 => 0.0,
-            int n => angles.Average() is double mean ? angles.Sum(a => (a - mean) * (a - mean)) / n : 0.0,
+            int n => values.Average() is double mean
+                ? values.Sum(v => (v - mean) * (v - mean)) / n
+                : 0.0,
         };
 }

--- a/libs/rhino/extraction/ExtractionCompute.cs
+++ b/libs/rhino/extraction/ExtractionCompute.cs
@@ -340,27 +340,20 @@ internal static class ExtractionCompute {
 
     [Pure]
     private static Vector3d ComputeBestFitPlaneNormal(Point3d[] points, Point3d centroid) {
-        double[,] covariance = new double[3, 3];
+        Vector3d v1 = (points[0] - centroid);
+        v1 = v1.Length > 1e-10 ? v1 / v1.Length : Vector3d.XAxis;
 
-        for (int i = 0; i < points.Length; i++) {
-            Vector3d diff = points[i] - centroid;
-            covariance[0, 0] += diff.X * diff.X;
-            covariance[0, 1] += diff.X * diff.Y;
-            covariance[0, 2] += diff.X * diff.Z;
-            covariance[1, 1] += diff.Y * diff.Y;
-            covariance[1, 2] += diff.Y * diff.Z;
-            covariance[2, 2] += diff.Z * diff.Z;
+        for (int i = 1; i < points.Length; i++) {
+            Vector3d v2 = (points[i] - centroid);
+            v2 = v2.Length > 1e-10 ? v2 / v2.Length : Vector3d.YAxis;
+            Vector3d normal = Vector3d.CrossProduct(v1, v2);
+
+            if (normal.Length > 1e-10) {
+                return normal / normal.Length;
+            }
         }
 
-        covariance[1, 0] = covariance[0, 1];
-        covariance[2, 0] = covariance[0, 2];
-        covariance[2, 1] = covariance[1, 2];
-
-        Vector3d normal = Vector3d.CrossProduct(
-            new Vector3d(covariance[0, 0], covariance[1, 0], covariance[2, 0]),
-            new Vector3d(covariance[0, 1], covariance[1, 1], covariance[2, 1]));
-
-        return normal.Length > 1e-10 ? normal / normal.Length : Vector3d.ZAxis;
+        return Vector3d.ZAxis;
     }
 
     private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> TryDetectGridPattern(Point3d[] centers, IGeometryContext context) {

--- a/libs/rhino/extraction/ExtractionConfig.cs
+++ b/libs/rhino/extraction/ExtractionConfig.cs
@@ -6,17 +6,53 @@ namespace Arsenal.Rhino.Extraction;
 
 /// <summary>Validation modes for semantic extraction with type inheritance fallback.</summary>
 internal static class ExtractionConfig {
-    internal const double FilletG2Threshold = 0.95;
-    internal const double FilletG2AbsoluteTolerance = 0.001;
-    internal const double ChamferAngleTolerance = 0.1;
-    internal const int MinHoleSides = 16;
+    /// <summary>Feature type identifiers: 0=Fillet, 1=Chamfer, 2=Hole, 3=GenericEdge, 4=VariableRadiusFillet.</summary>
+    internal const byte FeatureTypeFillet = 0;
+    internal const byte FeatureTypeChamfer = 1;
+    internal const byte FeatureTypeHole = 2;
+    internal const byte FeatureTypeGenericEdge = 3;
+    internal const byte FeatureTypeVariableRadiusFillet = 4;
+
+    /// <summary>Primitive type identifiers: 0=Plane, 1=Cylinder, 2=Sphere, 3=Unknown, 4=Cone, 5=Torus, 6=Extrusion.</summary>
+    internal const byte PrimitiveTypePlane = 0;
+    internal const byte PrimitiveTypeCylinder = 1;
+    internal const byte PrimitiveTypeSphere = 2;
+    internal const byte PrimitiveTypeUnknown = 3;
+    internal const byte PrimitiveTypeCone = 4;
+    internal const byte PrimitiveTypeTorus = 5;
+    internal const byte PrimitiveTypeExtrusion = 6;
+
+    /// <summary>Pattern type identifiers: 0=Linear, 1=Radial, 2=Grid, 3=Scaling.</summary>
+    internal const byte PatternTypeLinear = 0;
+    internal const byte PatternTypeRadial = 1;
+    internal const byte PatternTypeGrid = 2;
+    internal const byte PatternTypeScaling = 3;
+
+    /// <summary>Fillet curvature coefficient of variation threshold 0.15 for constant curvature detection.</summary>
+    internal const double FilletCurvatureVariationThreshold = 0.15;
+    /// <summary>Fillet curvature sample count 5 for edge analysis.</summary>
+    internal const int FilletCurvatureSampleCount = 5;
+    /// <summary>G2 continuity angle tolerance 0.01 radians for smooth edge detection.</summary>
+    internal const double G2ContinuityTolerance = 0.01;
+    /// <summary>Chamfer dihedral angle range: sharp edge below 0.349 radians (20°).</summary>
+    internal const double SharpEdgeAngleThreshold = 0.349;
+    /// <summary>Chamfer dihedral angle range: smooth edge above 2.967 radians (170°).</summary>
+    internal const double SmoothEdgeAngleThreshold = 2.967;
+    /// <summary>Minimum hole polyline sides 16 for circular approximation.</summary>
+    internal const int MinHolePolySides = 16;
+    /// <summary>Primitive fit tolerance 0.001 for TryGet* methods.</summary>
     internal const double PrimitiveFitTolerance = 0.001;
-    internal const int PrimitiveSampleCount = 100;
-    internal const double SymmetryAngleTolerance = 0.01;
+    /// <summary>Primitive residual sample count 20 for RMS distance calculation.</summary>
+    internal const int PrimitiveResidualSampleCount = 20;
+    /// <summary>Pattern minimum instances 3 for detection.</summary>
     internal const int PatternMinInstances = 3;
-    /// <summary>Orthogonality threshold 0.1 for dot product in grid basis detection.</summary>
+    /// <summary>Radial pattern distance variation tolerance 0.05 relative to mean radius.</summary>
+    internal const double RadialDistanceVariationThreshold = 0.05;
+    /// <summary>Radial pattern angle variation tolerance 0.05 radians for uniform spacing.</summary>
+    internal const double RadialAngleVariationThreshold = 0.05;
+    /// <summary>Grid orthogonality threshold 0.1 for dot product in basis detection.</summary>
     internal const double GridOrthogonalityThreshold = 0.1;
-    /// <summary>Grid point validation tolerance 0.1 for integer coordinate deviation.</summary>
+    /// <summary>Grid point deviation tolerance 0.1 for integer coordinate validation.</summary>
     internal const double GridPointDeviationThreshold = 0.1;
     /// <summary>Scaling pattern variance threshold 0.1 for ratio consistency.</summary>
     internal const double ScalingVarianceThreshold = 0.1;


### PR DESCRIPTION
Comprehensive Review of ExtractionCompute.cs
I've completed a deep line-by-line analysis of ExtractionCompute.cs against the Rhino SDK documentation and your coding standards. Here are my findings organized by severity:

🔴 CRITICAL ISSUES (Will cause runtime errors or incorrect behavior)
Issue #1: Cylinder.Center Property Does Not Exist (Line 75)
Location: ClassifySurface - Cylinder detection

// ❌ CURRENT (WILL NOT COMPILE)
(true, 1, new Plane(cyl.Center, cyl.Axis), [cyl.Radius, cyl.TotalHeight,])

// ✅ CORRECT
(true, 1, new Plane(cyl.Circle.Center, cyl.Axis), [cyl.Radius, cyl.TotalHeight,])
Reason: RhinoCommon Cylinder has no Center property. Cylinders are defined by a base circle and height. Must use cyl.Circle.Center.

Issue #2: Radial Pattern Detection is Fundamentally Broken (Lines 103-104)
Location: DetectPatternType - Circular/radial pattern

// ❌ CURRENT (INCORRECT LOGIC)
pts.Skip(1).Select(p => Vector3d.VectorAngle(pts[0] - pts[1], p - pts[1])).ToArray() is double[] angles
    ? ResultFactory.Create(value: (Type: (byte)1, SymmetryTransform: Transform.Rotation(angles[0], Vector3d.ZAxis, pts[0]), Confidence: 0.8))
Problems:

Assumes pts[1] is rotation center (it's just the second point!)
Uses arbitrary Vector3d.ZAxis instead of computing actual rotation plane
angles[0] (angle between pts[0] and pts[2]) is meaningless as a rotation transform parameter
Correct Approach:

Point3d center = new(pts.Average(p => p.X), pts.Average(p => p.Y), pts.Average(p => p.Z));
Vector3d[] radii = [.. pts.Select(p => p - center),];
double[] distances = [.. radii.Select(r => r.Length),];
// Check if all points are equidistant from center (±tolerance)
bool isCircular = distances.All(d => Math.Abs(d - distances[0]) < context.AbsoluteTolerance);
// Compute rotation plane from point cloud
Vector3d normal = ComputeBestFitPlaneNormal(pts);
// Compute angular spacing
double[] angles = [...]; // angles between consecutive points
bool uniformAngles = /* check if angles are constant */;
Issue #3: Residuals Array Length Mismatch (Line 65)
Location: DecomposeToPrimitives - Brep decomposition

// ❌ CURRENT
Primitives: b.Faces.Select(...).Where(t => t.Success).Select(t => t.Primitive).ToArray(),
Residuals: b.Faces.Select(_ => 0.0).ToArray()  // Wrong length!
Problem: Primitives array filters Where(t => t.Success), so has length ≤ Faces.Count. Residuals has length = Faces.Count. Arrays must have matching lengths.

Correct:

(bool Success, (byte Type, Plane Frame, double[] Params) Primitive, double Residual)[] classified = 
    [.. b.Faces.Select(f => f.DuplicateSurface() switch {
        null => (false, default, 0.0),
        Surface surf => ((Func<(bool, (byte, Plane, double[]), double)>)(() => {
            (bool success, byte type, Plane frame, double[] pars) = ClassifySurface(surf);
            surf.Dispose();
            return (success, (type, frame, pars), 0.0); // Compute actual residual here
        }))(),
    }),];

return ResultFactory.Create(value: (
    Primitives: [.. classified.Where(c => c.Success).Select(c => c.Primitive),],
    Residuals: [.. classified.Where(c => c.Success).Select(c => c.Residual),]
));
⚠️ MAJOR ISSUES (Incorrect algorithm logic, missing functionality)
Issue #4: Insufficient Curvature Sampling for Fillet Detection (Lines 23-24)
Current: Only 3 samples (start, middle, end)

(double k0, double k1, double k2) = (e.EdgeCurve.CurvatureAt(tMin).Length, e.EdgeCurve.CurvatureAt(tMid).Length, e.EdgeCurve.CurvatureAt(tMax).Length);
Problem: Fillets with varying curvature will be missed. A fillet could have high curvature at ends but low in middle (or vice versa).

Solution: Sample at more points (5-7 minimum) or use adaptive sampling based on edge length.

####Issue #5: Flawed Constant Curvature Detection (Line 26)

// ❌ CURRENT
bool isConstCurv = !e.EdgeCurve.TryGetPolyline(out Polyline _) && (max - min) < Math.Max(ExtractionConfig.FilletG2Threshold * avg, ExtractionConfig.FilletG2AbsoluteTolerance);
Problems:

!TryGetPolyline() just means "not a polyline" - irrelevant to curvature constancy
FilletG2Threshold = 0.95 is misnamed (not a G2 threshold, it's a variation multiplier)
Logic compares (max - min) against 0.95 * avg, which doesn't make mathematical sense
Example: if avg = 1.0, then tolerance is 0.95. If curvatures are [0.1, 1.0, 1.9], max-min = 1.8 > 0.95, fails. But coefficient of variation is high - this IS varying curvature!
Should use coefficient of variation: stdDev / avg < threshold or (max - min) / avg < threshold
Correct approach:

double[] curvatures = [k0, k1, k2, k3, k4,]; // Sample more points
double mean = curvatures.Average();
double stdDev = Math.Sqrt(curvatures.Sum(k => (k - mean) * (k - mean)) / curvatures.Length);
double coefficientOfVariation = mean > context.AbsoluteTolerance ? stdDev / mean : 0.0;
bool isConstCurv = coefficientOfVariation < ExtractionConfig.FilletCurvatureVariationThreshold; // Use 0.1-0.2
Issue #6: Chamfer Detection Only Checks 45° (Line 30)
// ❌ CURRENT
Math.Abs(dihedral - (Math.PI / 4)) < ExtractionConfig.ChamferAngleTolerance ? 1 : 3
Problem: Real chamfers are 30°, 45°, 60°, or other angles. This only detects 45° ± 0.1 rad (≈ 40-50°).

Solution: Chamfer = NOT smooth (dihedral not near 180°) AND NOT sharp (not near 0°) AND has planar faces

bool isSmooth = Math.Abs(dihedral - Math.PI) < context.AngleTolerance;
bool isSharp = dihedral < context.AngleTolerance * 2;
bool isChamfer = !isSmooth && !isSharp && !isG2;
Issue #7: Primitive Hole Detection is Too Restrictive (Lines 32-33)
Current: Only detects polyline holes with ≥16 sides

l.LoopType == BrepLoopType.Inner && l.To3dCurve() is Curve c && c.IsClosed && c.TryGetPolyline(out Polyline pl) && pl.Count >= ExtractionConfig.MinHoleSides
Problem: Misses circular/elliptical holes (most common!). A circle won't necessarily convert to polyline.

Solution: Check for circles/ellipses first:

l.LoopType == BrepLoopType.Inner && l.To3dCurve() is Curve c && c.IsClosed && 
    (c.TryGetCircle(out Circle circ, context.AbsoluteTolerance) || 
     c.TryGetEllipse(out Ellipse ell, context.AbsoluteTolerance) ||
     (c.TryGetPolyline(out Polyline pl) && pl.Count >= ExtractionConfig.MinHoleSides))
Issue #8: Grid Pattern Returns Identity Transform (Line 120)
// ❌ CURRENT
ResultFactory.Create(value: (Type: (byte)2, SymmetryTransform: Transform.Identity, Confidence: 0.9))
Problem: Transform.Identity contains zero information about the grid. The basis vectors u and v are computed but discarded!

Solution: Encode grid information in transform or return it separately:

// Option 1: Return composite translation transform representing grid step
Transform gridTransform = Transform.Translation(u); // Primary direction

// Option 2: Return custom data structure (better)
ResultFactory.Create(value: (Type: (byte)2, SymmetryTransform: Transform.Identity, GridU: u, GridV: v, Confidence: 0.9))
Issue #9: FindGridBasis Returns Wrong Vector (Lines 126-128)
// ❌ CURRENT
Vector3d u = candidates[0] / candidates[0].Length;  // Normalize
...
return v.Length > context.AbsoluteTolerance ? (u * candidates[0].Length, v, true) : ...;  // Denormalize
Problem: This just returns candidates[0], which is an arbitrary vector to one of the grid points, NOT the grid spacing.

Solution: Find the GCD (greatest common divisor) of projections:

Vector3d uDir = candidates[0] / candidates[0].Length;
double[] projections = [.. candidates.Select(c => Math.Abs(Vector3d.Multiply(c, uDir))).Where(p => p > context.AbsoluteTolerance),];
double gridSpacing = ComputeGCD(projections, context.AbsoluteTolerance);
Vector3d u = uDir * gridSpacing;
📝 MINOR ISSUES (Suboptimal but functional)
Issue #10: No Null Check on CurvatureAt (Line 24)
double k0 = e.EdgeCurve.CurvatureAt(tMin).Length;
Add safety: Check if curvature vector is valid before taking length.

Issue #11: Plane Parameters Incomplete (Line 73)
[pl.OriginX, pl.OriginY, pl.OriginZ,]
Should include normal: [pl.OriginX, pl.OriginY, pl.OriginZ, pl.Normal.X, pl.Normal.Y, pl.Normal.Z,]

Issue #12: Arbitrary Sphere Plane Normal (Line 77)
new Plane(sph.Center, Vector3d.ZAxis)
Should derive meaningful orientation or use sphere's equatorial plane.

Issue #13: Redundant Cone Height Check (Line 78)
cone.Height > ExtractionConfig.PrimitiveFitTolerance && Math.Abs(cone.Height) > 1e-8
Second check is redundant since PrimitiveFitTolerance = 0.001 > 1e-8. Remove magic number.

Issue #14: Scaling Pattern Uses Wrong Origin and Ratio (Lines 138-142)
Uses first point as origin (incorrect) and first ratio as scale factor (incorrect for geometric sequences).

Issue #15: Misleading Function Names
ComputeAngularVariance → used for ratios too, should be ComputeVariance
FilletG2Threshold → should be FilletCurvatureVariationThreshold
🎯 OPTIMIZATION OPPORTUNITIES
Use for loops instead of LINQ for curvature sampling in hot paths (per standards)
Cache mass properties in ExtractFeatures instead of recomputing for holes
Pre-filter invalid edges before processing in ExtractFeatures
Use array pooling for large point arrays in pattern detection
📋 STYLE VIOLATIONS (Per CLAUDE.md)
Issue #16: Redundant Length Check (Line 99)
deltas.Length is 0 ? ... : deltas.All(...) ? ...
If geometries.Length >= PatternMinInstances (3), then deltas.Length >= 2. First check is impossible. Remove.

Issue #17: Double To3dCurve() Call (Lines 32-33)
l.To3dCurve() is Curve c && c.IsClosed && ... 
Select(l => ((Func<(byte, double)>)(() => { using Curve? c = l.To3dCurve(); ...
Calls To3dCurve() twice - wasteful. Restructure to call once.

Compute Actual Residuals instead of hardcoded zeros - sample points on surface and measure RMS distance to primitive.

Remove Manufacturing References - per your requirements, nothing manufacturing-related needed. Remove "ManufacturingScore" comment on line 39 or clarify it's geometric quality.