### PR TITLE
Fix disposable handling in topology healing

### DIFF
--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -127,7 +127,7 @@ internal static class TopologyCompute {
 
                     return bestHealed is Brep healed
                         ? ResultFactory.Create<(Brep, byte, bool)>(value: (healed, bestStrategy, bestNakedEdges < originalNakedEdges))
-                        : ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.HealingFailed.WithContext(string.Create(CultureInfo.InvariantCulture, $"All {strategyCount.ToString(CultureInfo.InvariantCulture)} strategies failed")));
+                        : ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.HealingFailed.WithContext($"All {strategyCount.ToString(CultureInfo.InvariantCulture)} strategies failed"));
                 }))());
 
     [Pure]

--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -109,18 +109,15 @@ internal static class TopologyCompute {
                             ? (true, copy.Edges.Count(e => e.Valence == EdgeAdjacency.Naked))
                             : (false, int.MaxValue);
                         bool isImprovement = evaluation.IsValid && evaluation.NakedEdges < originalNakedEdges && evaluation.NakedEdges < bestNakedEdges;
-                        Brep? previousHealed = bestHealed;
-                        byte previousStrategy = bestStrategy;
-                        int previousNakedEdges = bestNakedEdges;
 
-                        (bestHealed, bestStrategy, bestNakedEdges) = (isImprovement, previousHealed) switch {
+                        (bestHealed, bestStrategy, bestNakedEdges) = (isImprovement, bestHealed) switch {
                             (true, Brep? prev) => ((Func<(Brep?, byte, int)>)(() => {
                                 prev?.Dispose();
                                 return (copy, strategy, evaluation.NakedEdges);
                             }))(),
                             (_, Brep? prev) => ((Func<(Brep?, byte, int)>)(() => {
                                 copy.Dispose();
-                                return (prev, previousStrategy, previousNakedEdges);
+                                return (prev, bestStrategy, bestNakedEdges);
                             }))(),
                         };
                     }


### PR DESCRIPTION
## Summary
- dispose unused Brep duplicates while evaluating topology healing strategies
- retain only the best healing result and release superseded brep instances
- report attempted strategy count when healing cannot improve the model

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912eda0b9788321820f347eb6484e43)