### PR TITLE
Fix extraction fallback specificity ordering

### DIFF
--- a/libs/rhino/extraction/ExtractionCore.cs
+++ b/libs/rhino/extraction/ExtractionCore.cs
@@ -289,7 +289,7 @@ internal static class ExtractionCore {
             .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
                 static group => group.Key,
-                static group => group.OrderBy(static entry => entry.Key.GeometryType, _specificityComparer)
+                static group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
                     .Select(static entry => (entry.Key.GeometryType, entry.Value))
                     .ToArray())
             .ToFrozenDictionary();

--- a/libs/rhino/extraction/ExtractionCore.cs
+++ b/libs/rhino/extraction/ExtractionCore.cs
@@ -289,7 +289,7 @@ internal static class ExtractionCore {
             .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
                 static group => group.Key,
-                static group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
+                static group => group.OrderBy(static entry => entry.Key.GeometryType, _specificityComparer)
                     .Select(static entry => (entry.Key.GeometryType, entry.Value))
                     .ToArray())
             .ToFrozenDictionary();
@@ -348,7 +348,7 @@ internal static class ExtractionCore {
             .GroupBy(static entry => entry.Key.Kind)
             .ToDictionary(
                 static group => group.Key,
-                static group => group.OrderByDescending(static entry => entry.Key.GeometryType, _specificityComparer)
+                static group => group.OrderBy(static entry => entry.Key.GeometryType, _specificityComparer)
                     .Select(static entry => (entry.Key.GeometryType, entry.Value))
                     .ToArray())
             .ToFrozenDictionary();


### PR DESCRIPTION
## Summary
- ensure extraction fallback registries order geometry handlers from most specific to most general
- allow derived Rhino geometry types to resolve specialized handlers before generic GeometryBase fallbacks

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c613b1b48321a1f0eeb6d0171a17)