### PR TITLE
Tighten Rhino analysis and orientation tolerances

### DIFF
--- a/libs/rhino/analysis/Analysis.cs
+++ b/libs/rhino/analysis/Analysis.cs
@@ -108,7 +108,7 @@ public static class Analysis {
         Curve curve,
         IGeometryContext context,
         double? parameter = null,
-        int derivativeOrder = 2) =>
+        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) =>
         AnalysisCore.Execute(curve, context, t: parameter, uv: null, index: null, testPoint: null, derivativeOrder: derivativeOrder)
             .Map(results => (CurveData)results[0]);
 
@@ -118,7 +118,7 @@ public static class Analysis {
         Surface surface,
         IGeometryContext context,
         (double u, double v)? uvParameter = null,
-        int derivativeOrder = 2) =>
+        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) =>
         AnalysisCore.Execute(surface, context, t: null, uv: uvParameter, index: null, testPoint: null, derivativeOrder: derivativeOrder)
             .Map(results => (SurfaceData)results[0]);
 
@@ -130,7 +130,7 @@ public static class Analysis {
         (double u, double v)? uvParameter = null,
         int faceIndex = 0,
         Point3d? testPoint = null,
-        int derivativeOrder = 2) =>
+        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) =>
         AnalysisCore.Execute(brep, context, t: null, uv: uvParameter, index: faceIndex, testPoint: testPoint, derivativeOrder: derivativeOrder)
             .Map(results => (BrepData)results[0]);
 
@@ -152,7 +152,7 @@ public static class Analysis {
         (double u, double v)? uvParameter = null,
         int? index = null,
         Point3d? testPoint = null,
-        int derivativeOrder = 2) where T : notnull =>
+        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) where T : notnull =>
         UnifiedOperation.Apply(
             geometries,
             (Func<object, Result<IReadOnlyList<IResult>>>)(item =>

--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -57,7 +57,7 @@ internal static class OrientCompute {
                             }),
                             ];
 
-                            return results.MaxBy(r => r.Item2) is (Transform best, double bestScore, byte[] met) && bestScore > 0.0
+                            return results.MaxBy(r => r.Item2) is (Transform best, double bestScore, byte[] met) && bestScore >= OrientConfig.MinimumOptimizationScore
                                 ? ResultFactory.Create(value: (best, bestScore, met))
                                 : ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.TransformFailed.WithContext("No valid orientation found"));
                         }))()
@@ -68,9 +68,12 @@ internal static class OrientCompute {
     internal static Result<(Transform RelativeTransform, double Twist, double Tilt, byte SymmetryType, byte Relationship)> ComputeRelative(
         GeometryBase geometryA,
         GeometryBase geometryB,
-        IGeometryContext context) =>
-        (OrientCore.PlaneExtractors.TryGetValue(geometryA.GetType(), out Func<object, Result<Plane>>? extA),
-         OrientCore.PlaneExtractors.TryGetValue(geometryB.GetType(), out Func<object, Result<Plane>>? extB))
+        IGeometryContext context) {
+        double symmetryTolerance = Math.Max(context.AbsoluteTolerance, OrientConfig.SymmetryTestTolerance);
+        double angleTolerance = Math.Max(context.AngleToleranceRadians, OrientConfig.SymmetryTestTolerance);
+
+        return (OrientCore.PlaneExtractors.TryGetValue(geometryA.GetType(), out Func<object, Result<Plane>>? extA),
+            OrientCore.PlaneExtractors.TryGetValue(geometryB.GetType(), out Func<object, Result<Plane>>? extB))
                 switch {
                     (true, true) when extA!(geometryA) is Result<Plane> ra && extB!(geometryB) is Result<Plane> rb => (ra, rb) switch {
                         (Result<Plane> { IsSuccess: true }, Result<Plane> { IsSuccess: true }) => (ra.Value, rb.Value) is (Plane pa, Plane pb)
@@ -83,8 +86,8 @@ internal static class OrientCompute {
                                                 reflected.Transform(Transform.Mirror(mirrorPlane: mirror));
                                                 return reflected;
                                             }).ToArray() is Point3d[] reflectedA
-                                            && reflectedA.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < context.AbsoluteTolerance))
-                                            && bb.Vertices.All(vb => reflectedA.Any(ra => ra.DistanceTo(vb.Location) < context.AbsoluteTolerance))
+                                            && reflectedA.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < symmetryTolerance))
+                                            && bb.Vertices.All(vb => reflectedA.Any(ra => ra.DistanceTo(vb.Location) < symmetryTolerance))
                                                 ? (byte)1 : (byte)0
                                         : new Plane(pa.Origin, pa.ZAxis) is Plane mirror2 && mirror2.IsValid
                                             && ba.Vertices.Select(va => {
@@ -92,10 +95,10 @@ internal static class OrientCompute {
                                                 reflected.Transform(Transform.Mirror(mirrorPlane: mirror2));
                                                 return reflected;
                                             }).ToArray() is Point3d[] reflectedA2
-                                            && reflectedA2.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < context.AbsoluteTolerance))
-                                            && bb.Vertices.All(vb => reflectedA2.Any(ra => ra.DistanceTo(vb.Location) < context.AbsoluteTolerance))
+                                            && reflectedA2.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < symmetryTolerance))
+                                            && bb.Vertices.All(vb => reflectedA2.Any(ra => ra.DistanceTo(vb.Location) < symmetryTolerance))
                                                 ? (byte)1 : (byte)0,
-                                    (Curve ca, Curve cb) when ca.SpanCount == cb.SpanCount && pa.ZAxis.IsValid && pa.ZAxis.Length > context.AbsoluteTolerance => ((Func<byte>)(() => {
+                                    (Curve ca, Curve cb) when ca.SpanCount == cb.SpanCount && pa.ZAxis.IsValid && pa.ZAxis.Length > symmetryTolerance => ((Func<byte>)(() => {
                                         Point3d[] samplesA = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => ca.PointAt(ca.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
                                         Point3d[] samplesB = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => cb.PointAt(cb.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
                                         int[] testIndices = [0, samplesA.Length / 2, samplesA.Length - 1,];
@@ -104,7 +107,7 @@ internal static class OrientCompute {
                                             Vector3d vecB = samplesB[idx] - pa.Origin;
                                             Vector3d projA = vecA - ((vecA * pa.ZAxis) * pa.ZAxis);
                                             Vector3d projB = vecB - ((vecB * pa.ZAxis) * pa.ZAxis);
-                                            return projA.Length < context.AbsoluteTolerance || projB.Length < context.AbsoluteTolerance
+                                            return projA.Length < symmetryTolerance || projB.Length < symmetryTolerance
                                                 ? double.NaN
                                                 : Vector3d.CrossProduct(projA, projB) * pa.ZAxis < 0
                                                     ? -Vector3d.VectorAngle(projA, projB)
@@ -113,19 +116,19 @@ internal static class OrientCompute {
                                         ];
                                         return candidateAngles.Length == 0
                                             ? (byte)0
-                                            : candidateAngles.All(a => Math.Abs(a - candidateAngles[0]) < context.AngleToleranceRadians)
+                                            : candidateAngles.All(a => Math.Abs(a - candidateAngles[0]) < angleTolerance)
                                                 && Transform.Rotation(candidateAngles[0], pa.ZAxis, pa.Origin) is Transform rotation
                                                 && samplesA.Zip(samplesB, (ptA, ptB) => {
                                                     Point3d rotated = ptA;
                                                     rotated.Transform(rotation);
                                                     return rotated.DistanceTo(ptB);
-                                                }).All(dist => dist < context.AbsoluteTolerance)
+                                                }).All(dist => dist < symmetryTolerance)
                                                     ? (byte)2 : (byte)0;
                                     }))(),
                                     _ => (byte)0,
                                 }, Math.Abs(Vector3d.Multiply(pa.ZAxis, pb.ZAxis)) switch {
-                                    double dot when Math.Abs(dot - 1.0) < context.AbsoluteTolerance => (byte)1,
-                                    double dot when Math.Abs(dot) < context.AbsoluteTolerance => (byte)2,
+                                    double dot when Math.Abs(dot - 1.0) < angleTolerance => (byte)1,
+                                    double dot when Math.Abs(dot) < angleTolerance => (byte)2,
                                     _ => (byte)3,
                                 }) is (byte symmetry, byte relationship)
                                     ? ResultFactory.Create(value: (xform, twist, tilt, symmetry, relationship))
@@ -136,6 +139,7 @@ internal static class OrientCompute {
                     },
                     _ => ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.UnsupportedOrientationType),
                 };
+    }
 
     /// <summary>Detect patterns in geometry array and compute alignment.</summary>
     [Pure]

--- a/libs/rhino/orientation/OrientConfig.cs
+++ b/libs/rhino/orientation/OrientConfig.cs
@@ -35,8 +35,6 @@ internal static class OrientConfig {
     internal const double BestFitResidualThreshold = 1e-3;
     /// <summary>Minimum 3 instances for pattern detection.</summary>
     internal const int PatternMinInstances = 3;
-    /// <summary>Optimization iteration limit for orientation search.</summary>
-    internal const int OptimizationMaxIterations = 24;
     /// <summary>Symmetry test tolerance for relative orientation.</summary>
     internal const double SymmetryTestTolerance = 1e-3;
     /// <summary>Primary score weight 0.4 for orientation criteria 4.</summary>

--- a/libs/rhino/orientation/OrientCore.cs
+++ b/libs/rhino/orientation/OrientCore.cs
@@ -67,13 +67,39 @@ internal static class OrientCore {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Plane> ExtractBestFitPlane(GeometryBase geometry) =>
         geometry switch {
-            PointCloud pc when pc.Count >= OrientConfig.BestFitMinPoints => Plane.FitPlaneToPoints(pc.GetPoints(), out Plane plane) == PlaneFitResult.Success
-                ? ResultFactory.Create(value: plane)
-                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            PointCloud pc when pc.Count >= OrientConfig.BestFitMinPoints => ((Func<Result<Plane>>)(() => {
+                Point3d[] points = pc.GetPoints();
+                return Plane.FitPlaneToPoints(points, out Plane plane) == PlaneFitResult.Success
+                    ? ((Func<Result<Plane>>)(() => {
+                        double sumSquaredDistances = 0.0;
+                        for (int i = 0; i < points.Length; i++) {
+                            double distance = plane.DistanceTo(points[i]);
+                            sumSquaredDistances += distance * distance;
+                        }
+                        double rms = points.Length > 0 ? Math.Sqrt(sumSquaredDistances / points.Length) : double.PositiveInfinity;
+                        return rms <= OrientConfig.BestFitResidualThreshold
+                            ? ResultFactory.Create(value: plane)
+                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                    }))()
+                    : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+            }))(),
             PointCloud pc => ResultFactory.Create<Plane>(error: E.Geometry.InsufficientParameters.WithContext($"Best-fit plane requires {OrientConfig.BestFitMinPoints} points, got {pc.Count}")),
-            Mesh m when m.Vertices.Count >= OrientConfig.BestFitMinPoints => Plane.FitPlaneToPoints(m.Vertices.ToPoint3dArray(), out Plane plane) == PlaneFitResult.Success
-                ? ResultFactory.Create(value: plane)
-                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            Mesh m when m.Vertices.Count >= OrientConfig.BestFitMinPoints => ((Func<Result<Plane>>)(() => {
+                Point3d[] points = m.Vertices.ToPoint3dArray();
+                return Plane.FitPlaneToPoints(points, out Plane plane) == PlaneFitResult.Success
+                    ? ((Func<Result<Plane>>)(() => {
+                        double sumSquaredDistances = 0.0;
+                        for (int i = 0; i < points.Length; i++) {
+                            double distance = plane.DistanceTo(points[i]);
+                            sumSquaredDistances += distance * distance;
+                        }
+                        double rms = points.Length > 0 ? Math.Sqrt(sumSquaredDistances / points.Length) : double.PositiveInfinity;
+                        return rms <= OrientConfig.BestFitResidualThreshold
+                            ? ResultFactory.Create(value: plane)
+                            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                    }))()
+                    : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+            }))(),
             Mesh m => ResultFactory.Create<Plane>(error: E.Geometry.InsufficientParameters.WithContext($"Best-fit plane requires {OrientConfig.BestFitMinPoints} points, got {m.Vertices.Count}")),
             _ => ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
         };


### PR DESCRIPTION
## Summary
- align analysis entry points with shared derivative-order constant to keep the API consistent
- enforce best-fit plane quality and symmetry tolerances in orientation routines using OrientConfig thresholds
- drop an unused optimization constant and require a minimum score when picking canonical orientation

## Testing
- dotnet build *(fails: `dotnet` CLI unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914377e0d8c8321b2e30a4c6bf43f8c)