### PR TITLE
Fix duplicate XML documentation comments in TopologyConfig

### DIFF
--- a/libs/rhino/topology/TopologyConfig.cs
+++ b/libs/rhino/topology/TopologyConfig.cs
@@ -53,9 +53,7 @@ internal static class TopologyConfig {
     /// <summary>Healing strategy: Combined Repair + JoinNakedEdges.</summary>
     internal const byte StrategyCombined = 3;
 
-    /// <summary>Maximum number of healing strategies available.</summary>
-    /// <summary>Maximum healing strategies available (0-3 inclusive).</summary>
-    /// <summary>Maximum number of healing strategies (4 total: Conservative, Moderate, Aggressive, Combined).</summary>
+    /// <summary>Maximum number of healing strategies (4 total: Conservative, Moderate, Aggressive, Combined). Strategies indexed 0-3.</summary>
     internal const int MaxHealingStrategies = 4;
 
     /// <summary>Healing strategy tolerance multipliers: [Conservative=0.1×, Moderate=1.0×, Aggressive=10.0×].</summary>


### PR DESCRIPTION
Remove duplicate XML summary comments for MaxHealingStrategies constant. Consolidate three redundant summaries into single clear documentation.

- Removed duplicate comment lines 56-57
- Consolidated to single line describing count, purpose, and valid range
- Maintains clarity: 4 strategies (Conservative, Moderate, Aggressive, Combined) indexed 0-3