### PR TITLE
Prevent zero-distance linear pattern classification

### DIFF
--- a/libs/rhino/extraction/ExtractionCompute.cs
+++ b/libs/rhino/extraction/ExtractionCompute.cs
@@ -278,7 +278,6 @@ internal static class ExtractionCompute {
 
     private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> DetectPatternType(Point3d[] centers, IGeometryContext context) =>
         Enumerable.Range(0, centers.Length - 1).Select(i => centers[i + 1] - centers[i]).ToArray() is Vector3d[] deltas
-            && deltas.Length > 0
             && deltas[0].Length > context.AbsoluteTolerance
             && deltas.All(d => (d - deltas[0]).Length < context.AbsoluteTolerance)
             ? ResultFactory.Create(value: (Type: ExtractionConfig.PatternTypeLinear, SymmetryTransform: Transform.Translation(deltas[0]), Confidence: 1.0))

--- a/libs/rhino/extraction/ExtractionCompute.cs
+++ b/libs/rhino/extraction/ExtractionCompute.cs
@@ -277,7 +277,10 @@ internal static class ExtractionCompute {
                 .Bind(centers => DetectPatternType(centers: [.. centers], context: context)));
 
     private static Result<(byte Type, Transform SymmetryTransform, double Confidence)> DetectPatternType(Point3d[] centers, IGeometryContext context) =>
-        Enumerable.Range(0, centers.Length - 1).Select(i => centers[i + 1] - centers[i]).ToArray() is Vector3d[] deltas && deltas.All(d => (d - deltas[0]).Length < context.AbsoluteTolerance)
+        Enumerable.Range(0, centers.Length - 1).Select(i => centers[i + 1] - centers[i]).ToArray() is Vector3d[] deltas
+            && deltas.Length > 0
+            && deltas[0].Length > context.AbsoluteTolerance
+            && deltas.All(d => (d - deltas[0]).Length < context.AbsoluteTolerance)
             ? ResultFactory.Create(value: (Type: ExtractionConfig.PatternTypeLinear, SymmetryTransform: Transform.Translation(deltas[0]), Confidence: 1.0))
             : TryDetectRadialPattern(centers: centers, context: context) is Result<(byte, Transform, double)> radialResult && radialResult.IsSuccess
                 ? radialResult


### PR DESCRIPTION
## Summary
- require a non-trivial translation vector before reporting a linear extraction pattern

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691449a9af5c832188606fa41ad0997a)