### PR TITLE
Refine Rhino orientation pattern detection checks

### DIFF
--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -54,7 +54,7 @@ internal static class OrientCompute {
                             }),
                             ];
 
-                            return results.MaxBy(r => r.Item2) is (Transform best, double bestScore, byte[] met) && bestScore > 0.0
+                            return results.MaxBy(r => r.Item2) is (Transform best, double bestScore, byte[] met) && bestScore >= OrientConfig.MinimumOptimizationScore
                                 ? ResultFactory.Create(value: (best, bestScore, met))
                                 : ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.TransformFailed.WithContext("No valid orientation found"));
                         }))()
@@ -152,10 +152,39 @@ internal static class OrientCompute {
                         Result<Point3d>[] centroidResults = [.. validGeometries.Select(g => OrientCore.ExtractCentroid(g, useMassProperties: false)),];
                         return centroidResults.All(r => r.IsSuccess)
                             ? centroidResults.Select(r => r.Value).ToArray() is Point3d[] centroids && centroids.Length >= 3 && centroids.Skip(1).Zip(centroids, (c2, c1) => c2 - c1).ToArray() is Vector3d[] deltas && deltas.Average(v => v.Length) is double avgLen && avgLen > context.AbsoluteTolerance
-                                ? deltas.All(v => Math.Abs(v.Length - avgLen) / avgLen < context.AbsoluteTolerance)
-                                    ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (0, [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Translation(deltas[0] * i)),], [.. deltas.Select((v, i) => (v, i)).Where(pair => Math.Abs(pair.v.Length - avgLen) / avgLen >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.i),], deltas.Sum(v => Math.Abs(v.Length - avgLen)) / centroids.Length))
+                                ? deltas.Length > 0 && new Vector3d(deltas[0]) is Vector3d baseVector && baseVector.Unitize() && deltas.All(v =>
+                                    new Vector3d(v) is Vector3d direction && direction.Unitize()
+                                        && Vector3d.VectorAngle(direction, baseVector) <= context.AngleToleranceRadians
+                                        && Math.Abs(v.Length - avgLen) / avgLen < context.AbsoluteTolerance)
+                                    ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (0,
+                                        [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Translation(baseVector * (avgLen * i))),],
+                                        [.. deltas.Select((vector, index) => {
+                                            Vector3d candidate = new(vector);
+                                            bool success = candidate.Unitize();
+                                            double angleDifference = success ? Vector3d.VectorAngle(candidate, baseVector) : double.PositiveInfinity;
+                                            return (vector, index, angleDifference);
+                                        }).Where(entry =>
+                                            Math.Abs(entry.vector.Length - avgLen) / avgLen >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)
+                                            || entry.angleDifference > (context.AngleToleranceRadians * OrientConfig.PatternAnomalyThreshold)).Select(entry => entry.index),],
+                                        deltas.Sum(v => Math.Abs(v.Length - avgLen)) / centroids.Length
+                                            + deltas.Select(v => {
+                                                Vector3d normalized = new(v);
+                                                return normalized.Unitize() ? Vector3d.VectorAngle(normalized, baseVector) : double.NaN;
+                                            }).Where(angle => !double.IsNaN(angle)).DefaultIfEmpty(0.0).Average()))
                                     : new Point3d(centroids.Average(p => p.X), centroids.Average(p => p.Y), centroids.Average(p => p.Z)) is Point3d center && centroids.Select(p => p.DistanceTo(center)).ToArray() is double[] radii && radii.Average() is double avgRadius && avgRadius > context.AbsoluteTolerance && radii.All(r => Math.Abs(r - avgRadius) / avgRadius < context.AbsoluteTolerance)
-                                        ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (1, [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Rotation(2.0 * Math.PI * i / centroids.Length, Vector3d.ZAxis, center)),], [.. radii.Select((r, i) => (r, i)).Where(pair => Math.Abs(pair.r - avgRadius) / avgRadius >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.i),], radii.Sum(r => Math.Abs(r - avgRadius)) / centroids.Length))
+                                        ? centroids.Select((point, index) => (point, index, vector: point - center)).Select(tuple => (tuple.point, tuple.index, vector: tuple.vector, angle: Math.Atan2(tuple.vector.Y, tuple.vector.X) is double raw && raw < 0.0 ? raw + (2.0 * Math.PI) : raw)).OrderBy(pair => pair.angle).ToArray() is (Point3d point, int index, Vector3d vector, double angle)[] ordered && ordered.Length == centroids.Length
+                                            ? (2.0 * Math.PI) / centroids.Length is double expectedSpacing && ordered.Select((entry, idx) => (entry, idx)).ToArray() is ((Point3d point, int index, Vector3d vector, double angle) entry, int idx)[] enumerated
+                                                && enumerated.Select(item => item.entry.angle).Zip(enumerated.Skip(1).Select(item => item.entry.angle).Append(enumerated[0].entry.angle + (2.0 * Math.PI)), (current, next) => next - current).ToArray() is double[] angleDiffs
+                                                && angleDiffs.All(diff => Math.Abs(diff - expectedSpacing) <= (context.AngleToleranceRadians * OrientConfig.PatternAnomalyThreshold))
+                                                ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (1,
+                                                    [.. enumerated.Select(item => (
+                                                        item.entry.index,
+                                                        Transform: Transform.Rotation(((enumerated[0].entry.angle + (expectedSpacing * item.idx)) - item.entry.angle), Vector3d.ZAxis, center))).OrderBy(pair => pair.index).Select(pair => pair.Transform),],
+                                                    [.. angleDiffs.Select((diff, idx) => (diff, idx)).Where(pair => Math.Abs(pair.diff - expectedSpacing) > (context.AngleToleranceRadians * OrientConfig.PatternAnomalyThreshold)).Select(pair => enumerated[pair.idx].entry.index),],
+                                                    radii.Sum(r => Math.Abs(r - avgRadius)) / centroids.Length
+                                                        + angleDiffs.Sum(diff => Math.Abs(diff - expectedSpacing)) / centroids.Length))
+                                                : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern angles not uniform"))
+                                            : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern ordering failed"))
                                         : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern too irregular"))
                                 : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Insufficient valid centroids"))
                             : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext($"Centroid extraction failed for {centroidResults.Count(r => !r.IsSuccess)} geometries"));


### PR DESCRIPTION
## Summary
- enforce the configured minimum score when choosing optimized orientation transforms
- tighten translation pattern detection to require direction alignment and report angular anomalies
- validate radial pattern angle spacing and build per-geometry correction transforms for consistent alignment

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912ed8f069083219a889f9c1c0a1e41)