### PR TITLE
Fix Brep connectivity traversal

### DIFF
--- a/libs/rhino/topology/TopologyCore.cs
+++ b/libs/rhino/topology/TopologyCore.cs
@@ -118,28 +118,12 @@ internal static class TopologyCore {
     internal static Result<Topology.ConnectivityData> ExecuteConnectivity<T>(T input, IGeometryContext context) where T : notnull =>
         Execute(input: input, context: context, opType: TopologyConfig.OpType.Connectivity,
             operation: g => g switch {
-                Brep brep => brep.GetConnectedComponents() switch {
-                    null or { Length: 0 } => ComputeConnectivity(_: brep, faceCount: brep.Faces.Count, getAdjacent: fIdx => brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()), getBounds: fIdx => brep.Faces[fIdx].GetBoundingBox(accurate: false), getAdjacentForGraph: fIdx => [.. brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()).Where(adj => adj != fIdx),]),
-                    Brep[] { Length: 1 } => ComputeConnectivity(_: brep, faceCount: brep.Faces.Count, getAdjacent: fIdx => brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()), getBounds: fIdx => brep.Faces[fIdx].GetBoundingBox(accurate: false), getAdjacentForGraph: fIdx => [.. brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()).Where(adj => adj != fIdx),]),
-                    Brep[] components => ((Func<Result<IReadOnlyList<Topology.ConnectivityData>>>)(() => {
-                        foreach (Brep component in components) {
-                            using (component) { }
-                        }
-                        Dictionary<int, int> faceToComponent = [];
-                        int faceOffset = 0;
-                        for (int compIdx = 0; compIdx < components.Length; compIdx++) {
-                            for (int localFaceIdx = 0; localFaceIdx < components[compIdx].Faces.Count; localFaceIdx++) {
-                                faceToComponent[faceOffset + localFaceIdx] = compIdx;
-                            }
-                            faceOffset += components[compIdx].Faces.Count;
-                        }
-                        IReadOnlyList<IReadOnlyList<int>> componentIndices = [.. Enumerable.Range(0, components.Length).Select(compIdx => (IReadOnlyList<int>)[.. faceToComponent.Where(kvp => kvp.Value == compIdx).Select(kvp => kvp.Key),]),];
-                        IReadOnlyList<int> componentSizes = [.. components.Select(c => c.Faces.Count),];
-                        IReadOnlyList<BoundingBox> componentBounds = [.. components.Select(c => c.GetBoundingBox(accurate: false)),];
-                        FrozenDictionary<int, IReadOnlyList<int>> adjacencyGraph = Enumerable.Range(0, brep.Faces.Count).ToFrozenDictionary(keySelector: fIdx => fIdx, elementSelector: fIdx => (IReadOnlyList<int>)[.. brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()).Where(adj => adj != fIdx),]);
-                        return ResultFactory.Create(value: (IReadOnlyList<Topology.ConnectivityData>)[new Topology.ConnectivityData(ComponentIndices: componentIndices, ComponentSizes: componentSizes, ComponentBounds: componentBounds, TotalComponents: components.Length, IsFullyConnected: components.Length == 1, AdjacencyGraph: adjacencyGraph),]);
-                    }))(),
-                },
+                Brep brep => ComputeConnectivity(
+                    _: brep,
+                    faceCount: brep.Faces.Count,
+                    getAdjacent: fIdx => brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()),
+                    getBounds: fIdx => brep.Faces[fIdx].GetBoundingBox(accurate: false),
+                    getAdjacentForGraph: fIdx => [.. brep.Faces[fIdx].AdjacentEdges().SelectMany(eIdx => brep.Edges[eIdx].AdjacentFaces()).Where(adj => adj != fIdx),]),
                 Mesh mesh => ComputeConnectivity(_: mesh, faceCount: mesh.Faces.Count, getAdjacent: fIdx => mesh.Faces.AdjacentFaces(fIdx).Where(adj => adj >= 0), getBounds: fIdx => mesh.Faces[fIdx] switch { MeshFace face => face.IsQuad ? new BoundingBox([mesh.Vertices[face.A], mesh.Vertices[face.B], mesh.Vertices[face.C], mesh.Vertices[face.D],]) : new BoundingBox([mesh.Vertices[face.A], mesh.Vertices[face.B], mesh.Vertices[face.C],]) }, getAdjacentForGraph: fIdx => [.. mesh.Faces.AdjacentFaces(fIdx).Where(adj => adj >= 0),]),
                 _ => ResultFactory.Create<IReadOnlyList<Topology.ConnectivityData>>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Type: {typeof(T).Name}")),
             });


### PR DESCRIPTION
## Summary
- rely on the existing BFS-based connectivity routine for Brep topology
- remove the incorrect use of disposed Brep component clones when computing connectivity metadata

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916af45981083219ae9cab355edd772)