### PR TITLE
Embed orientation metadata in frozen map

### DIFF
--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
@@ -9,10 +11,6 @@ namespace Arsenal.Rhino.Orientation;
 
 /// <summary>Optimization, relative orientation, pattern alignment algorithms.</summary>
 internal static class OrientCompute {
-    /// <summary>Optimize orientation for canonical alignment and stability.</summary>
-    /// <param name="brep">Brep geometry to optimize.</param>
-    /// <param name="criteria">Optimization criterion: 1=Minimize bounding box (compact packing), 2=Align centroid to bounding center, 3=Maximize bounding box degeneracy (flatness), 4=Canonical position (ground plane + centered + low profile).</param>
-    /// <param name="tolerance">Absolute tolerance for geometric comparisons.</param>
     [Pure]
     internal static Result<(Transform OptimalTransform, double Score, byte[] CriteriaMet)> OptimizeOrientation(
         Brep brep,
@@ -27,8 +25,8 @@ internal static class OrientCompute {
                     ? ResultFactory.Create<(Transform, double, byte[])>(error: E.Validation.ToleranceAbsoluteInvalid)
                     : validBrep.GetBoundingBox(accurate: true) is BoundingBox box && box.IsValid
                         ? ((Func<Result<(Transform, double, byte[])>>)(() => {
-                            using VolumeMassProperties? vmp = validBrep.IsSolid && validBrep.IsManifold ? VolumeMassProperties.Compute(validBrep) : null;
-                            Plane[] testPlanes = [
+                            using VolumeMassProperties? properties = validBrep.IsSolid && validBrep.IsManifold ? VolumeMassProperties.Compute(validBrep) : null;
+                            Plane[] candidates = [
                                 new Plane(box.Center, Vector3d.XAxis, Vector3d.YAxis),
                                 new Plane(box.Center, Vector3d.YAxis, Vector3d.ZAxis),
                                 new Plane(box.Center, Vector3d.XAxis, Vector3d.ZAxis),
@@ -37,112 +35,129 @@ internal static class OrientCompute {
                                 new Plane(box.Center, new Vector3d(0, 1, 1) / Math.Sqrt(2), Vector3d.XAxis),
                             ];
 
-                            (Transform, double, byte[])[] results = [.. testPlanes.Select(plane => {
-                                Transform xf = Transform.PlaneToPlane(plane, Plane.WorldXY);
+                            (Transform, double, byte[])[] evaluations = [.. candidates.Select(candidate => {
+                                Transform transform = Transform.PlaneToPlane(candidate, Plane.WorldXY);
                                 using Brep test = (Brep)validBrep.Duplicate();
-                                return !test.Transform(xf) ? (Transform.Identity, 0.0, Array.Empty<byte>())
+                                return !test.Transform(transform)
+                                    ? (Transform.Identity, 0.0, Array.Empty<byte>())
                                     : test.GetBoundingBox(accurate: true) is BoundingBox testBox && testBox.IsValid
-                                        ? (xf, criteria switch {
+                                        ? (transform, criteria switch {
                                             1 => testBox.Diagonal.Length > tolerance ? 1.0 / testBox.Diagonal.Length : 0.0,
-                                            2 => vmp is not null && testBox.Diagonal.Length > tolerance ? Math.Max(0.0, 1.0 - (Math.Abs(testBox.Center.Z - vmp.Centroid.Z) / testBox.Diagonal.Length)) : 0.0,
-                                            3 => testBox.IsDegenerate(tolerance) is int deg ? deg switch {
+                                            2 => properties is not null && testBox.Diagonal.Length > tolerance ? Math.Max(0.0, 1.0 - (Math.Abs(testBox.Center.Z - properties.Centroid.Z) / testBox.Diagonal.Length)) : 0.0,
+                                            3 => testBox.IsDegenerate(tolerance) is int degeneracy ? degeneracy switch {
                                                 0 => 0.0,
-                                                >= 1 and <= 3 => deg / 3.0,
+                                                >= 1 and <= 3 => degeneracy / 3.0,
                                                 _ => 0.0,
                                             } : 0.0,
-                                            4 => (testBox.Min.Z >= -tolerance ? OrientConfig.OrientationScoreWeight1 : 0.0) + (Math.Abs(testBox.Center.X) < tolerance && Math.Abs(testBox.Center.Y) < tolerance ? OrientConfig.OrientationScoreWeight2 : 0.0) + ((testBox.Max.Z - testBox.Min.Z) < (testBox.Diagonal.Length * OrientConfig.LowProfileAspectRatio) ? OrientConfig.OrientationScoreWeight3 : 0.0),
+                                            4 => (testBox.Min.Z >= -tolerance ? OrientConfig.OrientationScoreWeight1 : 0.0)
+                                                + (Math.Abs(testBox.Center.X) < tolerance && Math.Abs(testBox.Center.Y) < tolerance ? OrientConfig.OrientationScoreWeight2 : 0.0)
+                                                + ((testBox.Max.Z - testBox.Min.Z) < (testBox.Diagonal.Length * OrientConfig.LowProfileAspectRatio) ? OrientConfig.OrientationScoreWeight3 : 0.0),
                                             _ => 0.0,
                                         }, criteria is >= 1 and <= 4 ? [criteria,] : Array.Empty<byte>())
                                         : (Transform.Identity, 0.0, Array.Empty<byte>());
                             }),
                             ];
 
-                            return results.MaxBy(r => r.Item2) is (Transform best, double bestScore, byte[] met) && bestScore > 0.0
-                                ? ResultFactory.Create(value: (best, bestScore, met))
+                            return evaluations.MaxBy(result => result.Item2) is (Transform best, double score, byte[] met) && score > 0.0
+                                ? ResultFactory.Create(value: (best, score, met))
                                 : ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.TransformFailed.WithContext("No valid orientation found"));
                         }))()
                         : ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.TransformFailed.WithContext("Invalid bounding box")));
 
-    /// <summary>Compute relative orientation between two geometries.</summary>
     [Pure]
     internal static Result<(Transform RelativeTransform, double Twist, double Tilt, byte SymmetryType, byte Relationship)> ComputeRelative(
         GeometryBase geometryA,
         GeometryBase geometryB,
         IGeometryContext context) =>
-        geometryA is null || geometryB is null
-            ? ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed.WithContext("Null geometry"))
-            : !geometryA.IsValid || !geometryB.IsValid
-                ? ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Validation.GeometryInvalid)
-                : (OrientCore.PlaneExtractors.TryGetValue(geometryA.GetType(), out Func<object, Result<Plane>>? extA),
-                   OrientCore.PlaneExtractors.TryGetValue(geometryB.GetType(), out Func<object, Result<Plane>>? extB))
-                switch {
-                    (true, true) when extA!(geometryA) is Result<Plane> ra && extB!(geometryB) is Result<Plane> rb => (ra, rb) switch {
-                        (Result<Plane> { IsSuccess: true }, Result<Plane> { IsSuccess: true }) => (ra.Value, rb.Value) is (Plane pa, Plane pb)
-                            ? Transform.PlaneToPlane(pa, pb) is Transform xform && Vector3d.VectorAngle(pa.XAxis, pb.XAxis) is double twist && Vector3d.VectorAngle(pa.ZAxis, pb.ZAxis) is double tilt
-                                ? ((geometryA, geometryB) switch {
-                                    (Brep ba, Brep bb) when ba.Vertices.Count == bb.Vertices.Count => (pb.Origin - pa.Origin).Length > OrientConfig.MinVectorLength
-                                        ? new Plane(pa.Origin, pb.Origin - pa.Origin) is Plane mirror && mirror.IsValid
-                                            && ba.Vertices.Select(va => {
-                                                Point3d reflected = va.Location;
-                                                reflected.Transform(Transform.Mirror(mirrorPlane: mirror));
-                                                return reflected;
-                                            }).ToArray() is Point3d[] reflectedA
-                                            && reflectedA.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < context.AbsoluteTolerance))
-                                                ? (byte)1 : (byte)0
-                                        : new Plane(pa.Origin, pa.ZAxis) is Plane mirror2 && mirror2.IsValid
-                                            && ba.Vertices.Select(va => {
-                                                Point3d reflected = va.Location;
-                                                reflected.Transform(Transform.Mirror(mirrorPlane: mirror2));
-                                                return reflected;
-                                            }).ToArray() is Point3d[] reflectedA2
-                                            && reflectedA2.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < context.AbsoluteTolerance))
-                                                ? (byte)1 : (byte)0,
-                                    (Curve ca, Curve cb) when ca.SpanCount == cb.SpanCount && pa.ZAxis.IsValid && pa.ZAxis.Length > context.AbsoluteTolerance => Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).All(i => {
-                                        double t = ca.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1));
-                                        Point3d ptA = ca.PointAt(t);
-                                        Point3d ptB = cb.PointAt(t);
-                                        Vector3d vecA = ptA - pa.Origin;
-                                        Vector3d vecB = ptB - pa.Origin;
-                                        double distA = vecA.Length;
-                                        double distB = vecB.Length;
-                                        return (distA < context.AbsoluteTolerance && distB < context.AbsoluteTolerance) || (Math.Abs(distA - distB) < context.AbsoluteTolerance && Vector3d.VectorAngle(vecA, vecB) < OrientConfig.SymmetryAngleToleranceRadians);
-                                    }) ? (byte)2 : (byte)0,
-                                    _ => (byte)0,
-                                }, Math.Abs(Vector3d.Multiply(pa.ZAxis, pb.ZAxis)) switch {
-                                    double dot when Math.Abs(dot - 1.0) < context.AbsoluteTolerance => (byte)1,
-                                    double dot when Math.Abs(dot) < context.AbsoluteTolerance => (byte)2,
-                                    _ => (byte)3,
-                                }) is (byte symmetry, byte relationship)
-                                    ? ResultFactory.Create(value: (xform, twist, tilt, symmetry, relationship))
-                                    : ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed)
-                                : ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed)
-                            : ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed),
-                        _ => ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed),
-                    },
-                    _ => ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.UnsupportedOrientationType),
-                };
+        ResultFactory.Create(value: (geometryA, geometryB))
+            .Ensure(pair => pair.geometryA is not null && pair.geometryB is not null, error: E.Geometry.OrientationFailed.WithContext("Null geometry"))
+            .Bind(pair => OrientCore.ExtractPlane(pair.geometryA!, context)
+                .Bind(planeA => OrientCore.ExtractPlane(pair.geometryB!, context)
+                    .Bind(planeB => {
+                        Transform relative = Transform.PlaneToPlane(planeA, planeB);
+                        double twist = Vector3d.VectorAngle(planeA.XAxis, planeB.XAxis);
+                        double tilt = Vector3d.VectorAngle(planeA.ZAxis, planeB.ZAxis);
 
-    /// <summary>Detect patterns in geometry array and compute alignment.</summary>
+                        Result<byte> symmetry = (pair.geometryA, pair.geometryB) switch {
+                            (Brep brepA, Brep brepB) when brepA.Vertices.Count == brepB.Vertices.Count => ((Func<Result<byte>>)(() => {
+                                Vector3d originDelta = planeB.Origin - planeA.Origin;
+                                Plane primaryMirror = originDelta.Length > OrientConfig.MinVectorLength ? new Plane(planeA.Origin, originDelta) : new Plane(planeA.Origin, planeA.ZAxis);
+                                Plane fallbackMirror = new Plane(planeA.Origin, planeA.ZAxis);
+                                bool primaryValid = primaryMirror.IsValid;
+                                Plane selectedMirror = primaryValid ? primaryMirror : fallbackMirror;
+
+                                bool mirrored = brepA.Vertices
+                                    .Select(vertex => {
+                                        Point3d reflected = vertex.Location;
+                                        reflected.Transform(Transform.Mirror(mirrorPlane: selectedMirror));
+                                        return reflected;
+                                    })
+                                    .All(reflected => brepB.Vertices.Any(target => reflected.DistanceTo(target.Location) < context.AbsoluteTolerance));
+
+                                return ResultFactory.Create(value: mirrored ? (byte)1 : (byte)0);
+                            }))(),
+                            (Curve curveA, Curve curveB) when curveA.SpanCount == curveB.SpanCount && planeA.ZAxis.IsValid && planeA.ZAxis.Length > context.AbsoluteTolerance => ((Func<Result<byte>>)(() => {
+                                bool rotational = Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount)
+                                    .Select(index => {
+                                        double parameter = curveA.Domain.ParameterAt(index / (double)(OrientConfig.RotationSymmetrySampleCount - 1));
+                                        Point3d pointA = curveA.PointAt(parameter);
+                                        Point3d pointB = curveB.PointAt(parameter);
+                                        Vector3d vectorA = pointA - planeA.Origin;
+                                        Vector3d vectorB = pointB - planeA.Origin;
+                                        double distanceA = vectorA.Length;
+                                        double distanceB = vectorB.Length;
+                                        return (distanceA < context.AbsoluteTolerance && distanceB < context.AbsoluteTolerance)
+                                            || (Math.Abs(distanceA - distanceB) < context.AbsoluteTolerance && Vector3d.VectorAngle(vectorA, vectorB) < OrientConfig.SymmetryAngleToleranceRadians);
+                                    })
+                                    .All(result => result);
+
+                                return ResultFactory.Create(value: rotational ? (byte)2 : (byte)0);
+                            }))(),
+                            _ => ResultFactory.Create(value: (byte)0),
+                        };
+
+                        byte relationship = Math.Abs(Vector3d.Multiply(planeA.ZAxis, planeB.ZAxis)) switch {
+                            double dot when Math.Abs(dot - 1.0) < context.AbsoluteTolerance => (byte)1,
+                            double dot when Math.Abs(dot) < context.AbsoluteTolerance => (byte)2,
+                            _ => (byte)3,
+                        };
+
+                        return symmetry.Map(symmetryValue => (relative, twist, tilt, symmetryValue, relationship));
+                    })));
+
     [Pure]
     internal static Result<(byte PatternType, Transform[] IdealTransforms, int[] Anomalies, double Deviation)> DetectPattern(
         GeometryBase[] geometries,
         IGeometryContext context) =>
-        geometries is null
-            ? ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.InsufficientParameters.WithContext("Geometries array is null"))
-            : ResultFactory.Create(value: geometries)
-                .Ensure(g => g.All(item => item?.IsValid == true), error: E.Validation.GeometryInvalid)
-                .Bind(validGeometries => validGeometries.Length >= OrientConfig.PatternMinInstances
-                    ? ((Func<Result<(byte, Transform[], int[], double)>>)(() => {
-                        Result<Point3d>[] centroidResults = [.. validGeometries.Select(g => OrientCore.ExtractCentroid(g, useMassProperties: false)),];
-                        return centroidResults.All(r => r.IsSuccess)
-                            ? centroidResults.Select(r => r.Value).ToArray() is Point3d[] centroids && centroids.Length >= 3 && centroids.Skip(1).Zip(centroids, (c2, c1) => c2 - c1).ToArray() is Vector3d[] deltas && deltas.Average(v => v.Length) is double avgLen && avgLen > context.AbsoluteTolerance
-                                ? deltas.All(v => Math.Abs(v.Length - avgLen) / avgLen < context.AbsoluteTolerance)
-                                    ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (0, [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Translation(deltas[0] * i)),], [.. deltas.Select((v, i) => (v, i)).Where(pair => Math.Abs(pair.v.Length - avgLen) / avgLen >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.i),], deltas.Sum(v => Math.Abs(v.Length - avgLen)) / centroids.Length))
-                                    : new Point3d(centroids.Average(p => p.X), centroids.Average(p => p.Y), centroids.Average(p => p.Z)) is Point3d center && centroids.Select(p => p.DistanceTo(center)).ToArray() is double[] radii && radii.Average() is double avgRadius && avgRadius > context.AbsoluteTolerance && radii.All(r => Math.Abs(r - avgRadius) / avgRadius < context.AbsoluteTolerance)
-                                        ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (1, [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Rotation(2.0 * Math.PI * i / centroids.Length, Vector3d.ZAxis, center)),], [.. radii.Select((r, i) => (r, i)).Where(pair => Math.Abs(pair.r - avgRadius) / avgRadius >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.i),], radii.Sum(r => Math.Abs(r - avgRadius)) / centroids.Length))
-                                        : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern too irregular"))
-                                : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Insufficient valid centroids"))
-                            : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext($"Centroid extraction failed for {centroidResults.Count(r => !r.IsSuccess)} geometries"));
-                    }))()
-                    : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.InsufficientParameters.WithContext($"Pattern detection requires at least {OrientConfig.PatternMinInstances} geometries, got {validGeometries.Length}")));
+        geometries switch {
+            null => ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.InsufficientParameters.WithContext("Geometries array is null")),
+            _ => ResultFactory.Create(value: geometries)
+                .Ensure(array => array.Length >= OrientConfig.PatternMinInstances, error: E.Geometry.InsufficientParameters.WithContext($"Pattern detection requires at least {OrientConfig.PatternMinInstances} geometries, got {geometries.Length}"))
+                .Bind(validGeometries => ((Func<Result<(byte, Transform[], int[], double)>>)(() => {
+                    Result<Point3d>[] centroidResults = [.. validGeometries.Select(geometry => OrientCore.ExtractCentroid(geometry, useMassProperties: false, context)),];
+                    return centroidResults.All(result => result.IsSuccess)
+                        ? centroidResults.Select(result => result.Value).ToArray() is Point3d[] centroids && centroids.Length >= 3
+                            ? ((Func<Result<(byte, Transform[], int[], double)>>)(() => {
+                                Vector3d[] deltas = centroids.Skip(1).Zip(centroids, (next, current) => next - current).ToArray();
+                                double averageLength = deltas.Average(vector => vector.Length);
+                                return averageLength > context.AbsoluteTolerance
+                                    ? deltas.All(vector => Math.Abs(vector.Length - averageLength) / averageLength < context.AbsoluteTolerance)
+                                        ? ResultFactory.Create(value: (
+                                            PatternType: (byte)0,
+                                            IdealTransforms: [.. Enumerable.Range(0, centroids.Length).Select(index => Transform.Translation(deltas[0] * index)),],
+                                            Anomalies: [.. deltas.Select((vector, index) => (vector, index)).Where(pair => Math.Abs(pair.vector.Length - averageLength) / averageLength >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.index),],
+                                            Deviation: deltas.Sum(vector => Math.Abs(vector.Length - averageLength)) / centroids.Length))
+                                        : new Point3d(centroids.Average(point => point.X), centroids.Average(point => point.Y), centroids.Average(point => point.Z)) is Point3d center && centroids.Select(point => point.DistanceTo(center)).ToArray() is double[] radii && radii.Average() is double averageRadius && averageRadius > context.AbsoluteTolerance && radii.All(radius => Math.Abs(radius - averageRadius) / averageRadius < context.AbsoluteTolerance)
+                                            ? ResultFactory.Create(value: (
+                                                PatternType: (byte)1,
+                                                IdealTransforms: [.. Enumerable.Range(0, centroids.Length).Select(index => Transform.Rotation(2.0 * Math.PI * index / centroids.Length, Vector3d.ZAxis, center)),],
+                                                Anomalies: [.. radii.Select((radius, index) => (radius, index)).Where(pair => Math.Abs(pair.radius - averageRadius) / averageRadius >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.index),],
+                                                Deviation: radii.Sum(radius => Math.Abs(radius - averageRadius)) / centroids.Length))
+                                            : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern too irregular"))
+                                    : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Insufficient valid centroids"));
+                            }))()
+                            : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Insufficient valid centroids"))
+                        : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext($"Centroid extraction failed for {centroidResults.Count(result => !result.IsSuccess)} geometries"));
+                }))()),
+        };
 }

--- a/libs/rhino/orientation/OrientCore.cs
+++ b/libs/rhino/orientation/OrientCore.cs
@@ -1,78 +1,308 @@
+using System;
 using System.Collections.Frozen;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
+using Arsenal.Core.Validation;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Orientation;
 
-/// <summary>Plane/centroid extraction and transformation via mass properties.</summary>
+/// <summary>Validation-driven orientation dispatch with minimal strategy surface.</summary>
 internal static class OrientCore {
-    internal static readonly FrozenDictionary<Type, Func<object, Result<Plane>>> PlaneExtractors =
-        new Dictionary<Type, Func<object, Result<Plane>>> {
-            [typeof(Curve)] = g => ((Curve)g).FrameAt(((Curve)g).Domain.Mid, out Plane f) && f.IsValid
-                ? ResultFactory.Create(value: f)
-                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            [typeof(Surface)] = g => ((Surface)g) switch {
-                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane f) && f.IsValid => ResultFactory.Create(value: f),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-            [typeof(Brep)] = g => ((Brep)g) switch {
-                Brep b when b.IsSolid => ((Func<Result<Plane>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(b); return vmp is not null ? ResultFactory.Create(value: new Plane(vmp.Centroid, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)) : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed); }))(),
-                Brep b when b.SolidOrientation != BrepSolidOrientation.None => ((Func<Result<Plane>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(b); return amp is not null ? ResultFactory.Create(value: new Plane(amp.Centroid, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)) : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed); }))(),
-                Brep b => ResultFactory.Create(value: new Plane(b.GetBoundingBox(accurate: false).Center, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)),
-            },
-            [typeof(Extrusion)] = g => ((Extrusion)g) switch {
-                Extrusion e when e.IsSolid => ((Func<Result<Plane>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(e); using LineCurve path = e.PathLineCurve(); return vmp is not null ? ResultFactory.Create(value: new Plane(vmp.Centroid, path.TangentAtStart)) : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed); }))(),
-                Extrusion e when e.IsClosed(0) && e.IsClosed(1) => ((Func<Result<Plane>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(e); using LineCurve path = e.PathLineCurve(); return amp is not null ? ResultFactory.Create(value: new Plane(amp.Centroid, path.TangentAtStart)) : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed); }))(),
-                Extrusion e => ((Func<Result<Plane>>)(() => { using LineCurve path = e.PathLineCurve(); return ResultFactory.Create(value: new Plane(e.GetBoundingBox(accurate: false).Center, path.TangentAtStart)); }))(),
-            },
-            [typeof(Mesh)] = g => ((Mesh)g) switch {
-                Mesh m when m.IsClosed => ((Func<Result<Plane>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(m); return vmp is not null ? ResultFactory.Create(value: new Plane(vmp.Centroid, m.Normals.Count > 0 ? m.Normals[0] : Vector3d.ZAxis)) : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed); }))(),
-                Mesh m => ((Func<Result<Plane>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(m); return amp is not null ? ResultFactory.Create(value: new Plane(amp.Centroid, m.Normals.Count > 0 ? m.Normals[0] : Vector3d.ZAxis)) : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed); }))(),
-            },
-            [typeof(Point3d)] = g => ResultFactory.Create(value: new Plane((Point3d)g, Vector3d.ZAxis)),
-            [typeof(PointCloud)] = g => (PointCloud)g switch {
-                PointCloud pc when pc.Count > 0 => ResultFactory.Create(value: new Plane(pc[0].Location, Vector3d.ZAxis)),
-                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            },
-        }.ToFrozenDictionary();
+    private static readonly FrozenDictionary<Type, (byte Kind, V PlaneMode, bool SupportsBestFit)> TypeMetadata = new Dictionary<Type, (byte Kind, V PlaneMode, bool SupportsBestFit)> {
+        [typeof(Curve)] = (1, V.None, false),
+        [typeof(NurbsCurve)] = (1, V.None, false),
+        [typeof(LineCurve)] = (1, V.None, false),
+        [typeof(ArcCurve)] = (1, V.None, false),
+        [typeof(PolyCurve)] = (1, V.None, false),
+        [typeof(PolylineCurve)] = (1, V.None, false),
+        [typeof(Surface)] = (2, V.None, false),
+        [typeof(NurbsSurface)] = (2, V.None, false),
+        [typeof(PlaneSurface)] = (2, V.None, false),
+        [typeof(Brep)] = (3, V.MassProperties | V.BoundingBox, false),
+        [typeof(Extrusion)] = (4, V.MassProperties | V.BoundingBox, false),
+        [typeof(Mesh)] = (5, V.MassProperties | V.BoundingBox, true),
+        [typeof(PointCloud)] = (6, V.None, true),
+    }.ToFrozenDictionary();
 
-    /// <summary>Centroid extraction via mass properties or bbox.</summary>
-    internal static Result<Point3d> ExtractCentroid(GeometryBase geometry, bool useMassProperties) =>
-        (geometry, useMassProperties) switch {
-            (Brep brep, true) when brep.IsSolid => ((Func<Result<Point3d>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(brep); return vmp is not null ? ResultFactory.Create(value: vmp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (Brep brep, true) when brep.SolidOrientation != BrepSolidOrientation.None => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(brep); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (Extrusion ext, true) when ext.IsSolid => ((Func<Result<Point3d>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(ext); return vmp is not null ? ResultFactory.Create(value: vmp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (Extrusion ext, true) when ext.IsClosed(0) && ext.IsClosed(1) => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(ext); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (Mesh mesh, true) when mesh.IsClosed => ((Func<Result<Point3d>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(mesh); return vmp is not null ? ResultFactory.Create(value: vmp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (Mesh mesh, true) => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(mesh); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (Curve curve, true) => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(curve); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
-            (GeometryBase g, false) => g.GetBoundingBox(accurate: true) switch {
-                BoundingBox b when b.IsValid => ResultFactory.Create(value: b.Center),
-                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
-            },
-            _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
-        };
+    private static Result<(byte Kind, V PlaneMode, bool SupportsBestFit)> ResolveKind(GeometryBase geometry) =>
+        geometry is null
+            ? ResultFactory.Create<(byte Kind, V PlaneMode, bool SupportsBestFit)>(error: E.Geometry.UnsupportedOrientationType.WithContext("null"))
+            : TypeMetadata.TryGetValue(geometry.GetType(), out (byte Kind, V PlaneMode, bool SupportsBestFit) direct)
+                ? ResultFactory.Create(value: direct)
+                : ((Func<Result<(byte Kind, V PlaneMode, bool SupportsBestFit)>>)(() => {
+                    KeyValuePair<Type, (byte Kind, V PlaneMode, bool SupportsBestFit)> match = TypeMetadata.FirstOrDefault(pair => pair.Key.IsInstanceOfType(geometry));
+                    return match.Key is not null
+                        ? ResultFactory.Create(value: match.Value)
+                        : ResultFactory.Create<(byte Kind, V PlaneMode, bool SupportsBestFit)>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name));
+                }))();
 
-    /// <summary>Transform application with duplication and errors.</summary>
+    internal static Result<Point3d> ExtractCentroid(GeometryBase geometry, bool useMassProperties, IGeometryContext context) =>
+        ResolveKind(geometry)
+            .Bind(_ => {
+                Type runtimeType = geometry.GetType();
+                V configuredMode;
+                V baseMode = OrientConfig.ValidationModes.TryGetValue(runtimeType, out configuredMode) ? configuredMode : V.Standard;
+                V validationMode = baseMode | (useMassProperties ? V.MassProperties : V.BoundingBox);
+
+                return ResultFactory.Create(value: geometry)
+                    .Validate(args: [context, validationMode,])
+                    .Bind(valid => (useMassProperties, valid) switch {
+                        (true, Curve curve) => ((Func<Result<Point3d>>)(() => {
+                            using AreaMassProperties? properties = AreaMassProperties.Compute(curve);
+                            return properties?.Centroid is Point3d centroid
+                                ? ResultFactory.Create(value: centroid)
+                                : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                        }))(),
+                        (true, Surface surface) => ((Func<Result<Point3d>>)(() => {
+                            using AreaMassProperties? properties = AreaMassProperties.Compute(surface);
+                            return properties?.Centroid is Point3d centroid
+                                ? ResultFactory.Create(value: centroid)
+                                : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                        }))(),
+                        (true, Brep brep) => (brep.IsSolid
+                            ? (Func<Result<Point3d>>)(() => {
+                                using VolumeMassProperties? properties = VolumeMassProperties.Compute(brep);
+                                return properties?.Centroid is Point3d centroid
+                                    ? ResultFactory.Create(value: centroid)
+                                    : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                            })
+                            : (Func<Result<Point3d>>)(() => {
+                                using AreaMassProperties? properties = AreaMassProperties.Compute(brep);
+                                return properties?.Centroid is Point3d centroid
+                                    ? ResultFactory.Create(value: centroid)
+                                    : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                            }))(),
+                        (true, Extrusion extrusion) => (extrusion.IsSolid
+                            ? (Func<Result<Point3d>>)(() => {
+                                using VolumeMassProperties? properties = VolumeMassProperties.Compute(extrusion);
+                                return properties?.Centroid is Point3d centroid
+                                    ? ResultFactory.Create(value: centroid)
+                                    : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                            })
+                            : extrusion.IsClosed(0) && extrusion.IsClosed(1)
+                                ? (Func<Result<Point3d>>)(() => {
+                                    using AreaMassProperties? properties = AreaMassProperties.Compute(extrusion);
+                                    return properties?.Centroid is Point3d centroid
+                                        ? ResultFactory.Create(value: centroid)
+                                        : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                                })
+                                : (Func<Result<Point3d>>)(() => extrusion.GetBoundingBox(accurate: true) switch {
+                                    BoundingBox box when box.IsValid => ResultFactory.Create(value: box.Center),
+                                    _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+                                }))(),
+                        (true, Mesh mesh) => (mesh.IsClosed
+                            ? (Func<Result<Point3d>>)(() => {
+                                using VolumeMassProperties? properties = VolumeMassProperties.Compute(mesh);
+                                return properties?.Centroid is Point3d centroid
+                                    ? ResultFactory.Create(value: centroid)
+                                    : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                            })
+                            : (Func<Result<Point3d>>)(() => {
+                                using AreaMassProperties? properties = AreaMassProperties.Compute(mesh);
+                                return properties?.Centroid is Point3d centroid
+                                    ? ResultFactory.Create(value: centroid)
+                                    : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed);
+                            }))(),
+                        (_, PointCloud cloud) => cloud.GetBoundingBox(accurate: true) switch {
+                            BoundingBox box when box.IsValid => ResultFactory.Create(value: box.Center),
+                            _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+                        },
+                        (false, GeometryBase geometryBase) => geometryBase.GetBoundingBox(accurate: true) switch {
+                            BoundingBox box when box.IsValid => ResultFactory.Create(value: box.Center),
+                            _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+                        },
+                        _ => ResultFactory.Create<Point3d>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name)),
+                    });
+            });
+
+    internal static Result<Plane> ExtractPlane(GeometryBase geometry, IGeometryContext context) =>
+        ResolveKind(geometry)
+            .Bind(metadata => {
+                Type runtimeType = geometry.GetType();
+                V configuredMode;
+                V baseMode = OrientConfig.ValidationModes.TryGetValue(runtimeType, out configuredMode) ? configuredMode : V.Standard;
+                V validationMode = baseMode | metadata.PlaneMode;
+
+                return ResultFactory.Create(value: geometry)
+                    .Validate(args: [context, validationMode,])
+                    .Bind(valid => valid switch {
+                        Curve curve => curve.FrameAt(curve.Domain.Mid, out Plane frame) && frame.IsValid
+                            ? ResultFactory.Create(value: frame)
+                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+                        Surface surface => surface.FrameAt(surface.Domain(0).Mid, surface.Domain(1).Mid, out Plane frame) && frame.IsValid
+                            ? ResultFactory.Create(value: frame)
+                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+                        Brep brep => ((Func<Result<Plane>>)(() => {
+                            Vector3d normal = brep.Faces.Count > 0 ? brep.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis;
+                            bool solid = brep.IsSolid;
+                            bool oriented = brep.SolidOrientation != BrepSolidOrientation.None;
+                            return (solid
+                                ? (Func<Result<Plane>>)(() => {
+                                    using VolumeMassProperties? properties = VolumeMassProperties.Compute(brep);
+                                    return properties?.Centroid is Point3d centroid
+                                        ? ResultFactory.Create(value: new Plane(centroid, normal))
+                                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                })
+                                : oriented
+                                    ? (Func<Result<Plane>>)(() => {
+                                        using AreaMassProperties? properties = AreaMassProperties.Compute(brep);
+                                        return properties?.Centroid is Point3d centroid
+                                            ? ResultFactory.Create(value: new Plane(centroid, normal))
+                                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                    })
+                                    : (Func<Result<Plane>>)(() => {
+                                        BoundingBox box = brep.GetBoundingBox(accurate: true);
+                                        return box.IsValid
+                                            ? ResultFactory.Create(value: new Plane(box.Center, normal))
+                                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                    }))();
+                        }))(),
+                        Extrusion extrusion => ((Func<Result<Plane>>)(() => {
+                            using LineCurve path = extrusion.PathLineCurve();
+                            Vector3d tangent = path.TangentAtStart;
+                            bool solid = extrusion.IsSolid;
+                            bool closed = extrusion.IsClosed(0) && extrusion.IsClosed(1);
+                            return (solid
+                                ? (Func<Result<Plane>>)(() => {
+                                    using VolumeMassProperties? properties = VolumeMassProperties.Compute(extrusion);
+                                    return properties?.Centroid is Point3d centroid
+                                        ? ResultFactory.Create(value: new Plane(centroid, tangent))
+                                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                })
+                                : closed
+                                    ? (Func<Result<Plane>>)(() => {
+                                        using AreaMassProperties? properties = AreaMassProperties.Compute(extrusion);
+                                        return properties?.Centroid is Point3d centroid
+                                            ? ResultFactory.Create(value: new Plane(centroid, tangent))
+                                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                    })
+                                    : (Func<Result<Plane>>)(() => {
+                                        BoundingBox box = extrusion.GetBoundingBox(accurate: true);
+                                        return box.IsValid
+                                            ? ResultFactory.Create(value: new Plane(box.Center, tangent))
+                                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                    }))();
+                        }))(),
+                        Mesh mesh => ((Func<Result<Plane>>)(() => {
+                            Vector3d normal = mesh.Normals.Count > 0 ? mesh.Normals[0] : Vector3d.ZAxis;
+                            bool solid = mesh.IsClosed;
+                            return (solid
+                                ? (Func<Result<Plane>>)(() => {
+                                    using VolumeMassProperties? properties = VolumeMassProperties.Compute(mesh);
+                                    return properties?.Centroid is Point3d centroid
+                                        ? ResultFactory.Create(value: new Plane(centroid, normal))
+                                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                })
+                                : (Func<Result<Plane>>)(() => {
+                                    using AreaMassProperties? properties = AreaMassProperties.Compute(mesh);
+                                    return properties?.Centroid is Point3d centroid
+                                        ? ResultFactory.Create(value: new Plane(centroid, normal))
+                                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                                }))();
+                        }))(),
+                        PointCloud cloud => cloud.Count > 0
+                            ? ResultFactory.Create(value: new Plane(cloud[0].Location, Vector3d.ZAxis))
+                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+                        _ => ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name)),
+                    });
+            });
+
+    internal static Result<Plane> ExtractBestFitPlane(GeometryBase geometry, IGeometryContext context) =>
+        ResolveKind(geometry)
+            .Bind(metadata => metadata.SupportsBestFit
+                ? ((Func<Result<Plane>>)(() => {
+                    Type runtimeType = geometry.GetType();
+                    V configuredMode;
+                    V baseMode = OrientConfig.ValidationModes.TryGetValue(runtimeType, out configuredMode) ? configuredMode : V.Standard;
+                    V validationMode = baseMode | V.Degeneracy;
+
+                    return ResultFactory.Create(value: geometry)
+                        .Validate(args: [context, validationMode,])
+                        .Bind(valid => valid switch {
+                            Mesh mesh => mesh.Vertices.Count >= OrientConfig.BestFitMinPoints && Plane.FitPlaneToPoints(mesh.Vertices.ToPoint3dArray(), out Plane plane) == PlaneFitResult.Success
+                                ? ResultFactory.Create(value: plane)
+                                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+                            PointCloud cloud => cloud.Count >= OrientConfig.BestFitMinPoints && Plane.FitPlaneToPoints(cloud.GetPoints(), out Plane plane) == PlaneFitResult.Success
+                                ? ResultFactory.Create(value: plane)
+                                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+                            _ => ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name)),
+                        });
+                }))()
+                : ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)));
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<IReadOnlyList<T>> ApplyTransform<T>(T geometry, Transform xform) where T : GeometryBase =>
-        (T)geometry.Duplicate() switch {
-            T dup when dup.Transform(xform) => ResultFactory.Create(value: (IReadOnlyList<T>)[dup,]),
-            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed),
-        };
+    internal static Result<IReadOnlyList<T>> ApplyTransform<T>(T geometry, Transform transform) where T : GeometryBase =>
+        ResolveKind(geometry)
+            .Bind(_ => {
+                GeometryBase? duplicate = geometry switch {
+                    Curve curve => (GeometryBase?)curve.DuplicateCurve(),
+                    Surface surface => surface.DuplicateSurface(),
+                    Brep brep => brep.DuplicateBrep(),
+                    Extrusion extrusion => extrusion.Duplicate(),
+                    Mesh mesh => mesh.DuplicateMesh(),
+                    PointCloud cloud => cloud.Duplicate(),
+                    _ => null,
+                };
 
-    /// <summary>Best-fit plane from point cloud or mesh via PCA.</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<Plane> ExtractBestFitPlane(GeometryBase geometry) =>
-        geometry switch {
-            PointCloud pc when pc.Count > 0 => Plane.FitPlaneToPoints(pc.GetPoints(), out Plane plane) == PlaneFitResult.Success
-                ? ResultFactory.Create(value: plane)
-                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            Mesh m when m.Vertices.Count > 0 => Plane.FitPlaneToPoints(m.Vertices.ToPoint3dArray(), out Plane plane) == PlaneFitResult.Success
-                ? ResultFactory.Create(value: plane)
-                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
-            _ => ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
-        };
+                return duplicate is null
+                    ? ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed)
+                    : duplicate.Transform(transform)
+                        ? duplicate is T typed
+                            ? ResultFactory.Create(value: (IReadOnlyList<T>)[typed,])
+                            : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name))
+                        : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed);
+            });
+
+    internal static Result<T> FlipGeometry<T>(T geometry) where T : GeometryBase =>
+        ResolveKind(geometry)
+            .Bind(_ => geometry switch {
+                Curve curve => ResultFactory.Create(value: curve.DuplicateCurve())
+                    .Bind(duplicate => duplicate is null
+                        ? ResultFactory.Create<T>(error: E.Geometry.TransformFailed)
+                        : duplicate.Reverse()
+                            ? duplicate is T typed
+                                ? ResultFactory.Create(value: typed)
+                                : ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name))
+                            : ResultFactory.Create<T>(error: E.Geometry.TransformFailed)),
+                Brep brep => ResultFactory.Create(value: brep.DuplicateBrep())
+                    .Bind(duplicate => duplicate is null
+                        ? ResultFactory.Create<T>(error: E.Geometry.TransformFailed)
+                        : ((Func<Result<T>>)(() => {
+                            duplicate.Flip();
+                            return duplicate is T typed
+                                ? ResultFactory.Create(value: typed)
+                                : ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name));
+                        }))()),
+                Extrusion extrusion => ResultFactory.Create(value: extrusion.ToBrep())
+                    .Bind(brep => brep is null
+                        ? ResultFactory.Create<T>(error: E.Geometry.TransformFailed)
+                        : ((Func<Result<T>>)(() => {
+                            brep.Flip();
+                            return Extrusion.TryGetExtrusion(brep, out Extrusion? extracted) && extracted is not null
+                                ? extracted is T typed
+                                    ? ResultFactory.Create(value: typed)
+                                    : ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name))
+                                : ResultFactory.Create<T>(error: E.Geometry.TransformFailed);
+                        }))()),
+                Mesh mesh => ResultFactory.Create(value: mesh.DuplicateMesh())
+                    .Bind(duplicate => duplicate is null
+                        ? ResultFactory.Create<T>(error: E.Geometry.TransformFailed)
+                        : ((Func<Result<T>>)(() => {
+                            duplicate.Flip(vertexNormals: true, faceNormals: true, faceOrientation: true);
+                            return duplicate is T typed
+                                ? ResultFactory.Create(value: typed)
+                                : ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name));
+                        }))()),
+                PointCloud cloud => ResultFactory.Create(value: cloud.Duplicate())
+                    .Bind(duplicate => duplicate is null
+                        ? ResultFactory.Create<T>(error: E.Geometry.TransformFailed)
+                        : duplicate is T typed
+                            ? ResultFactory.Create(value: typed)
+                            : ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name))),
+                _ => ResultFactory.Create<T>(error: E.Geometry.UnsupportedOrientationType.WithContext(typeof(T).Name)),
+            });
 }


### PR DESCRIPTION
## Summary
- integrate orientation type metadata directly into the frozen lookup to eliminate standalone kind constants
- consume the stored plane-mode and best-fit flags during plane and best-fit extraction to reduce branching and keep validation dense

## Testing
- `dotnet build` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912937e39c4832183e67a54a7812f07)