### PR TITLE
Review codebase style and formatting guidelines

### DIFF
--- a/libs/rhino/extraction/Extract.cs
+++ b/libs/rhino/extraction/Extract.cs
@@ -89,7 +89,7 @@ public static class Extract {
         };
 
         return requestResult.Bind(request =>
-            UnifiedOperation.Apply(input, (Func<T, Result<IReadOnlyList<Point3d>>>)(item => ExtractionCore.Execute(item, request, context)), new OperationConfig<T, Point3d> { Context = context, ValidationMode = request.ValidationMode, }));
+            UnifiedOperation.Apply(input, (Func<T, Result<IReadOnlyList<Point3d>>>)(item => ExtractionCore.Execute(item, request, context)), new OperationConfig<T, Point3d> { Context = context, ValidationMode = request.ValidationMode, EnableDiagnostics = false, }));
     }
 
     /// <summary>Batch point extraction with error accumulation and parallelism.</summary>
@@ -126,7 +126,7 @@ public static class Extract {
         };
 
         return requestResult.Bind(request =>
-            UnifiedOperation.Apply(input, (Func<T, Result<IReadOnlyList<Curve>>>)(item => ExtractionCore.ExecuteCurves(item, request, context)), new OperationConfig<T, Curve> { Context = context, ValidationMode = request.ValidationMode, }));
+            UnifiedOperation.Apply(input, (Func<T, Result<IReadOnlyList<Curve>>>)(item => ExtractionCore.ExecuteCurves(item, request, context)), new OperationConfig<T, Curve> { Context = context, ValidationMode = request.ValidationMode, EnableDiagnostics = false, }));
     }
 
     /// <summary>Batch curve extraction with error accumulation and parallelism.</summary>

--- a/libs/rhino/orientation/Orient.cs
+++ b/libs/rhino/orientation/Orient.cs
@@ -71,6 +71,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = OrientConfig.ValidationModes.GetValueOrDefault(typeof(T), V.Standard),
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -90,6 +91,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = mode.Mode is (>= 1 and <= 4) ? V.Standard | V.BoundingBox : mode.Mode is 5 ? V.Standard | V.MassProperties : V.Standard,
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -103,6 +105,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = useMass ? V.Standard | V.MassProperties : V.Standard | V.BoundingBox,
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -131,6 +134,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = V.Standard,
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -143,6 +147,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = V.Standard,
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -156,6 +161,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = OrientConfig.ValidationModes.GetValueOrDefault(typeof(T), V.Standard),
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -177,6 +183,7 @@ public static class Orient {
             config: new OperationConfig<T, T> {
                 Context = context,
                 ValidationMode = OrientConfig.ValidationModes.GetValueOrDefault(typeof(T), V.Standard),
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -208,6 +215,7 @@ public static class Orient {
             config: new OperationConfig<Brep, (Transform, double, byte[])> {
                 Context = context,
                 ValidationMode = V.Standard | V.Topology,
+                EnableDiagnostics = false,
             }).Map(r => r[0]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Ensures consistency across all libs/rhino/ main files by explicitly setting EnableDiagnostics = false in OperationConfig for all UnifiedOperation.Apply calls.

Changes:
- Extract.cs: Added EnableDiagnostics = false to 2 UnifiedOperation calls
- Orient.cs: Added EnableDiagnostics = false to 8 UnifiedOperation calls

All changes follow K&R brace style, use trailing commas, and maintain explicit type declarations per coding standards.