### PR TITLE
Add SelfIntersection validation flag to core validation modes

### DIFF
--- a/libs/core/validation/V.cs
+++ b/libs/core/validation/V.cs
@@ -26,16 +26,17 @@ public readonly struct V(ushort flags) : IEquatable<V> {
     public static readonly V NurbsGeometry = new(1024);
     public static readonly V ExtrusionGeometry = new(2048);
     public static readonly V UVDomain = new(4096);
-    public static readonly V BrepGranular = new(8192);
+    public static readonly V SelfIntersection = new(8192);
+    public static readonly V BrepGranular = new(16384);
     public static readonly V All = new((ushort)(
         Standard._flags | AreaCentroid._flags | BoundingBox._flags | MassProperties._flags |
         Topology._flags | Degeneracy._flags | Tolerance._flags |
         MeshSpecific._flags | SurfaceContinuity._flags | PolycurveStructure._flags |
         NurbsGeometry._flags | ExtrusionGeometry._flags | UVDomain._flags |
-        BrepGranular._flags
+        SelfIntersection._flags | BrepGranular._flags
     ));
 
-    public static readonly FrozenSet<V> AllFlags = ((V[])[Standard, AreaCentroid, BoundingBox, MassProperties, Topology, Degeneracy, Tolerance, MeshSpecific, SurfaceContinuity, PolycurveStructure, NurbsGeometry, ExtrusionGeometry, UVDomain, BrepGranular,]).ToFrozenSet();
+    public static readonly FrozenSet<V> AllFlags = ((V[])[Standard, AreaCentroid, BoundingBox, MassProperties, Topology, Degeneracy, Tolerance, MeshSpecific, SurfaceContinuity, PolycurveStructure, NurbsGeometry, ExtrusionGeometry, UVDomain, SelfIntersection, BrepGranular,]).ToFrozenSet();
 
     [Pure] private string DebuggerDisplay => this.ToString();
 
@@ -94,7 +95,8 @@ public readonly struct V(ushort flags) : IEquatable<V> {
             1024 => nameof(NurbsGeometry),
             2048 => nameof(ExtrusionGeometry),
             4096 => nameof(UVDomain),
-            8192 => nameof(BrepGranular),
+            8192 => nameof(SelfIntersection),
+            16384 => nameof(BrepGranular),
             _ => $"Combined({this._flags})",
         };
 }

--- a/libs/core/validation/ValidationRules.cs
+++ b/libs/core/validation/ValidationRules.cs
@@ -52,6 +52,7 @@ public static class ValidationRules {
             [V.NurbsGeometry] = (["IsValid", "IsPeriodic", "IsRational", "Degree",], [], E.Validation.NurbsControlPointCount),
             [V.ExtrusionGeometry] = (["IsValid", "IsSolid", "IsClosed", "IsCappedAtTop", "IsCappedAtBottom", "CapCount",], [], E.Validation.ExtrusionProfileInvalid),
             [V.UVDomain] = (["IsValid", "HasNurbsForm",], [], E.Validation.UVDomainSingularity),
+            [V.SelfIntersection] = ([], ["HasSelfIntersections",], E.Validation.SelfIntersecting),
             [V.BrepGranular] = ([], ["IsValidTopology", "IsValidGeometry", "IsValidTolerancesAndFlags",], E.Validation.BrepTopologyInvalid),  // Uses BrepTopologyInvalid for all 3 methods
         }.ToFrozenDictionary();
 


### PR DESCRIPTION
## Summary
- add the SelfIntersection validation mode and rebalance BrepGranular flag values
- wire the new mode into the validation rules to use Rhino's HasSelfIntersections check

## Testing
- dotnet build *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b9084ee48321b223d6c3e329d783)