### PR TITLE
Align curve symmetry detection frames

### DIFF
--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -103,9 +103,8 @@ internal static class OrientCompute {
                                         Point3d[] samplesBOriginal = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => cb.PointAt(cb.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
                                         Transform alignBToA = Transform.PlaneToPlane(pb, pa);
                                         Point3d[] samplesB = [.. samplesBOriginal.Select(point => {
-                                            Point3d aligned = point;
-                                            aligned.Transform(alignBToA);
-                                            return aligned;
+                                            point.Transform(alignBToA);
+                                            return point;
                                         }),];
                                         int[] testIndices = [0, samplesA.Length / 2, samplesA.Length - 1,];
                                         double[] candidateAngles = [.. testIndices.Select(idx => {

--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -102,9 +102,7 @@ internal static class OrientCompute {
                                         Point3d[] samplesA = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => ca.PointAt(ca.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
                                         Point3d[] samplesBOriginal = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => cb.PointAt(cb.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
                                         Transform alignBToA = Transform.PlaneToPlane(pb, pa);
-                                        Point3d[] samplesB = [.. samplesBOriginal.Select(point => {
-                                            point.Transform(alignBToA);
-                                            return point;
+                                        Point3d[] samplesB = [.. samplesBOriginal.Select(point => alignBToA * point)];
                                         }),];
                                         int[] testIndices = [0, samplesA.Length / 2, samplesA.Length - 1,];
                                         double[] candidateAngles = [.. testIndices.Select(idx => {

--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -100,7 +100,13 @@ internal static class OrientCompute {
                                                 ? (byte)1 : (byte)0,
                                     (Curve ca, Curve cb) when ca.SpanCount == cb.SpanCount && pa.ZAxis.IsValid && pa.ZAxis.Length > symmetryTolerance => ((Func<byte>)(() => {
                                         Point3d[] samplesA = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => ca.PointAt(ca.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
-                                        Point3d[] samplesB = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => cb.PointAt(cb.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
+                                        Point3d[] samplesBOriginal = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => cb.PointAt(cb.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
+                                        Transform alignBToA = Transform.PlaneToPlane(pb, pa);
+                                        Point3d[] samplesB = [.. samplesBOriginal.Select(point => {
+                                            Point3d aligned = point;
+                                            aligned.Transform(alignBToA);
+                                            return aligned;
+                                        }),];
                                         int[] testIndices = [0, samplesA.Length / 2, samplesA.Length - 1,];
                                         double[] candidateAngles = [.. testIndices.Select(idx => {
                                             Vector3d vecA = samplesA[idx] - pa.Origin;


### PR DESCRIPTION
## Summary
- align curve-based symmetry detection with source plane coordinates during relative orientation checks

## Testing
- dotnet build *(fails: `dotnet` executable not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144f3639888321945a9a0da33f4aec)