### PR TITLE
Audit Rhino extraction library code quality and SDK usage

### DIFF
--- a/libs/rhino/extraction/ExtractionCompute.cs
+++ b/libs/rhino/extraction/ExtractionCompute.cs
@@ -262,7 +262,7 @@ internal static class ExtractionCompute {
                 ? (true, ExtractionConfig.PrimitiveTypePlane, frame, [frame.OriginX, frame.OriginY, frame.OriginZ,])
                 : (false, ExtractionConfig.PrimitiveTypeUnknown, Plane.WorldXY, []),
             (false, true, false) when meanMean > RhinoMath.ZeroTolerance => surface.FrameAt(u: surface.Domain(0).Mid, v: surface.Domain(1).Mid, out Plane frame)
-                ? (true, ExtractionConfig.PrimitiveTypeCylinder, frame, [1.0 / meanMean, surface.GetBoundingBox(accurate: false).Diagonal.Length,])
+                ? (true, ExtractionConfig.PrimitiveTypeCylinder, frame, [1.0 / (2.0 * meanMean), surface.GetBoundingBox(accurate: false).Diagonal.Length,])
                 : (false, ExtractionConfig.PrimitiveTypeUnknown, Plane.WorldXY, []),
             (true, true, false) when gaussianMean > RhinoMath.ZeroTolerance && meanMean > RhinoMath.ZeroTolerance => surface.FrameAt(u: surface.Domain(0).Mid, v: surface.Domain(1).Mid, out Plane frame)
                 ? (true, ExtractionConfig.PrimitiveTypeSphere, frame, [1.0 / Math.Sqrt(gaussianMean),])


### PR DESCRIPTION
…rect mean curvature formula

Corrects differential geometry bug where cylinder radius was calculated as R = 1/H instead of R = 1/(2H). For a cylinder, mean curvature H = 1/(2R), therefore the radius recovery formula must be R = 1/(2H). This fix ensures accurate cylinder primitive detection and residual calculations.