### PR TITLE
Fix RTree nearest neighbor for field interpolation

### DIFF
--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -227,7 +227,12 @@ internal static class FieldsCompute {
             ? ((Func<int>)(() => {
                 using RTree tree = RTree.CreateFromPointArray(grid);
                 int idx = -1;
-                _ = tree.Search(new Sphere(query, radius: double.MaxValue), (sender, args) => idx = args.Id);
+                double bestDistance = double.MaxValue;
+                _ = tree.Search(new Sphere(query, radius: double.MaxValue), (sender, args) => {
+                    int candidateIdx = args.Id;
+                    double distance = query.DistanceTo(grid[candidateIdx]);
+                    (idx, bestDistance) = distance < bestDistance ? (candidateIdx, distance) : (idx, bestDistance);
+                });
                 return idx;
             }))()
             : ((Func<int>)(() => {


### PR DESCRIPTION
## Summary
- fix the RTree-backed nearest-neighbor search used by `FieldsCompute.InterpolateNearest` so that we track the closest sample instead of returning the last callback result
- keep the lightweight linear scan fallback unchanged for small grids

## Testing
- Not run (dotnet command unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919387dce1883219ba929dc94ab3830)