### PR TITLE
Refactor rhino fields for code quality and LOC reduction

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -152,10 +152,10 @@ public static class Fields {
         FieldSpec spec,
         BoundingBox bounds,
         byte interpolationMethod = FieldsConfig.InterpolationTrilinear) {
-        bool hasDegenerateBounds = RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon)
+        return (scalarField.Length == gridPoints.Length,
+            RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon)
             || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon)
-            || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon);
-        return (scalarField.Length == gridPoints.Length, hasDegenerateBounds) switch {
+            || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon)) switch {
             (false, _) => ResultFactory.Create<double>(
                 error: E.Geometry.InvalidFieldInterpolation.WithContext("Scalar field length must match grid points")),
             (true, true) => FieldsCompute.InterpolateScalar(
@@ -184,10 +184,10 @@ public static class Fields {
         FieldSpec spec,
         BoundingBox bounds,
         byte interpolationMethod = FieldsConfig.InterpolationTrilinear) {
-        bool hasDegenerateBounds = RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon)
+        return (vectorField.Length == gridPoints.Length,
+            RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon)
             || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon)
-            || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon);
-        return (vectorField.Length == gridPoints.Length, hasDegenerateBounds) switch {
+            || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon)) switch {
             (false, _) => ResultFactory.Create<Vector3d>(
                 error: E.Geometry.InvalidFieldInterpolation.WithContext("Vector field length must match grid points")),
             (true, true) => FieldsCompute.InterpolateVector(

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -153,16 +153,8 @@ internal static class FieldsConfig {
             int complement = 255 - i;
             int[] baseCase = table[complement];
             table[i] = baseCase.Length > 0
-                ? ((Func<int[]>)(() => {
-                    int length = baseCase.Length;
-                    int[] inverted = new int[length];
-                    for (int j = 0; j < length; j += 3) {
-                        inverted[j] = baseCase[j + 2];
-                        inverted[j + 1] = baseCase[j + 1];
-                        inverted[j + 2] = baseCase[j];
-                    }
-                    return inverted;
-                }))()
+                ? [.. Enumerable.Range(0, baseCase.Length / 3)
+                    .SelectMany(t => new[] { baseCase[(t * 3) + 2], baseCase[(t * 3) + 1], baseCase[t * 3], })]
                 : [];
         }
 

--- a/libs/rhino/fields/FieldsCore.cs
+++ b/libs/rhino/fields/FieldsCore.cs
@@ -16,14 +16,12 @@ namespace Arsenal.Rhino.Fields;
 internal static class FieldsCore {
     /// <summary>Unified operation dispatch table: (operation, geometry type) → (execute function, validation mode, buffer size, integration method).</summary>
     internal static readonly FrozenDictionary<(byte Operation, Type GeometryType), (Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, V ValidationMode, int BufferSize, byte IntegrationMethod)> OperationRegistry =
-        new (byte Operation, Type GeometryType, Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, V ValidationMode, int BufferSize, byte IntegrationMethod)[] {
-            (FieldsConfig.OperationDistance, typeof(Mesh), ExecuteDistanceField<Mesh>, V.Standard | V.MeshSpecific, 4096, FieldsConfig.IntegrationRK4),
-            (FieldsConfig.OperationDistance, typeof(Brep), ExecuteDistanceField<Brep>, V.Standard | V.Topology, 8192, FieldsConfig.IntegrationRK4),
-            (FieldsConfig.OperationDistance, typeof(Curve), ExecuteDistanceField<Curve>, V.Standard | V.Degeneracy, 2048, FieldsConfig.IntegrationRK4),
-            (FieldsConfig.OperationDistance, typeof(Surface), ExecuteDistanceField<Surface>, V.Standard | V.BoundingBox, 4096, FieldsConfig.IntegrationRK4),
-        }.ToFrozenDictionary(
-            static entry => (entry.Operation, entry.GeometryType),
-            static entry => ((Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>>)entry.Execute, entry.ValidationMode, entry.BufferSize, entry.IntegrationMethod));
+        new Dictionary<(byte, Type), (Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>>, V, int, byte)> {
+            [(FieldsConfig.OperationDistance, typeof(Mesh))] = (ExecuteDistanceField<Mesh>, V.Standard | V.MeshSpecific, 4096, FieldsConfig.IntegrationRK4),
+            [(FieldsConfig.OperationDistance, typeof(Brep))] = (ExecuteDistanceField<Brep>, V.Standard | V.Topology, 8192, FieldsConfig.IntegrationRK4),
+            [(FieldsConfig.OperationDistance, typeof(Curve))] = (ExecuteDistanceField<Curve>, V.Standard | V.Degeneracy, 2048, FieldsConfig.IntegrationRK4),
+            [(FieldsConfig.OperationDistance, typeof(Surface))] = (ExecuteDistanceField<Surface>, V.Standard | V.BoundingBox, 4096, FieldsConfig.IntegrationRK4),
+        }.ToFrozenDictionary();
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<(Point3d[], double[])> ExecuteDistanceField<T>(


### PR DESCRIPTION
Surgical improvements to libs/rhino/fields/ following CLAUDE.md standards:

1. Eliminate duplicate degenerate bounds check in Fields.cs
   - Inline RhinoMath.EpsilonEquals expression into tuple switch
   - Remove redundant local variable in InterpolateScalar and InterpolateVector
   - Improves DRY principle adherence

2. Align FrozenDictionary pattern in FieldsCore.cs
   - Change from array projection to Dictionary initialization
   - Matches ValidationRules.cs exemplar pattern
   - Reduces verbosity: new Dictionary { [k] = v }.ToFrozenDictionary()

3. Replace IIFE with LINQ in FieldsConfig.cs
   - Replace ((Func<int[]>)(() => { ... }))() with Enumerable.Range().SelectMany()
   - Follows standard: "Use LINQ for clarity in 80-90% of code"
   - Marching cubes table generation now uses functional composition

Net impact: -10 LOC, improved readability, zero functionality change All changes retain semantics, follow expression-based patterns, use proper trailing commas