### PR TITLE
Tighten core diagnostics API and tolerance validation

### DIFF
--- a/libs/core/context/GeometryContext.cs
+++ b/libs/core/context/GeometryContext.cs
@@ -72,8 +72,21 @@ public sealed record GeometryContext(
 
     /// <summary>Creates validated context with normalization.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<GeometryContext> Create(double absoluteTolerance, double relativeTolerance, double angleToleranceRadians, UnitSystem units) =>
-        (!RhinoMath.IsValidDouble(absoluteTolerance <= 0d ? DefaultAbsoluteTolerance : absoluteTolerance) || !RhinoMath.IsValidDouble(relativeTolerance) || !RhinoMath.IsValidDouble(angleToleranceRadians <= 0d ? DefaultAngleToleranceRadians : angleToleranceRadians)) ? ResultFactory.Create<GeometryContext>(errors: [E.Validation.ToleranceAbsoluteInvalid,]) :
-        ValidationRules.For(absoluteTolerance <= 0d ? DefaultAbsoluteTolerance : absoluteTolerance, relativeTolerance, angleToleranceRadians <= 0d ? DefaultAngleToleranceRadians : angleToleranceRadians) is SystemError[] { Length: > 0 } errors ? ResultFactory.Create<GeometryContext>(errors: errors) :
-        ResultFactory.Create(value: new GeometryContext(absoluteTolerance <= 0d ? DefaultAbsoluteTolerance : absoluteTolerance, relativeTolerance, angleToleranceRadians <= 0d ? DefaultAngleToleranceRadians : angleToleranceRadians, units));
+    public static Result<GeometryContext> Create(double absoluteTolerance, double relativeTolerance, double angleToleranceRadians, UnitSystem units) {
+        double normalizedAbsoluteTolerance = absoluteTolerance <= 0d ? DefaultAbsoluteTolerance : absoluteTolerance;
+        double normalizedRelativeTolerance = relativeTolerance;
+        double normalizedAngleToleranceRadians = angleToleranceRadians <= 0d ? DefaultAngleToleranceRadians : angleToleranceRadians;
+
+        SystemError[] invalidParameters = [
+            .. (!RhinoMath.IsValidDouble(normalizedAbsoluteTolerance) ? new SystemError[] { E.Validation.ToleranceAbsoluteInvalid, } : System.Array.Empty<SystemError>()),
+            .. (!RhinoMath.IsValidDouble(normalizedRelativeTolerance) ? new SystemError[] { E.Validation.ToleranceRelativeInvalid, } : System.Array.Empty<SystemError>()),
+            .. (!RhinoMath.IsValidDouble(normalizedAngleToleranceRadians) ? new SystemError[] { E.Validation.ToleranceAngleInvalid, } : System.Array.Empty<SystemError>()),
+        ];
+
+        return invalidParameters is { Length: > 0 } parameterErrors
+            ? ResultFactory.Create<GeometryContext>(errors: parameterErrors)
+            : ValidationRules.For(normalizedAbsoluteTolerance, normalizedRelativeTolerance, normalizedAngleToleranceRadians) is SystemError[] { Length: > 0 } validationErrors
+                ? ResultFactory.Create<GeometryContext>(errors: validationErrors)
+                : ResultFactory.Create(value: new GeometryContext(normalizedAbsoluteTolerance, normalizedRelativeTolerance, normalizedAngleToleranceRadians, units));
+    }
 }

--- a/libs/core/context/GeometryContext.cs
+++ b/libs/core/context/GeometryContext.cs
@@ -77,13 +77,13 @@ public sealed record GeometryContext(
         double normalizedRelativeTolerance = relativeTolerance <= 0d ? DefaultRelativeTolerance : relativeTolerance;
         double normalizedAngleToleranceRadians = angleToleranceRadians <= 0d ? DefaultAngleToleranceRadians : angleToleranceRadians;
 
-        SystemError[] invalidParameters = [
-            .. (!RhinoMath.IsValidDouble(normalizedAbsoluteTolerance) ? new SystemError[] { E.Validation.ToleranceAbsoluteInvalid, } : System.Array.Empty<SystemError>()),
-            .. (!RhinoMath.IsValidDouble(normalizedRelativeTolerance) ? new SystemError[] { E.Validation.ToleranceRelativeInvalid, } : System.Array.Empty<SystemError>()),
-            .. (!RhinoMath.IsValidDouble(normalizedAngleToleranceRadians) ? new SystemError[] { E.Validation.ToleranceAngleInvalid, } : System.Array.Empty<SystemError>()),
-        ];
+        List<SystemError> invalidParameters = new();
+        if (!RhinoMath.IsValidDouble(normalizedAbsoluteTolerance)) { invalidParameters.Add(E.Validation.ToleranceAbsoluteInvalid); }
+        if (!RhinoMath.IsValidDouble(normalizedRelativeTolerance)) { invalidParameters.Add(E.Validation.ToleranceRelativeInvalid); }
+        if (!RhinoMath.IsValidDouble(normalizedAngleToleranceRadians)) { invalidParameters.Add(E.Validation.ToleranceAngleInvalid); }
+        SystemError[] invalidParametersArray = [.. invalidParameters];
 
-        return invalidParameters is { Length: > 0 } parameterErrors
+        return invalidParametersArray is { Length: > 0 } parameterErrors
             ? ResultFactory.Create<GeometryContext>(errors: parameterErrors)
             : ValidationRules.For(normalizedAbsoluteTolerance, normalizedRelativeTolerance, normalizedAngleToleranceRadians) is SystemError[] { Length: > 0 } validationErrors
                 ? ResultFactory.Create<GeometryContext>(errors: validationErrors)

--- a/libs/core/context/GeometryContext.cs
+++ b/libs/core/context/GeometryContext.cs
@@ -74,7 +74,7 @@ public sealed record GeometryContext(
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<GeometryContext> Create(double absoluteTolerance, double relativeTolerance, double angleToleranceRadians, UnitSystem units) {
         double normalizedAbsoluteTolerance = absoluteTolerance <= 0d ? DefaultAbsoluteTolerance : absoluteTolerance;
-        double normalizedRelativeTolerance = relativeTolerance;
+        double normalizedRelativeTolerance = relativeTolerance <= 0d ? DefaultRelativeTolerance : relativeTolerance;
         double normalizedAngleToleranceRadians = angleToleranceRadians <= 0d ? DefaultAngleToleranceRadians : angleToleranceRadians;
 
         SystemError[] invalidParameters = [

--- a/libs/core/diagnostics/DiagnosticCapture.cs
+++ b/libs/core/diagnostics/DiagnosticCapture.cs
@@ -9,7 +9,7 @@ using Arsenal.Core.Validation;
 namespace Arsenal.Core.Diagnostics;
 
 /// <summary>Diagnostic capture with ConditionalWeakTable storage for compile-time tracing.</summary>
-public static class DiagnosticCapture {
+internal static class DiagnosticCapture {
 #if DEBUG
     private static readonly ActivitySource _activitySource = new("Arsenal.Core", "1.0.0");
     private static readonly ConditionalWeakTable<object, StrongBox<DiagnosticContext>> _metadata = [];
@@ -17,7 +17,7 @@ public static class DiagnosticCapture {
 
     /// <summary>True if diagnostics enabled (DEBUG only).</summary>
     [Pure]
-    public static bool IsEnabled =>
+    internal static bool IsEnabled =>
 #if DEBUG
         true;
 #else
@@ -26,7 +26,7 @@ public static class DiagnosticCapture {
 
     /// <summary>Gets diagnostic metadata for Result (DEBUG only).</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryGetDiagnostics<T>(this Result<T> result, [MaybeNullWhen(false)] out DiagnosticContext context) {
+    internal static bool TryGetDiagnostics<T>(this Result<T> result, [MaybeNullWhen(false)] out DiagnosticContext context) {
 #if DEBUG
         bool found = _metadata.TryGetValue(result, out StrongBox<DiagnosticContext>? box);
         context = found && box is not null ? box.Value! : default;
@@ -41,7 +41,7 @@ public static class DiagnosticCapture {
     /// <summary>Clears all diagnostic metadata (DEBUG only).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #pragma warning disable IDE0022 // Use expression body for method
-    public static void Clear() {
+    internal static void Clear() {
 #if DEBUG
         _metadata.Clear();
 #endif
@@ -50,7 +50,7 @@ public static class DiagnosticCapture {
 
     /// <summary>Captures operation diagnostics with timing and allocation tracking (DEBUG only).</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Capture<T>(
+    internal static Result<T> Capture<T>(
         this Result<T> result,
         string operation,
         V? validationApplied = null,

--- a/libs/core/diagnostics/DiagnosticContext.cs
+++ b/libs/core/diagnostics/DiagnosticContext.cs
@@ -10,7 +10,7 @@ namespace Arsenal.Core.Diagnostics;
 /// <summary>Zero-allocation observability with compile-time toggleable tracing.</summary>
 [StructLayout(LayoutKind.Auto)]
 [DebuggerDisplay("{DebuggerDisplay}")]
-public readonly record struct DiagnosticContext(
+internal readonly record struct DiagnosticContext(
     string Operation,
     TimeSpan Elapsed,
     long Allocations,

--- a/libs/core/validation/V.cs
+++ b/libs/core/validation/V.cs
@@ -36,7 +36,7 @@ public readonly struct V(ushort flags) : IEquatable<V> {
         SelfIntersection._flags | BrepGranular._flags
     ));
 
-    public static readonly V[] AllFlags = [Standard, AreaCentroid, BoundingBox, MassProperties, Topology, Degeneracy, Tolerance, MeshSpecific, SurfaceContinuity, PolycurveStructure, NurbsGeometry, ExtrusionGeometry, UVDomain, SelfIntersection, BrepGranular,];
+    internal static readonly V[] AllFlags = [Standard, AreaCentroid, BoundingBox, MassProperties, Topology, Degeneracy, Tolerance, MeshSpecific, SurfaceContinuity, PolycurveStructure, NurbsGeometry, ExtrusionGeometry, UVDomain, SelfIntersection, BrepGranular,];
 
     private static readonly FrozenDictionary<ushort, string> _names =
         new Dictionary<ushort, string> {

--- a/libs/core/validation/ValidationRules.cs
+++ b/libs/core/validation/ValidationRules.cs
@@ -13,7 +13,7 @@ using Rhino.Geometry.Intersect;
 namespace Arsenal.Core.Validation;
 
 /// <summary>Validation via compiled expression trees with caching.</summary>
-public static class ValidationRules {
+internal static class ValidationRules {
     /// <summary>Cache key for validator lookups.</summary>
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
     private readonly record struct CacheKey(Type Type, V Mode = default, string? Member = null, byte Kind = 0);
@@ -64,7 +64,7 @@ public static class ValidationRules {
 
     /// <summary>Validation errors for tolerance values.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static SystemError[] For<T>(T input, params object[] args) where T : notnull =>
+    internal static SystemError[] For<T>(T input, params object[] args) where T : notnull =>
         (typeof(T), input, args) switch {
             (Type t, double absoluteTolerance, [double relativeTolerance, double angleToleranceRadians]) when t == typeof(double) =>
                 [.. (!(RhinoMath.IsValidDouble(absoluteTolerance) && absoluteTolerance > RhinoMath.ZeroTolerance) ?


### PR DESCRIPTION
## Summary
- normalize GeometryContext.Create inputs before validation and return precise tolerance errors
- scope DiagnosticCapture, DiagnosticContext, ValidationRules.For, and V.AllFlags as internal to shrink the core surface area
- keep UnifiedOperation diagnostics working while avoiding unused public API exposure

## Testing
- dotnet build *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914376e8568832182b219a1742812da)