### PR TITLE
Enhance mesh near-miss sampling coverage

### DIFF
--- a/libs/rhino/intersection/IntersectionCompute.cs
+++ b/libs/rhino/intersection/IntersectionCompute.cs
@@ -148,13 +148,21 @@ internal static class IntersectionCompute {
                                                 ? ResultFactory.Create(value: toArrays(brepPairs))
                                                 : ResultFactory.Create<(Point3d[], Point3d[], double[])>(value: ([], [], []))
                                             : ResultFactory.Create<(Point3d[], Point3d[], double[])>(value: ([], [], [])),
-                                        (Mesh meshA, Mesh meshB) => (meshA.Vertices.Count > 0) && (meshB.Vertices.Count > 0) && Math.Min(meshA.Vertices.Count, IntersectionConfig.MaxNearMissSamples) is int sampleCount
-                                            ? Enumerable.Range(0, sampleCount)
-                                                .Select(index => new Point3d(meshA.Vertices[index * meshA.Vertices.Count / sampleCount]))
-                                                .Select(point => meshB.ClosestMeshPoint(point, 0.0) is MeshPoint meshPoint && meshPoint.Point.IsValid
+                                        (Mesh meshA, Mesh meshB) => (meshA.Vertices.Count > 0)
+                                                && (meshB.Vertices.Count > 0)
+                                                && Math.Min(meshA.Vertices.Count, IntersectionConfig.MaxNearMissSamples) is int samplesA
+                                                && Math.Min(meshB.Vertices.Count, IntersectionConfig.MaxNearMissSamples) is int samplesB
+                                            ? Enumerable.Range(0, samplesA)
+                                                .Select(index => new Point3d(meshA.Vertices[index * meshA.Vertices.Count / samplesA]))
+                                                .Select(point => meshB.ClosestMeshPoint(point, searchRadius) is MeshPoint meshPoint && meshPoint.Point.IsValid
                                                     ? (PointA: point, PointB: meshPoint.Point, Distance: point.DistanceTo(meshPoint.Point))
                                                     : (PointA: Point3d.Unset, PointB: Point3d.Unset, Distance: double.MaxValue))
-                                                .Where(candidate => (candidate.Distance < searchRadius) && (candidate.Distance > minDistance) && candidate.PointA.IsValid)
+                                                .Concat(Enumerable.Range(0, samplesB)
+                                                    .Select(index => new Point3d(meshB.Vertices[index * meshB.Vertices.Count / samplesB]))
+                                                    .Select(point => meshA.ClosestMeshPoint(point, searchRadius) is MeshPoint meshPoint && meshPoint.Point.IsValid
+                                                        ? (PointA: meshPoint.Point, PointB: point, Distance: meshPoint.Point.DistanceTo(point))
+                                                        : (PointA: Point3d.Unset, PointB: Point3d.Unset, Distance: double.MaxValue)))
+                                                .Where(candidate => (candidate.Distance < searchRadius) && (candidate.Distance > minDistance) && candidate.PointA.IsValid && candidate.PointB.IsValid)
                                                 .ToArray() is (Point3d PointA, Point3d PointB, double Distance)[] meshPairs && meshPairs.Length > 0
                                                 ? ResultFactory.Create(value: toArrays(meshPairs))
                                                 : ResultFactory.Create<(Point3d[], Point3d[], double[])>(value: ([], [], []))


### PR DESCRIPTION
## Summary
- extend mesh near-miss sampling to probe vertices from both meshes so near misses are orientation-independent
- ensure mesh near-miss candidates retain search-radius filtering and drop invalid mesh points before returning results

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c60be9308321847f167e1ea60c4f)