### PR TITLE
Review and validate rhino intersection library code quality

### DIFF
--- a/libs/rhino/intersection/Intersect.cs
+++ b/libs/rhino/intersection/Intersect.cs
@@ -88,7 +88,7 @@ public static class Intersect {
 
     /// <summary>Analyzes intersection stability via spherical perturbation sampling.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(double StabilityScore, double PerturbationSensitivity, bool[] UnstableFlags)> AnalyzeStability(
+    public static Result<(double StabilityScore, double PerturbationSensitivity)> AnalyzeStability(
         IntersectionOutput baseIntersection,
         GeometryBase geometryA,
         GeometryBase geometryB,


### PR DESCRIPTION
…g and remove broken UnstableFlags

Replace non-uniform spherical grid with Fibonacci sphere (golden ratio spiral) to eliminate polar clustering bias in perturbation sampling. Remove UnstableFlags feature that incorrectly partitioned global perturbation deltas to individual intersection points.