### PR TITLE
Clamp medial axis tolerance and expose sample limits

### DIFF
--- a/libs/rhino/spatial/SpatialCompute.cs
+++ b/libs/rhino/spatial/SpatialCompute.cs
@@ -212,8 +212,7 @@ internal static class SpatialCompute {
                 (true, Curve[] edges) when Curve.JoinCurves(edges, joinTolerance: Math.Max(tolerance, context.AbsoluteTolerance), preserveDirection: false).FirstOrDefault() is Curve boundary && boundary.IsClosed && boundary.TryGetPlane(out Plane plane, tolerance: Math.Max(tolerance, context.AbsoluteTolerance)) && boundary.GetLength() > context.AbsoluteTolerance => ((Func<Result<(Curve[], double[])>>)(() => {
                     double effectiveTolerance = Math.Max(tolerance, context.AbsoluteTolerance);
                     double length = boundary.GetLength();
-                    double clampedSamples = Math.Max((double)SpatialConfig.MedialAxisMinSampleCount, Math.Min((double)SpatialConfig.MedialAxisMaxSampleCount, length / effectiveTolerance));
-                    int sampleCount = (int)clampedSamples;
+                    int sampleCount = (int)Math.Max(SpatialConfig.MedialAxisMinSampleCount, Math.Min(SpatialConfig.MedialAxisMaxSampleCount, length / effectiveTolerance));
                     Transform toPlane = Transform.PlaneToPlane(plane, Plane.WorldXY);
                     Transform fromPlane = Transform.PlaneToPlane(Plane.WorldXY, plane);
                     Point3d To3D(Point3d p2d) { Point3d pt = p2d; pt.Transform(fromPlane); return pt; }

--- a/libs/rhino/spatial/SpatialConfig.cs
+++ b/libs/rhino/spatial/SpatialConfig.cs
@@ -14,6 +14,8 @@ internal static class SpatialConfig {
     internal const int DBSCANMinPoints = 4;
     internal const double MedialAxisOffsetMultiplier = 10.0;
     internal const int DBSCANRTreeThreshold = 100;
+    internal const int MedialAxisMinSampleCount = 50;
+    internal const int MedialAxisMaxSampleCount = 500;
 
     /// <summary>Type extractors: polymorphic dispatch for centroid, RTree factory, etc.</summary>
     internal static readonly FrozenDictionary<(string Operation, Type GeometryType), Func<object, object>> TypeExtractors =


### PR DESCRIPTION
## Summary
- reuse the Rhino context tolerance when sampling planar Brep boundaries for medial axis extraction
- guard medial axis sampling counts behind named configuration constants to avoid ad-hoc literals

## Testing
- dotnet build *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144f3639888321945a9a0da33f4aec)