### PR TITLE
Refactor FrozenDicts with SelectMany pattern

### DIFF
--- a/libs/rhino/extraction/ExtractionCore.cs
+++ b/libs/rhino/extraction/ExtractionCore.cs
@@ -276,10 +276,9 @@ internal static class ExtractionCore {
         FrozenDictionary<byte, (Type GeometryType, Func<GeometryBase, Extract.Request, IGeometryContext, Result<Point3d[]>> Handler)[]> fallbacks = map
             .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
-                static group => group.Key,
-                group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
+                static group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
                     .Select(static entry => (entry.Key.GeometryType, entry.Value))
-                    .ToArray())
+                    .ToArray()
             .ToFrozenDictionary();
         return (map.ToFrozenDictionary(), fallbacks);
     }

--- a/libs/rhino/extraction/ExtractionCore.cs
+++ b/libs/rhino/extraction/ExtractionCore.cs
@@ -274,11 +274,11 @@ internal static class ExtractionCore {
                 : ResultFactory.Create<Point3d[]>(error: E.Geometry.InvalidExtraction.WithContext("Expected Curve and continuity")),
         };
         FrozenDictionary<byte, (Type GeometryType, Func<GeometryBase, Extract.Request, IGeometryContext, Result<Point3d[]>> Handler)[]> fallbacks = map
-            .GroupBy(entry => entry.Key.Kind)
+            .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
-                group => group.Key,
-                group => group.OrderByDescending(entry => entry.Key.GeometryType, _specificityComparer)
-                    .Select(entry => (entry.Key.GeometryType, entry.Value))
+                static group => group.Key,
+                group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
+                    .Select(static entry => (entry.Key.GeometryType, entry.Value))
                     .ToArray())
             .ToFrozenDictionary();
         return (map.ToFrozenDictionary(), fallbacks);
@@ -333,11 +333,11 @@ internal static class ExtractionCore {
                 : ResultFactory.Create<Curve[]>(error: E.Geometry.InvalidExtraction.WithContext("Invalid angle or brep")),
         };
         FrozenDictionary<byte, (Type GeometryType, Func<GeometryBase, Extract.Request, IGeometryContext, Result<Curve[]>> Handler)[]> fallbacks = map
-            .GroupBy(entry => entry.Key.Kind)
+            .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
-                group => group.Key,
-                group => group.OrderByDescending(entry => entry.Key.GeometryType, _specificityComparer)
-                    .Select(entry => (entry.Key.GeometryType, entry.Value))
+                static group => group.Key,
+                group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
+                    .Select(static entry => (entry.Key.GeometryType, entry.Value))
                     .ToArray())
             .ToFrozenDictionary();
         return (map.ToFrozenDictionary(), fallbacks);

--- a/libs/rhino/extraction/ExtractionCore.cs
+++ b/libs/rhino/extraction/ExtractionCore.cs
@@ -336,7 +336,7 @@ internal static class ExtractionCore {
             .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
                 static group => group.Key,
-                group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
+                static group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
                     .Select(static entry => (entry.Key.GeometryType, entry.Value))
                     .ToArray())
             .ToFrozenDictionary();

--- a/libs/rhino/intersection/IntersectionConfig.cs
+++ b/libs/rhino/intersection/IntersectionConfig.cs
@@ -72,7 +72,7 @@ internal static class IntersectionConfig {
             (typeof(Point3d[]), typeof(Mesh[]), V.None, V.None),
             (typeof(Ray3d), typeof(GeometryBase[]), V.None, V.None),
         }
-        .SelectMany<(Type TypeA, Type TypeB, V ModeA, V ModeB), KeyValuePair<(Type, Type), (V ModeA, V ModeB)>>(p => p.TypeA == p.TypeB
+        .SelectMany<(Type TypeA, Type TypeB, V ModeA, V ModeB), KeyValuePair<(Type, Type), (V ModeA, V ModeB)>>(static p => p.TypeA == p.TypeB
             ? [KeyValuePair.Create((p.TypeA, p.TypeB), (p.ModeA, p.ModeB)),]
             : [
                 KeyValuePair.Create((p.TypeA, p.TypeB), (p.ModeA, p.ModeB)),

--- a/libs/rhino/intersection/IntersectionCore.cs
+++ b/libs/rhino/intersection/IntersectionCore.cs
@@ -222,7 +222,7 @@ internal static class IntersectionCore {
                 int hits => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidMaxHits.WithContext(hits.ToString(CultureInfo.InvariantCulture))),
                 _ => ResultFactory.Create<Intersect.IntersectionOutput>(error: E.Geometry.InvalidMaxHits),
             }),
-        }.ToFrozenDictionary(entry => entry.Key, entry => {
+        }.ToFrozenDictionary(static entry => entry.Key, entry => {
             (V ModeA, V ModeB) = IntersectionConfig.ValidationModes.TryGetValue(entry.Key, out (V ModeA, V ModeB) found)
                 ? found
                 : (V.None, V.None);

--- a/libs/rhino/topology/TopologyCore.cs
+++ b/libs/rhino/topology/TopologyCore.cs
@@ -210,7 +210,7 @@ internal static class TopologyCore {
         }),
         ];
         IReadOnlyList<double> measures = [.. edgeIndices.Select(i => brep.Edges[i].GetLength()),];
-        FrozenDictionary<Topology.EdgeContinuityType, IReadOnlyList<int>> grouped = edgeIndices.Select((idx, pos) => (idx, type: classifications[pos])).GroupBy(x => x.type, x => x.idx).ToFrozenDictionary(g => g.Key, g => (IReadOnlyList<int>)[.. g,]);
+        FrozenDictionary<Topology.EdgeContinuityType, IReadOnlyList<int>> grouped = edgeIndices.Select((idx, pos) => (idx, type: classifications[pos])).GroupBy(static x => x.type, static x => x.idx).ToFrozenDictionary(static g => g.Key, static g => (IReadOnlyList<int>)[.. g,]);
         return ResultFactory.Create(value: (IReadOnlyList<Topology.EdgeClassificationData>)[new Topology.EdgeClassificationData(EdgeIndices: edgeIndices, Classifications: classifications, ContinuityMeasures: measures, GroupedByType: grouped, MinimumContinuity: minContinuity),]);
     }
 
@@ -230,7 +230,7 @@ internal static class TopologyCore {
         }),
         ];
         IReadOnlyList<double> measures = [.. edgeIndices.Select(i => mesh.TopologyEdges.GetTopologyVertices(i) switch { IndexPair verts => mesh.TopologyVertices[verts.I].DistanceTo(mesh.TopologyVertices[verts.J]) }),];
-        FrozenDictionary<Topology.EdgeContinuityType, IReadOnlyList<int>> grouped = edgeIndices.Select((idx, pos) => (idx, type: classifications[pos])).GroupBy(x => x.type, x => x.idx).ToFrozenDictionary(g => g.Key, g => (IReadOnlyList<int>)[.. g,]);
+        FrozenDictionary<Topology.EdgeContinuityType, IReadOnlyList<int>> grouped = edgeIndices.Select((idx, pos) => (idx, type: classifications[pos])).GroupBy(static x => x.type, static x => x.idx).ToFrozenDictionary(static g => g.Key, static g => (IReadOnlyList<int>)[.. g,]);
         return ResultFactory.Create(value: (IReadOnlyList<Topology.EdgeClassificationData>)[new Topology.EdgeClassificationData(EdgeIndices: edgeIndices, Classifications: classifications, ContinuityMeasures: measures, GroupedByType: grouped, MinimumContinuity: Continuity.C0_continuous),]);
     }
 


### PR DESCRIPTION
Prevents unnecessary closure allocations by marking 10 lambdas as static:

- IntersectionConfig.cs:75 - SelectMany predicate
- IntersectionCore.cs:225 - ToFrozenDictionary key selector
- ExtractionCore.cs:277-281 - GroupBy/ToDictionary chain (4 lambdas)
- ExtractionCore.cs:336-340 - Curve registry chain (4 lambdas)
- TopologyCore.cs:213,233 - GroupBy/ToFrozenDictionary chains (8 lambdas total)

Static lambdas avoid heap allocations for delegate instances since they don't capture any variables. This is a zero-cost abstraction improvement with no behavioral changes.