### PR TITLE
Review and apply coding style guidelines

### DIFF
--- a/libs/rhino/analysis/Analysis.cs
+++ b/libs/rhino/analysis/Analysis.cs
@@ -108,9 +108,8 @@ public static class Analysis {
         Curve curve,
         IGeometryContext context,
         double? parameter = null,
-        int derivativeOrder = 2,
-        bool enableDiagnostics = false) =>
-        AnalysisCore.Execute(curve, context, t: parameter, uv: null, index: null, testPoint: null, derivativeOrder: derivativeOrder, enableDiagnostics: enableDiagnostics)
+        int derivativeOrder = 2) =>
+        AnalysisCore.Execute(curve, context, t: parameter, uv: null, index: null, testPoint: null, derivativeOrder: derivativeOrder)
             .Map(results => (CurveData)results[0]);
 
     /// <summary>Surface analysis: derivatives, curvature, frames, singularities.</summary>
@@ -119,9 +118,8 @@ public static class Analysis {
         Surface surface,
         IGeometryContext context,
         (double u, double v)? uvParameter = null,
-        int derivativeOrder = 2,
-        bool enableDiagnostics = false) =>
-        AnalysisCore.Execute(surface, context, t: null, uv: uvParameter, index: null, testPoint: null, derivativeOrder: derivativeOrder, enableDiagnostics: enableDiagnostics)
+        int derivativeOrder = 2) =>
+        AnalysisCore.Execute(surface, context, t: null, uv: uvParameter, index: null, testPoint: null, derivativeOrder: derivativeOrder)
             .Map(results => (SurfaceData)results[0]);
 
     /// <summary>Brep analysis: surface evaluation, topology, proximity.</summary>
@@ -132,9 +130,8 @@ public static class Analysis {
         (double u, double v)? uvParameter = null,
         int faceIndex = 0,
         Point3d? testPoint = null,
-        int derivativeOrder = 2,
-        bool enableDiagnostics = false) =>
-        AnalysisCore.Execute(brep, context, t: null, uv: uvParameter, index: faceIndex, testPoint: testPoint, derivativeOrder: derivativeOrder, enableDiagnostics: enableDiagnostics)
+        int derivativeOrder = 2) =>
+        AnalysisCore.Execute(brep, context, t: null, uv: uvParameter, index: faceIndex, testPoint: testPoint, derivativeOrder: derivativeOrder)
             .Map(results => (BrepData)results[0]);
 
     /// <summary>Mesh analysis: topology navigation, manifold inspection.</summary>
@@ -142,9 +139,8 @@ public static class Analysis {
     public static Result<MeshData> Analyze(
         Mesh mesh,
         IGeometryContext context,
-        int vertexIndex = 0,
-        bool enableDiagnostics = false) =>
-        AnalysisCore.Execute(mesh, context, t: null, uv: null, index: vertexIndex, testPoint: null, derivativeOrder: 0, enableDiagnostics: enableDiagnostics)
+        int vertexIndex = 0) =>
+        AnalysisCore.Execute(mesh, context, t: null, uv: null, index: vertexIndex, testPoint: null, derivativeOrder: 0)
             .Map(results => (MeshData)results[0]);
 
     /// <summary>Batch analysis for heterogeneous geometry types.</summary>
@@ -156,19 +152,18 @@ public static class Analysis {
         (double u, double v)? uvParameter = null,
         int? index = null,
         Point3d? testPoint = null,
-        int derivativeOrder = 2,
-        bool enableDiagnostics = false) where T : notnull =>
+        int derivativeOrder = 2) where T : notnull =>
         UnifiedOperation.Apply(
             geometries,
             (Func<object, Result<IReadOnlyList<IResult>>>)(item =>
-                AnalysisCore.Execute(item, context, parameter, uvParameter, index, testPoint, derivativeOrder, enableDiagnostics: enableDiagnostics)),
+                AnalysisCore.Execute(item, context, parameter, uvParameter, index, testPoint, derivativeOrder)),
             new OperationConfig<object, IResult> {
                 Context = context,
                 ValidationMode = Core.Validation.V.None,
                 EnableCache = true,
                 AccumulateErrors = false,
                 OperationName = "Analysis.Multiple",
-                EnableDiagnostics = enableDiagnostics,
+                EnableDiagnostics = false,
             });
 
     /// <summary>Surface quality: curvature distribution, singularities, uniformity score.</summary>

--- a/libs/rhino/analysis/AnalysisCore.cs
+++ b/libs/rhino/analysis/AnalysisCore.cs
@@ -134,8 +134,7 @@ internal static class AnalysisCore {
         (double, double)? uv,
         int? index,
         Point3d? testPoint,
-        int derivativeOrder,
-        bool enableDiagnostics = false) =>
+        int derivativeOrder) =>
         _strategies.TryGetValue(geometry.GetType(), out (V mode, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>> compute) strategy)
             ? UnifiedOperation.Apply(
                 geometry,
@@ -150,7 +149,7 @@ internal static class AnalysisCore {
                     Context = context,
                     ValidationMode = V.None,
                     OperationName = $"Analysis.{geometry.GetType().Name}",
-                    EnableDiagnostics = enableDiagnostics,
+                    EnableDiagnostics = false,
                     AccumulateErrors = false,
                     EnableCache = false,
                     SkipInvalid = false,

--- a/libs/rhino/intersection/Intersect.cs
+++ b/libs/rhino/intersection/Intersect.cs
@@ -37,8 +37,7 @@ public static class Intersect {
         T1 geometryA,
         T2 geometryB,
         IGeometryContext context,
-        IntersectionOptions? options = null,
-        bool enableDiagnostics = false) where T1 : notnull where T2 : notnull {
+        IntersectionOptions? options = null) where T1 : notnull where T2 : notnull {
         IntersectionOptions opts = options ?? new IntersectionOptions();
         (Type t1, Type t2) = (typeof(T1), typeof(T2));
 
@@ -56,7 +55,7 @@ public static class Intersect {
                     ValidationMode = V.None,
                     AccumulateErrors = true,
                     OperationName = $"Intersect.{t1.Name}.{t2.Name}",
-                    EnableDiagnostics = enableDiagnostics,
+                    EnableDiagnostics = false,
                 }))
         .Map(outputs => outputs.Count switch {
             0 => IntersectionOutput.Empty,

--- a/libs/rhino/spatial/Spatial.cs
+++ b/libs/rhino/spatial/Spatial.cs
@@ -18,8 +18,7 @@ public static class Spatial {
         TInput input,
         TQuery query,
         IGeometryContext context,
-        int? bufferSize = null,
-        bool enableDiagnostics = false) where TInput : notnull where TQuery : notnull =>
+        int? bufferSize = null) where TInput : notnull where TQuery : notnull =>
         SpatialCore.OperationRegistry.TryGetValue((typeof(TInput), typeof(TQuery)), out (Func<object, RTree>? _, V mode, int bufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> execute) config) switch {
             true => UnifiedOperation.Apply(
                 input: input,
@@ -28,7 +27,7 @@ public static class Spatial {
                     Context = context,
                     ValidationMode = config.mode,
                     OperationName = $"Spatial.{typeof(TInput).Name}.{typeof(TQuery).Name}",
-                    EnableDiagnostics = enableDiagnostics,
+                    EnableDiagnostics = false,
                 }),
             false => ResultFactory.Create<IReadOnlyList<int>>(
                 error: E.Spatial.UnsupportedTypeCombo.WithContext(

--- a/libs/rhino/topology/Topology.cs
+++ b/libs/rhino/topology/Topology.cs
@@ -183,34 +183,30 @@ public static class Topology {
     public static Result<NakedEdgeData> GetNakedEdges<T>(
         T geometry,
         IGeometryContext context,
-        bool orderLoops = false,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteNakedEdges(input: geometry, context: context, orderLoops: orderLoops, enableDiagnostics: enableDiagnostics);
+        bool orderLoops = false) where T : notnull =>
+        TopologyCore.ExecuteNakedEdges(input: geometry, context: context, orderLoops: orderLoops);
 
     /// <summary>Closed boundary loops from naked edges.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<BoundaryLoopData> GetBoundaryLoops<T>(
         T geometry,
         IGeometryContext context,
-        double? tolerance = null,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteBoundaryLoops(input: geometry, context: context, tolerance: tolerance, enableDiagnostics: enableDiagnostics);
+        double? tolerance = null) where T : notnull =>
+        TopologyCore.ExecuteBoundaryLoops(input: geometry, context: context, tolerance: tolerance);
 
     /// <summary>Non-manifold vertex and edge detection.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<NonManifoldData> GetNonManifoldData<T>(
         T geometry,
-        IGeometryContext context,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteNonManifold(input: geometry, context: context, enableDiagnostics: enableDiagnostics);
+        IGeometryContext context) where T : notnull =>
+        TopologyCore.ExecuteNonManifold(input: geometry, context: context);
 
     /// <summary>Connected components and adjacency graph.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<ConnectivityData> GetConnectivity<T>(
         T geometry,
-        IGeometryContext context,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteConnectivity(input: geometry, context: context, enableDiagnostics: enableDiagnostics);
+        IGeometryContext context) where T : notnull =>
+        TopologyCore.ExecuteConnectivity(input: geometry, context: context);
 
     /// <summary>Edge classification by continuity type.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -218,35 +214,31 @@ public static class Topology {
         T geometry,
         IGeometryContext context,
         Continuity minimumContinuity = Continuity.G1_continuous,
-        double? angleThreshold = null,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteEdgeClassification(input: geometry, context: context, minimumContinuity: minimumContinuity, angleThreshold: angleThreshold, enableDiagnostics: enableDiagnostics);
+        double? angleThreshold = null) where T : notnull =>
+        TopologyCore.ExecuteEdgeClassification(input: geometry, context: context, minimumContinuity: minimumContinuity, angleThreshold: angleThreshold);
 
     /// <summary>Face adjacency for specific edge.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<AdjacencyData> GetAdjacency<T>(
         T geometry,
         IGeometryContext context,
-        int edgeIndex,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteAdjacency(input: geometry, context: context, edgeIndex: edgeIndex, enableDiagnostics: enableDiagnostics);
+        int edgeIndex) where T : notnull =>
+        TopologyCore.ExecuteAdjacency(input: geometry, context: context, edgeIndex: edgeIndex);
 
     /// <summary>Vertex topology: valence, manifold status.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<VertexData> GetVertexData<T>(
         T geometry,
         IGeometryContext context,
-        int vertexIndex,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteVertexData(input: geometry, context: context, vertexIndex: vertexIndex, enableDiagnostics: enableDiagnostics);
+        int vertexIndex) where T : notnull =>
+        TopologyCore.ExecuteVertexData(input: geometry, context: context, vertexIndex: vertexIndex);
 
     /// <summary>Ngon topology analysis for quad-dominant meshes.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<NgonTopologyData> GetNgonTopology<T>(
         T geometry,
-        IGeometryContext context,
-        bool enableDiagnostics = false) where T : notnull =>
-        TopologyCore.ExecuteNgonTopology(input: geometry, context: context, enableDiagnostics: enableDiagnostics);
+        IGeometryContext context) where T : notnull =>
+        TopologyCore.ExecuteNgonTopology(input: geometry, context: context);
 
     /// <summary>Diagnose topology problems with edge gaps, near-misses, repair suggestions.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Removed bool enableDiagnostics parameters from all public APIs and internal methods in libs/rhino/. Changed all OperationConfig initializations to use EnableDiagnostics = false directly instead of passing through a parameter.

Changes:
- Spatial.cs: Removed enableDiagnostics parameter from Analyze<TInput, TQuery>
- Intersect.cs: Removed enableDiagnostics parameter from Execute<T1, T2>
- Analysis.cs: Removed enableDiagnostics from all 5 Analyze methods and AnalyzeMultiple
- AnalysisCore.cs: Removed enableDiagnostics from internal Execute method
- Topology.cs: Removed enableDiagnostics from all 8 public topology methods
- TopologyCore.cs: Removed enableDiagnostics from all 9 internal methods and private Execute helper

All EnableDiagnostics config values now hardcoded to false.