### PR TITLE
Fix disposal of Rhino mass property computations in extraction

### DIFF
--- a/libs/rhino/extraction/ExtractionCompute.cs
+++ b/libs/rhino/extraction/ExtractionCompute.cs
@@ -110,7 +110,10 @@ internal static class ExtractionCompute {
                 => (true, Math.PI * ell.Radius1 * ell.Radius2),
             _ when c.TryGetPolyline(out Polyline pl) && pl.Count >= ExtractionConfig.MinHolePolySides => (
                 true,
-                AreaMassProperties.Compute(c) is AreaMassProperties amp && amp.Area is double area ? area : 0.0
+                ((Func<double>)(() => {
+                    using AreaMassProperties? massProperties = AreaMassProperties.Compute(c);
+                    return massProperties is { Area: double holeArea } ? holeArea : 0.0;
+                }))()
             ),
             _ => (false, 0.0),
         };


### PR DESCRIPTION
## Summary
- dispose Rhino mass property results when computing analytical extraction centroids
- ensure Brep hole classification releases AreaMassProperties instances

## Testing
- dotnet build *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912ed6a5cc883218757a194f4ab0908)