### PR TITLE
Streamline spatial validation tables

### DIFF
--- a/libs/rhino/spatial/Spatial.cs
+++ b/libs/rhino/spatial/Spatial.cs
@@ -23,7 +23,7 @@ public static class Spatial {
         IGeometryContext context,
         int? bufferSize = null,
         bool enableDiagnostics = false) where TInput : notnull where TQuery : notnull =>
-        SpatialCore.OperationRegistry.TryGetValue((typeof(TInput), typeof(TQuery)), out (Func<object, RTree>? _, V mode, int bufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> execute) config) switch {
+        SpatialCore.OperationRegistry.TryGetValue((typeof(TInput), typeof(TQuery)), out (Func<object, IGeometryContext, Result<RTree>>?, Func<object, IGeometryContext, Result<object>>, V mode, int bufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> execute) config) switch {
             true => UnifiedOperation.Apply(
                 input: input,
                 operation: (Func<TInput, Result<IReadOnlyList<int>>>)(item => config.execute(item, query, context, bufferSize ?? config.bufferSize)),

--- a/libs/rhino/spatial/SpatialCompute.cs
+++ b/libs/rhino/spatial/SpatialCompute.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
@@ -11,59 +13,75 @@ namespace Arsenal.Rhino.Spatial;
 /// <summary>Dense spatial algorithm implementations.</summary>
 internal static class SpatialCompute {
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Point3d Centroid(IEnumerable<int> indices, Point3d[] pts) =>
-        indices.ToArray() is { Length: > 0 } arr
-            ? ((Func<Point3d>)(() => {
-                double sumX = 0.0;
-                double sumY = 0.0;
-                double sumZ = 0.0;
-                for (int i = 0; i < arr.Length; i++) {
-                    sumX += pts[arr[i]].X;
-                    sumY += pts[arr[i]].Y;
-                    sumZ += pts[arr[i]].Z;
-                }
-                return new Point3d(sumX / arr.Length, sumY / arr.Length, sumZ / arr.Length);
-            }))()
-            : Point3d.Origin;
+    private static Result<Point3d> Centroid(int[] indices, Point3d[] points) {
+        if (indices.Length == 0) {
+            return ResultFactory.Create<Point3d>(error: E.Spatial.ClusteringFailed.WithContext("Cluster with zero members"));
+        }
+
+        double sumX = 0.0;
+        double sumY = 0.0;
+        double sumZ = 0.0;
+        for (int i = 0; i < indices.Length; i++) {
+            sumX += points[indices[i]].X;
+            sumY += points[indices[i]].Y;
+            sumZ += points[indices[i]].Z;
+        }
+
+        return ResultFactory.Create(value: new Point3d(sumX / indices.Length, sumY / indices.Length, sumZ / indices.Length));
+    }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Point3d ExtractCentroid(GeometryBase g) {
-        Type gType = g.GetType();
-        return SpatialConfig.TypeExtractors.TryGetValue(("Centroid", gType), out Func<object, object>? exactExtractor)
-            ? (Point3d)exactExtractor(g)
-            : SpatialConfig.TypeExtractors.FirstOrDefault(kv => string.Equals(kv.Key.Operation, "Centroid", StringComparison.Ordinal) && kv.Key.GeometryType.IsInstanceOfType(g)).Value is Func<object, object> fallbackExtractor
-                ? (Point3d)fallbackExtractor(g)
-                : g.GetBoundingBox(accurate: false).Center;
+    private static Result<Point3d> ExtractCentroid(GeometryBase geometry) {
+        Type? current = geometry.GetType();
+        while (current is not null) {
+            switch (SpatialConfig.CentroidExtractors.TryGetValue(current, out Func<GeometryBase, Result<Point3d>> extractor)) {
+                case true:
+                    return extractor(geometry);
+            }
+            current = current.BaseType;
+        }
+
+        return ResultFactory.Create<Point3d>(error: E.Spatial.ClusteringFailed.WithContext($"Unsupported centroid type: {geometry.GetType().Name}"));
     }
 
     internal static Result<(Point3d, double[])[]> Cluster<T>(T[] geometry, byte algorithm, int k, double epsilon, IGeometryContext context) where T : GeometryBase =>
-        geometry.Length is 0
-            ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Geometry.InvalidCount.WithContext("Cluster requires at least one geometry"))
-            : algorithm is > 2
-                ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed.WithContext($"Unknown algorithm: {algorithm}"))
-                : (algorithm is 0 or 2 && k <= 0)
-                    ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidClusterK)
-                    : (algorithm is 1 && epsilon <= 0)
-                        ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidEpsilon)
-                        : ResultFactory.Create(value: geometry)
-                            .Ensure(g => g.All(item => item?.IsValid == true), error: E.Validation.GeometryInvalid)
-                            .Bind(validGeometry => ClusterInternal(geometry: validGeometry, algorithm: algorithm, k: k, epsilon: epsilon, context: context));
+        ResultFactory.Create(value: (Geometry: geometry, Algorithm: algorithm, K: k, Epsilon: epsilon))
+            .Ensure(data => data.Geometry.Length > 0, error: E.Geometry.InvalidCount.WithContext("Cluster requires at least one geometry"))
+            .Ensure(data => data.Algorithm <= 2, error: E.Spatial.ClusteringFailed.WithContext($"Unknown algorithm: {data.Algorithm}"))
+            .Ensure(data => data.Algorithm is 0 or 2 ? data.K > 0 : true, error: E.Spatial.InvalidClusterK)
+            .Ensure(data => data.Algorithm is 1 ? data.Epsilon > context.AbsoluteTolerance : true, error: E.Spatial.InvalidEpsilon)
+            .Bind(data => ResultFactory.Create(value: data.Geometry)
+                .Traverse(item => ResultFactory.Create(value: (GeometryBase)item).Validate(args: [context, V.Standard | V.Topology,]))
+                .Map(valid => (data, Items: valid.ToArray())))
+            .Bind(payload => ClusterInternal(geometry: payload.Items, algorithm: payload.data.Algorithm, k: payload.data.K, epsilon: payload.data.Epsilon, context: context));
 
-    private static Result<(Point3d, double[])[]> ClusterInternal<T>(T[] geometry, byte algorithm, int k, double epsilon, IGeometryContext context) where T : GeometryBase {
-        Point3d[] pts = [.. geometry.Select(ExtractCentroid),];
-        return (algorithm is 0 or 2) && k > pts.Length
-            ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.KExceedsPointCount)
-            : SpatialConfig.TypeExtractors.TryGetValue(("ClusterAssign", typeof(void)), out Func<object, object>? assignFunc) && assignFunc((algorithm, pts, k, epsilon, context)) is int[] assigns && assigns.Length > 0
-                ? (algorithm is 1 ? assigns.Where(a => a >= 0).DefaultIfEmpty(-1).Max() + 1 : k) is int clusterCount && clusterCount > 0
-                    ? ResultFactory.Create<(Point3d, double[])[]>(value: [.. Enumerable.Range(0, clusterCount).Select(c => {
-                        int[] members = [.. Enumerable.Range(0, pts.Length).Where(i => assigns[i] == c),];
-                        Point3d centroid = members.Length > 0 ? Centroid(members, pts) : Point3d.Origin;
-                        double[] distances = members.Length > 0 ? [.. members.Select(i => pts[i].DistanceTo(centroid)),] : [];
-                        return (centroid, distances);
-                    }),
-                    ])
-                    : ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed)
-                : ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed);
+    private static Result<(Point3d, double[])[]> ClusterInternal(GeometryBase[] geometry, byte algorithm, int k, double epsilon, IGeometryContext context) =>
+        ResultFactory.Create(value: geometry)
+            .Traverse(ExtractCentroid)
+            .Map(validCentroids => validCentroids.ToArray())
+            .Bind(points =>
+                (algorithm is 0 or 2) && k > points.Length
+                    ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.KExceedsPointCount)
+                    : SpatialConfig.ClusterAssigners.TryGetValue(algorithm, out Func<(Point3d[] Points, int K, double Epsilon, IGeometryContext Context), Result<int[]>> assigner)
+                        ? assigner((points, k, epsilon, context)).Bind(assignments => assignments.Length > 0
+                            ? BuildClusters(points: points, assignments: assignments, algorithm: algorithm, requestedK: k)
+                            : ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed.WithContext("Empty assignments")))
+                        : ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed));
+
+    private static Result<(Point3d, double[])[]> BuildClusters(Point3d[] points, int[] assignments, byte algorithm, int requestedK) {
+        int clusterCount = algorithm == 1 ? assignments.Where(index => index >= 0).DefaultIfEmpty(-1).Max() + 1 : requestedK;
+        if (clusterCount <= 0) {
+            return ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed.WithContext("Non-positive cluster count"));
+        }
+
+        return ResultFactory.Create(value: Enumerable.Range(0, clusterCount))
+            .Traverse(cluster => {
+                int[] members = [.. Enumerable.Range(0, points.Length).Where(index => assignments[index] == cluster),];
+                return members.Length == 0
+                    ? ResultFactory.Create<(Point3d, double[])>(error: E.Spatial.ClusteringFailed.WithContext("Empty cluster"))
+                    : Centroid(members, points).Map(center => (center, [.. members.Select(index => points[index].DistanceTo(center)),]));
+            })
+            .Map(clusters => clusters.ToArray());
     }
 
     internal static int[] KMeansAssign(Point3d[] pts, int k, double tol, int maxIter) {
@@ -89,9 +107,7 @@ internal static class SpatialCompute {
                 sum += distSq[j];
             }
 
-            if (sum <= tol || sum <= 0.0) {
-                centroids[i] = pts[rng.Next(pts.Length)];
-            } else {
+            if (sum > tol && sum > 0.0) {
                 double target = rng.NextDouble() * sum;
                 double cumulative = 0.0;
                 int selectedIdx = pts.Length - 1;
@@ -103,7 +119,10 @@ internal static class SpatialCompute {
                     }
                 }
                 centroids[i] = pts[selectedIdx];
+                continue;
             }
+
+            centroids[i] = pts[rng.Next(pts.Length)];
         }
 
         // Lloyd's algorithm with hot-path optimization
@@ -222,15 +241,14 @@ internal static class SpatialCompute {
                 });
 
     internal static Result<(int, double, double)[]> ProximityField(GeometryBase[] geometry, Vector3d direction, double maxDist, double angleWeight, IGeometryContext context) =>
-        geometry.Length is 0
-            ? ResultFactory.Create<(int, double, double)[]>(error: E.Geometry.InvalidCount.WithContext("ProximityField requires at least one geometry"))
-            : direction.Length <= context.AbsoluteTolerance
-                ? ResultFactory.Create<(int, double, double)[]>(error: E.Spatial.ZeroLengthDirection)
-                : maxDist <= context.AbsoluteTolerance
-                    ? ResultFactory.Create<(int, double, double)[]>(error: E.Spatial.InvalidDistance.WithContext("MaxDistance must exceed tolerance"))
-                    : ResultFactory.Create(value: geometry)
-                        .Ensure(g => g.All(item => item?.IsValid == true), error: E.Validation.GeometryInvalid)
-                        .Bind(validGeometry => ProximityFieldCompute(geometry: validGeometry, direction: direction, maxDist: maxDist, angleWeight: angleWeight, context: context));
+        ResultFactory.Create(value: (Geometry: geometry, Direction: direction, MaxDistance: maxDist, AngleWeight: angleWeight))
+            .Ensure(data => data.Geometry.Length > 0, error: E.Geometry.InvalidCount.WithContext("ProximityField requires at least one geometry"))
+            .Ensure(data => data.Direction.Length > context.AbsoluteTolerance, error: E.Spatial.ZeroLengthDirection)
+            .Ensure(data => data.MaxDistance > context.AbsoluteTolerance, error: E.Spatial.InvalidDistance.WithContext("MaxDistance must exceed tolerance"))
+            .Bind(data => ResultFactory.Create(value: data.Geometry)
+                .Traverse(item => ResultFactory.Create(value: item).Validate(args: [context, V.Standard | V.BoundingBox,]))
+                .Map(valid => (data, Items: valid.ToArray())))
+            .Bind(payload => ProximityFieldCompute(geometry: payload.Items, direction: payload.data.Direction, maxDist: payload.data.MaxDistance, angleWeight: payload.data.AngleWeight, context: context));
 
     private static Result<(int, double, double)[]> ProximityFieldCompute(GeometryBase[] geometry, Vector3d direction, double maxDist, double angleWeight, IGeometryContext context) {
         using RTree tree = new();

--- a/libs/rhino/spatial/SpatialConfig.cs
+++ b/libs/rhino/spatial/SpatialConfig.cs
@@ -1,5 +1,8 @@
 using System.Collections.Frozen;
+using System.Linq;
 using Arsenal.Core.Context;
+using Arsenal.Core.Errors;
+using Arsenal.Core.Results;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Spatial;
@@ -15,27 +18,94 @@ internal static class SpatialConfig {
     internal const double MedialAxisOffsetMultiplier = 10.0;
     internal const int DBSCANRTreeThreshold = 100;
 
-    /// <summary>Type extractors: polymorphic dispatch for centroid, RTree factory, etc.</summary>
-    internal static readonly FrozenDictionary<(string Operation, Type GeometryType), Func<object, object>> TypeExtractors =
-        new Dictionary<(string, Type), Func<object, object>> {
-            // Centroid extraction via mass properties
-            [("Centroid", typeof(Curve))] = static g => g is Curve c ? (AreaMassProperties.Compute(c) is { Centroid: { IsValid: true } ct } ? ct : c.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(Surface))] = static g => g is Surface s ? (AreaMassProperties.Compute(s) is { Centroid: { IsValid: true } ct } ? ct : s.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(Brep))] = static g => g is Brep b ? (VolumeMassProperties.Compute(b) is { Centroid: { IsValid: true } ct } ? ct : b.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(Mesh))] = static g => g is Mesh m ? (VolumeMassProperties.Compute(m) is { Centroid: { IsValid: true } ct } ? ct : m.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(GeometryBase))] = static g => g is GeometryBase gb ? gb.GetBoundingBox(accurate: false).Center : Point3d.Origin,
-            // RTree factory construction
-            [("RTreeFactory", typeof(Point3d[]))] = static s => RTree.CreateFromPointArray((Point3d[])s) ?? new RTree(),
-            [("RTreeFactory", typeof(PointCloud))] = static s => RTree.CreatePointCloudTree((PointCloud)s) ?? new RTree(),
-            [("RTreeFactory", typeof(Mesh))] = static s => RTree.CreateMeshFaceTree((Mesh)s) ?? new RTree(),
-            // Clustering algorithm dispatch
-            [("ClusterAssign", typeof(void))] = static input => input is (byte alg, Point3d[] pts, int k, double eps, IGeometryContext ctx)
-                ? alg switch {
-                    0 => SpatialCompute.KMeansAssign(pts, k, ctx.AbsoluteTolerance, KMeansMaxIterations),
-                    1 => SpatialCompute.DBSCANAssign(pts, eps, DBSCANMinPoints),
-                    2 => SpatialCompute.HierarchicalAssign(pts, k),
-                    _ => [],
-                }
-                : [],
+    /// <summary>Mass-property centroid extractors keyed by geometry type hierarchy.</summary>
+    internal static readonly FrozenDictionary<Type, Func<GeometryBase, Result<Point3d>>> CentroidExtractors =
+        new Dictionary<Type, Func<GeometryBase, Result<Point3d>>> {
+            [typeof(Curve)] = static geometry => geometry switch {
+                Curve { IsValid: true } curve => AreaMassProperties.Compute(curve) switch {
+                    { Centroid: { IsValid: true } centroid } => ResultFactory.Create(value: centroid),
+                    _ => ResultFactory.Create<Point3d>(error: E.Spatial.ClusteringFailed.WithContext("Curve centroid invalid")),
+                },
+                _ => ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Surface)] = static geometry => geometry switch {
+                Surface { IsValid: true } surface => AreaMassProperties.Compute(surface) switch {
+                    { Centroid: { IsValid: true } centroid } => ResultFactory.Create(value: centroid),
+                    _ => ResultFactory.Create<Point3d>(error: E.Spatial.ClusteringFailed.WithContext("Surface centroid invalid")),
+                },
+                _ => ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Brep)] = static geometry => geometry switch {
+                Brep { IsValid: true } brep => VolumeMassProperties.Compute(brep) switch {
+                    { Centroid: { IsValid: true } centroid } => ResultFactory.Create(value: centroid),
+                    _ => ResultFactory.Create<Point3d>(error: E.Spatial.ClusteringFailed.WithContext("Brep centroid invalid")),
+                },
+                _ => ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Mesh)] = static geometry => geometry switch {
+                Mesh { IsValid: true } mesh => VolumeMassProperties.Compute(mesh) switch {
+                    { Centroid: { IsValid: true } centroid } => ResultFactory.Create(value: centroid),
+                    _ => ResultFactory.Create<Point3d>(error: E.Spatial.ClusteringFailed.WithContext("Mesh centroid invalid")),
+                },
+                _ => ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(GeometryBase)] = static geometry => geometry switch {
+                GeometryBase { IsValid: true } baseGeometry => ResultFactory.Create(value: baseGeometry.GetBoundingBox(accurate: true).Center),
+                _ => ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid),
+            },
+        }.ToFrozenDictionary();
+
+    /// <summary>RTree factories with validation-aware result creation.</summary>
+    internal static readonly FrozenDictionary<Type, Func<object, IGeometryContext, Result<RTree>>> RTreeFactories =
+        new Dictionary<Type, Func<object, IGeometryContext, Result<RTree>>> {
+            [typeof(Point3d[])] = static (source, _) => source switch {
+                Point3d[] points when points.Length > 0 => ResultFactory.Create(value: RTree.CreateFromPointArray(points) ?? new RTree()),
+                Point3d[] => ResultFactory.Create(value: new RTree()),
+                _ => ResultFactory.Create<RTree>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(PointCloud)] = static (source, _) => source switch {
+                PointCloud { Count: > 0 } cloud => ResultFactory.Create(value: RTree.CreatePointCloudTree(cloud) ?? new RTree()),
+                PointCloud => ResultFactory.Create(value: new RTree()),
+                _ => ResultFactory.Create<RTree>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Mesh)] = static (source, _) => source switch {
+                Mesh { IsValid: true } mesh => ResultFactory.Create(value: RTree.CreateMeshFaceTree(mesh) ?? new RTree()),
+                _ => ResultFactory.Create<RTree>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Curve[])] = static (source, _) => source switch {
+                Curve[] curves => ResultFactory.Create(value: curves.Length == 0
+                    ? new RTree()
+                    : Enumerable.Range(0, curves.Length).Aggregate(new RTree(), (tree, index) => {
+                        _ = tree.Insert(curves[index].GetBoundingBox(accurate: true), index);
+                        return tree;
+                    })),
+                _ => ResultFactory.Create<RTree>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Surface[])] = static (source, _) => source switch {
+                Surface[] surfaces => ResultFactory.Create(value: surfaces.Length == 0
+                    ? new RTree()
+                    : Enumerable.Range(0, surfaces.Length).Aggregate(new RTree(), (tree, index) => {
+                        _ = tree.Insert(surfaces[index].GetBoundingBox(accurate: true), index);
+                        return tree;
+                    })),
+                _ => ResultFactory.Create<RTree>(error: E.Validation.GeometryInvalid),
+            },
+            [typeof(Brep[])] = static (source, _) => source switch {
+                Brep[] breps => ResultFactory.Create(value: breps.Length == 0
+                    ? new RTree()
+                    : Enumerable.Range(0, breps.Length).Aggregate(new RTree(), (tree, index) => {
+                        _ = tree.Insert(breps[index].GetBoundingBox(accurate: true), index);
+                        return tree;
+                    })),
+                _ => ResultFactory.Create<RTree>(error: E.Validation.GeometryInvalid),
+            },
+        }.ToFrozenDictionary();
+
+    /// <summary>Cluster assignment dispatch keyed by algorithm identifier.</summary>
+    internal static readonly FrozenDictionary<byte, Func<(Point3d[] Points, int K, double Epsilon, IGeometryContext Context), Result<int[]>>> ClusterAssigners =
+        new Dictionary<byte, Func<(Point3d[] Points, int K, double Epsilon, IGeometryContext Context), Result<int[]>>> {
+            [0] = static parameters => ResultFactory.Create(value: SpatialCompute.KMeansAssign(parameters.Points, parameters.K, parameters.Context.AbsoluteTolerance, KMeansMaxIterations)),
+            [1] = static parameters => ResultFactory.Create(value: SpatialCompute.DBSCANAssign(parameters.Points, parameters.Epsilon, DBSCANMinPoints)),
+            [2] = static parameters => ResultFactory.Create(value: SpatialCompute.HierarchicalAssign(parameters.Points, parameters.K)),
         }.ToFrozenDictionary();
 }

--- a/libs/rhino/spatial/SpatialCore.cs
+++ b/libs/rhino/spatial/SpatialCore.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Buffers;
 using System.Collections.Frozen;
-using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Linq;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
@@ -12,116 +13,189 @@ namespace Arsenal.Rhino.Spatial;
 
 /// <summary>RTree construction and queries with pooled buffers.</summary>
 internal static class SpatialCore {
-    private static readonly Func<object, RTree> _pointArrayFactory = s => (RTree)SpatialConfig.TypeExtractors[("RTreeFactory", typeof(Point3d[]))](s);
-    private static readonly Func<object, RTree> _pointCloudFactory = s => (RTree)SpatialConfig.TypeExtractors[("RTreeFactory", typeof(PointCloud))](s);
-    private static readonly Func<object, RTree> _meshFactory = s => (RTree)SpatialConfig.TypeExtractors[("RTreeFactory", typeof(Mesh))](s);
-    private static readonly Func<object, RTree> _curveArrayFactory = s => BuildGeometryArrayTree((Curve[])s);
-    private static readonly Func<object, RTree> _surfaceArrayFactory = s => BuildGeometryArrayTree((Surface[])s);
-    private static readonly Func<object, RTree> _brepArrayFactory = s => BuildGeometryArrayTree((Brep[])s);
+    private static readonly FrozenDictionary<Type, Func<object, IGeometryContext, Result<object>>> _queryValidators =
+        new Dictionary<Type, Func<object, IGeometryContext, Result<object>>> {
+            [typeof(Sphere)] = static (query, context) => query switch {
+                Sphere { IsValid: true, Radius: > 0.0 } sphere when sphere.Radius > context.AbsoluteTolerance => ResultFactory.Create<object>(value: sphere),
+                Sphere => ResultFactory.Create<object>(error: E.Validation.GeometryInvalid.WithContext("Sphere query invalid")),
+                _ => ResultFactory.Create<object>(error: E.Spatial.UnsupportedTypeCombo.WithContext("Expected Sphere query")),
+            },
+            [typeof(BoundingBox)] = static (query, _) => query switch {
+                BoundingBox { IsValid: true } box => ResultFactory.Create<object>(value: box),
+                BoundingBox => ResultFactory.Create<object>(error: E.Validation.GeometryInvalid.WithContext("BoundingBox query invalid")),
+                _ => ResultFactory.Create<object>(error: E.Spatial.UnsupportedTypeCombo.WithContext("Expected BoundingBox query")),
+            },
+            [typeof((Point3d[], int))] = static (query, _) => query switch {
+                (Point3d[] Needles, int K) payload when payload.K > 0 && payload.Needles.Length > 0 => ResultFactory
+                    .Create(value: payload.Needles)
+                    .Traverse(static point => point.IsValid ? ResultFactory.Create(value: point) : ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid))
+                    .Map(validNeedles => (object)(validNeedles.ToArray(), payload.K)),
+                (Point3d[], int k) when k <= 0 => ResultFactory.Create<object>(error: E.Spatial.InvalidK),
+                (Point3d[] needles, int) when needles.Length == 0 => ResultFactory.Create<object>(error: E.Geometry.InvalidCount.WithContext("Needle set empty")),
+                _ => ResultFactory.Create<object>(error: E.Spatial.UnsupportedTypeCombo),
+            },
+            [typeof((Point3d[], double))] = static (query, context) => query switch {
+                (Point3d[] Needles, double Distance) payload when payload.Distance > context.AbsoluteTolerance && payload.Needles.Length > 0 => ResultFactory
+                    .Create(value: payload.Needles)
+                    .Traverse(static point => point.IsValid ? ResultFactory.Create(value: point) : ResultFactory.Create<Point3d>(error: E.Validation.GeometryInvalid))
+                    .Map(validNeedles => (object)(validNeedles.ToArray(), payload.Distance)),
+                (Point3d[], double distance) when distance <= context.AbsoluteTolerance => ResultFactory.Create<object>(error: E.Spatial.InvalidDistance.WithContext("Distance must exceed tolerance")),
+                (Point3d[] needles, double) when needles.Length == 0 => ResultFactory.Create<object>(error: E.Geometry.InvalidCount.WithContext("Needle set empty")),
+                _ => ResultFactory.Create<object>(error: E.Spatial.UnsupportedTypeCombo),
+            },
+            [typeof(double)] = static (query, _) => query switch {
+                double value when value >= 0.0 => ResultFactory.Create<object>(value: value),
+                double => ResultFactory.Create<object>(error: E.Spatial.InvalidDistance.WithContext("Tolerance must be non-negative")),
+                _ => ResultFactory.Create<object>(error: E.Spatial.UnsupportedTypeCombo.WithContext("Expected tolerance")),
+            },
+        }.ToFrozenDictionary();
 
-    /// <summary>(Input, Query) type pairs to (Factory, Mode, BufferSize, Execute) mapping.</summary>
-    internal static readonly FrozenDictionary<(Type Input, Type Query), (Func<object, RTree>? Factory, V Mode, int BufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> Execute)> OperationRegistry =
-        new (Type Input, Type Query, Func<object, RTree>? Factory, V Mode, int BufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> Execute)[] {
-            (typeof(Point3d[]), typeof(Sphere), _pointArrayFactory, V.None, SpatialConfig.DefaultBufferSize, MakeExecutor<Point3d[]>(_pointArrayFactory)),
-            (typeof(Point3d[]), typeof(BoundingBox), _pointArrayFactory, V.None, SpatialConfig.DefaultBufferSize, MakeExecutor<Point3d[]>(_pointArrayFactory)),
-            (typeof(Point3d[]), typeof((Point3d[], int)), _pointArrayFactory, V.None, SpatialConfig.DefaultBufferSize, MakeExecutor<Point3d[]>(_pointArrayFactory, (RTree.Point3dKNeighbors, RTree.Point3dClosestPoints))),
-            (typeof(Point3d[]), typeof((Point3d[], double)), _pointArrayFactory, V.None, SpatialConfig.DefaultBufferSize, MakeExecutor<Point3d[]>(_pointArrayFactory, (RTree.Point3dKNeighbors, RTree.Point3dClosestPoints))),
-            (typeof(PointCloud), typeof(Sphere), _pointCloudFactory, V.Standard, SpatialConfig.DefaultBufferSize, MakeExecutor<PointCloud>(_pointCloudFactory)),
-            (typeof(PointCloud), typeof(BoundingBox), _pointCloudFactory, V.Standard, SpatialConfig.DefaultBufferSize, MakeExecutor<PointCloud>(_pointCloudFactory)),
-            (typeof(PointCloud), typeof((Point3d[], int)), _pointCloudFactory, V.Standard, SpatialConfig.DefaultBufferSize, MakeExecutor<PointCloud>(_pointCloudFactory, (RTree.PointCloudKNeighbors, RTree.PointCloudClosestPoints))),
-            (typeof(PointCloud), typeof((Point3d[], double)), _pointCloudFactory, V.Standard, SpatialConfig.DefaultBufferSize, MakeExecutor<PointCloud>(_pointCloudFactory, (RTree.PointCloudKNeighbors, RTree.PointCloudClosestPoints))),
-            (typeof(Mesh), typeof(Sphere), _meshFactory, V.MeshSpecific, SpatialConfig.DefaultBufferSize, MakeExecutor<Mesh>(_meshFactory)),
-            (typeof(Mesh), typeof(BoundingBox), _meshFactory, V.MeshSpecific, SpatialConfig.DefaultBufferSize, MakeExecutor<Mesh>(_meshFactory)),
-            (typeof((Mesh, Mesh)), typeof(double), null, V.MeshSpecific, SpatialConfig.LargeBufferSize, MakeMeshOverlapExecutor()),
-            (typeof(Curve[]), typeof(Sphere), _curveArrayFactory, V.Degeneracy, SpatialConfig.DefaultBufferSize, MakeExecutor<Curve[]>(_curveArrayFactory)),
-            (typeof(Curve[]), typeof(BoundingBox), _curveArrayFactory, V.Degeneracy, SpatialConfig.DefaultBufferSize, MakeExecutor<Curve[]>(_curveArrayFactory)),
-            (typeof(Surface[]), typeof(Sphere), _surfaceArrayFactory, V.BoundingBox, SpatialConfig.DefaultBufferSize, MakeExecutor<Surface[]>(_surfaceArrayFactory)),
-            (typeof(Surface[]), typeof(BoundingBox), _surfaceArrayFactory, V.BoundingBox, SpatialConfig.DefaultBufferSize, MakeExecutor<Surface[]>(_surfaceArrayFactory)),
-            (typeof(Brep[]), typeof(Sphere), _brepArrayFactory, V.Topology, SpatialConfig.DefaultBufferSize, MakeExecutor<Brep[]>(_brepArrayFactory)),
-            (typeof(Brep[]), typeof(BoundingBox), _brepArrayFactory, V.Topology, SpatialConfig.DefaultBufferSize, MakeExecutor<Brep[]>(_brepArrayFactory)),
-        }.ToFrozenDictionary(static entry => (entry.Input, entry.Query), static entry => (entry.Factory, entry.Mode, entry.BufferSize, entry.Execute));
+    private static readonly Func<object, IGeometryContext, Func<object, IGeometryContext, Result<RTree>>, Result<RTree>> _treeResolver =
+        static (source, context, factory) => Spatial.TreeCache.TryGetValue(source, out RTree cached)
+            ? ResultFactory.Create(value: cached)
+            : factory(source, context).Map(tree => {
+                Spatial.TreeCache.Add(source, tree);
+                return tree;
+            });
 
-    private static Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> MakeExecutor<TInput>(
-        Func<object, RTree> factory,
-        (Func<TInput, Point3d[], int, IEnumerable<int[]>>? kNearest, Func<TInput, Point3d[], double, IEnumerable<int[]>>? distLimited)? proximityFuncs = null
-    ) where TInput : notnull =>
-        proximityFuncs is (Func<TInput, Point3d[], int, IEnumerable<int[]>> nearest, Func<TInput, Point3d[], double, IEnumerable<int[]>> limited)
-            ? (i, q, _, _) => q switch {
-                (Point3d[] needles, var limit) when limit is int or double => ExecuteProximitySearch(source: (TInput)i, needles: needles, limit: limit, kNearest: nearest, distLimited: limited),
-                _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo),
+    private static readonly Func<RTree, object, int, IGeometryContext, Result<IReadOnlyList<int>>> _rangeSearch =
+        static (tree, query, bufferSize, context) => {
+            int[] buffer = ArrayPool<int>.Shared.Rent(bufferSize);
+            int count = 0;
+            bool overflow = false;
+            bool unsupported = false;
+            try {
+                EventHandler<RTreeEventArgs> handler = (_, args) => {
+                    bool hasCapacity = count < buffer.Length;
+                    int index = hasCapacity ? count : buffer.Length - 1;
+                    buffer[index] = args.Id;
+                    count = hasCapacity ? count + 1 : count;
+                    overflow = hasCapacity ? overflow : true;
+                };
+                Action search = query switch {
+                    Sphere sphere => () => tree.Search(sphere, handler),
+                    BoundingBox box => () => tree.Search(box, handler),
+                    _ => () => unsupported = true,
+                };
+                search();
+                return unsupported
+                    ? ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo)
+                    : overflow
+                        ? ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.BufferOverflow.WithContext($"BufferSize: {bufferSize}, Tolerance: {context.AbsoluteTolerance}"))
+                        : ResultFactory.Create<IReadOnlyList<int>>(value: count > 0 ? [.. buffer[..count]] : []);
+            } finally {
+                ArrayPool<int>.Shared.Return(buffer, clearArray: true);
             }
-            : (i, q, _, b) => GetTree(source: (TInput)i, factory: factory).Bind(tree => ExecuteRangeSearch(tree: tree, queryShape: q, bufferSize: b));
-
-    private static Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> MakeMeshOverlapExecutor() =>
-        (i, q, c, b) => i is (Mesh m1, Mesh m2) && q is double tolerance
-            ? GetTree(source: m1, factory: _meshFactory).Bind(t1 => GetTree(source: m2, factory: _meshFactory).Bind(t2 => ExecuteOverlapSearch(tree1: t1, tree2: t2, tolerance: c.AbsoluteTolerance + tolerance, bufferSize: b)))
-            : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo);
-
-    /// <summary>Gets cached or constructs RTree with automatic caching.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<RTree> GetTree<T>(T source, Func<object, RTree> factory) where T : notnull =>
-        ResultFactory.Create(value: Spatial.TreeCache.GetValue(key: source, createValueCallback: _ => factory(source!)));
-
-    /// <summary>Builds RTree from geometry array with bounding box insertion.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static RTree BuildGeometryArrayTree<T>(T[] geometries) where T : GeometryBase {
-        RTree tree = new();
-        for (int i = 0; i < geometries.Length; i++) {
-            _ = tree.Insert(geometries[i].GetBoundingBox(accurate: true), i);
-        }
-        return tree;
-    }
-
-    /// <summary>Range search with sphere/box query using pooled buffers.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<int>> ExecuteRangeSearch(RTree tree, object queryShape, int bufferSize) {
-        int[] buffer = ArrayPool<int>.Shared.Rent(bufferSize);
-        int count = 0;
-        try {
-            Action search = queryShape switch {
-                Sphere sphere => () => tree.Search(sphere, (_, args) => { if (count < buffer.Length) { buffer[count++] = args.Id; } }),
-                BoundingBox box => () => tree.Search(box, (_, args) => { if (count < buffer.Length) { buffer[count++] = args.Id; } }),
-                _ => () => { }
-                ,
-            };
-            search();
-            return ResultFactory.Create<IReadOnlyList<int>>(value: count > 0 ? [.. buffer[..count]] : []);
-        } finally {
-            ArrayPool<int>.Shared.Return(buffer, clearArray: true);
-        }
-    }
-
-    /// <summary>K-nearest or distance-limited proximity search.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<int>> ExecuteProximitySearch<T>(T source, Point3d[] needles, object limit, Func<T, Point3d[], int, IEnumerable<int[]>> kNearest, Func<T, Point3d[], double, IEnumerable<int[]>> distLimited) where T : notnull =>
-        limit switch {
-            int k when k > 0 => kNearest(source, needles, k).ToArray() is int[][] results
-                ? ResultFactory.Create<IReadOnlyList<int>>(value: [.. results.SelectMany(static indices => indices),])
-                : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed),
-            double d when d > 0 => distLimited(source, needles, d).ToArray() is int[][] results
-                ? ResultFactory.Create<IReadOnlyList<int>>(value: [.. results.SelectMany(static indices => indices),])
-                : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed),
-            int => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.InvalidK),
-            double => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.InvalidDistance),
-            _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed),
         };
 
-    /// <summary>Mesh overlap detection with tolerance-aware dual-tree search.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<int>> ExecuteOverlapSearch(RTree tree1, RTree tree2, double tolerance, int bufferSize) {
-        int[] buffer = ArrayPool<int>.Shared.Rent(bufferSize);
-        int count = 0;
-        try {
-            return RTree.SearchOverlaps(tree1, tree2, tolerance, (_, args) => {
-                if (count + 1 < buffer.Length) {
-                    buffer[count++] = args.Id;
-                    buffer[count++] = args.IdB;
-                }
-            })
-                ? ResultFactory.Create<IReadOnlyList<int>>(value: count > 0 ? [.. buffer[..count]] : [])
-                : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed);
-        } finally {
-            ArrayPool<int>.Shared.Return(buffer, clearArray: true);
+    private static readonly Func<object, Point3d[], object, Func<object, Point3d[], int, IEnumerable<int[]>>, Func<object, Point3d[], double, IEnumerable<int[]>>, Result<IReadOnlyList<int>>> _proximitySearch =
+        static (source, needles, limit, kNearest, distLimited) => limit switch {
+            int count => kNearest(source, needles, count).ToArray() is int[][] results && results.Length > 0
+                ? ResultFactory.Create<IReadOnlyList<int>>(value: [.. results.SelectMany(static indices => indices),])
+                : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed.WithContext("No neighbors within K")),
+            double distance => distLimited(source, needles, distance).ToArray() is int[][] results && results.Length > 0
+                ? ResultFactory.Create<IReadOnlyList<int>>(value: [.. results.SelectMany(static indices => indices),])
+                : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed.WithContext("No neighbors within distance")),
+            _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo.WithContext("Invalid proximity payload")),
+        };
+
+    private static readonly Func<RTree, RTree, double, int, Result<IReadOnlyList<int>>> _overlapSearch =
+        static (treeA, treeB, tolerance, bufferSize) => {
+            int[] buffer = ArrayPool<int>.Shared.Rent(bufferSize);
+            int count = 0;
+            try {
+                bool hasIntersections = RTree.SearchOverlaps(treeA, treeB, tolerance, (_, args) => {
+                    bool hasCapacity = count + 1 < buffer.Length;
+                    int index = hasCapacity ? count : buffer.Length - 2;
+                    buffer[index] = args.Id;
+                    buffer[index + 1] = args.IdB;
+                    count = hasCapacity ? count + 2 : count;
+                });
+                return hasIntersections
+                    ? ResultFactory.Create<IReadOnlyList<int>>(value: count > 0 ? [.. buffer[..count]] : [])
+                    : ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.ProximityFailed);
+            } finally {
+                ArrayPool<int>.Shared.Return(buffer, clearArray: true);
+            }
+        };
+
+    /// <summary>(Input, Query) type pairs to (Factory, Mode, BufferSize, Execute) mapping.</summary>
+    internal static readonly FrozenDictionary<(Type Input, Type Query), (Func<object, IGeometryContext, Result<RTree>>? Factory, Func<object, IGeometryContext, Result<object>> QueryValidator, V Mode, int BufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> Execute)> OperationRegistry =
+        new (Type Input, Func<object, IGeometryContext, Result<RTree>> Factory, V Mode)[] {
+            (typeof(Point3d[]), SpatialConfig.RTreeFactories[typeof(Point3d[])], V.None),
+            (typeof(PointCloud), SpatialConfig.RTreeFactories[typeof(PointCloud)], V.Standard),
+            (typeof(Mesh), SpatialConfig.RTreeFactories[typeof(Mesh)], V.MeshSpecific),
+            (typeof(Curve[]), SpatialConfig.RTreeFactories[typeof(Curve[])], V.Degeneracy),
+            (typeof(Surface[]), SpatialConfig.RTreeFactories[typeof(Surface[])], V.BoundingBox),
+            (typeof(Brep[]), SpatialConfig.RTreeFactories[typeof(Brep[])], V.Topology),
         }
-    }
+            .SelectMany(entry => new (Type Input, Type Query, Func<object, IGeometryContext, Result<RTree>>? Factory, Func<object, IGeometryContext, Result<object>> QueryValidator, V Mode, int BufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> Execute)[] {
+                (entry.Input, typeof(Sphere), entry.Factory, _queryValidators[typeof(Sphere)], entry.Mode, SpatialConfig.DefaultBufferSize, (input, query, context, buffer) => _queryValidators[typeof(Sphere)](query, context).Bind(validQuery =>
+                    _treeResolver(source: input, context: context, factory: entry.Factory).Bind(tree =>
+                        _rangeSearch(tree: tree, query: validQuery, bufferSize: buffer, context: context)))),
+                (entry.Input, typeof(BoundingBox), entry.Factory, _queryValidators[typeof(BoundingBox)], entry.Mode, SpatialConfig.DefaultBufferSize, (input, query, context, buffer) => _queryValidators[typeof(BoundingBox)](query, context).Bind(validQuery =>
+                    _treeResolver(source: input, context: context, factory: entry.Factory).Bind(tree =>
+                        _rangeSearch(tree: tree, query: validQuery, bufferSize: buffer, context: context)))),
+            })
+            .Concat(new (Type Input, Type Query, Func<object, IGeometryContext, Result<RTree>>? Factory, Func<object, IGeometryContext, Result<object>> QueryValidator, V Mode, int BufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> Execute)[] {
+                (typeof(Point3d[]), typeof((Point3d[], int)), SpatialConfig.RTreeFactories[typeof(Point3d[])], _queryValidators[typeof((Point3d[], int))], V.None, SpatialConfig.DefaultBufferSize, (input, query, context, _) => input switch {
+                    Point3d[] points => _queryValidators[typeof((Point3d[], int))](query, context).Bind(validQuery => validQuery switch {
+                        (Point3d[] needles, int limit) => _proximitySearch(
+                            source: points,
+                            needles: needles,
+                            limit: limit,
+                            kNearest: static (source, payload, count) => RTree.Point3dKNeighbors((Point3d[])source, payload, count),
+                            distLimited: static (source, payload, distance) => RTree.Point3dClosestPoints((Point3d[])source, payload, distance)
+                        ),
+                        _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo),
+                    }),
+                    _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Validation.GeometryInvalid),
+                }),
+                (typeof(Point3d[]), typeof((Point3d[], double)), SpatialConfig.RTreeFactories[typeof(Point3d[])], _queryValidators[typeof((Point3d[], double))], V.None, SpatialConfig.DefaultBufferSize, (input, query, context, _) => input switch {
+                    Point3d[] points => _queryValidators[typeof((Point3d[], double))](query, context).Bind(validQuery => validQuery switch {
+                        (Point3d[] needles, double limit) => _proximitySearch(
+                            source: points,
+                            needles: needles,
+                            limit: limit,
+                            kNearest: static (source, payload, count) => RTree.Point3dKNeighbors((Point3d[])source, payload, count),
+                            distLimited: static (source, payload, distance) => RTree.Point3dClosestPoints((Point3d[])source, payload, distance)
+                        ),
+                        _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo),
+                    }),
+                    _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Validation.GeometryInvalid),
+                }),
+                (typeof(PointCloud), typeof((Point3d[], int)), SpatialConfig.RTreeFactories[typeof(PointCloud)], _queryValidators[typeof((Point3d[], int))], V.Standard, SpatialConfig.DefaultBufferSize, (input, query, context, _) => input switch {
+                    PointCloud cloud => _queryValidators[typeof((Point3d[], int))](query, context).Bind(validQuery => validQuery switch {
+                        (Point3d[] needles, int limit) => _proximitySearch(
+                            source: cloud,
+                            needles: needles,
+                            limit: limit,
+                            kNearest: static (source, payload, count) => RTree.PointCloudKNeighbors((PointCloud)source, payload, count),
+                            distLimited: static (source, payload, distance) => RTree.PointCloudClosestPoints((PointCloud)source, payload, distance)
+                        ),
+                        _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo),
+                    }),
+                    _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Validation.GeometryInvalid),
+                }),
+                (typeof(PointCloud), typeof((Point3d[], double)), SpatialConfig.RTreeFactories[typeof(PointCloud)], _queryValidators[typeof((Point3d[], double))], V.Standard, SpatialConfig.DefaultBufferSize, (input, query, context, _) => input switch {
+                    PointCloud cloud => _queryValidators[typeof((Point3d[], double))](query, context).Bind(validQuery => validQuery switch {
+                        (Point3d[] needles, double limit) => _proximitySearch(
+                            source: cloud,
+                            needles: needles,
+                            limit: limit,
+                            kNearest: static (source, payload, count) => RTree.PointCloudKNeighbors((PointCloud)source, payload, count),
+                            distLimited: static (source, payload, distance) => RTree.PointCloudClosestPoints((PointCloud)source, payload, distance)
+                        ),
+                        _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo),
+                    }),
+                    _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Validation.GeometryInvalid),
+                }),
+                (typeof((Mesh, Mesh)), typeof(double), SpatialConfig.RTreeFactories[typeof(Mesh)], _queryValidators[typeof(double)], V.MeshSpecific, SpatialConfig.LargeBufferSize, (input, query, context, buffer) => _queryValidators[typeof(double)](query, context).Bind(validTolerance => input switch {
+                    (Mesh meshA, Mesh meshB) => _treeResolver(source: meshA, context: context, factory: SpatialConfig.RTreeFactories[typeof(Mesh)]).Bind(treeA =>
+                        _treeResolver(source: meshB, context: context, factory: SpatialConfig.RTreeFactories[typeof(Mesh)]).Bind(treeB =>
+                            _overlapSearch(treeA: treeA, treeB: treeB, tolerance: context.AbsoluteTolerance + (double)validTolerance, bufferSize: buffer))),
+                    _ => ResultFactory.Create<IReadOnlyList<int>>(error: E.Spatial.UnsupportedTypeCombo.WithContext("Expected mesh pair")),
+                })),
+            })
+            .ToFrozenDictionary(entry => (entry.Input, entry.Query), entry => (entry.Factory, entry.QueryValidator, entry.Mode, entry.BufferSize, entry.Execute));
 }


### PR DESCRIPTION
## Summary
- extend the shared RTree factory map to cover curve, surface, and brep arrays so SpatialCore can reuse centralized constructors
- collapse the spatial query validators into a frozen dictionary and rebuild the operation registry around the shared tables
- wire overlap, range, and proximity delegates to the unified factories to avoid redundant static fields while preserving validation-driven dispatch

## Testing
- dotnet build *(fails: dotnet CLI not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691292dc3a3c8321abda5c3607de383f)