### PR TITLE
Fix streamline interpolation

### DIFF
--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -341,12 +341,12 @@ internal static class FieldsCompute {
         }))();
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Vector3d InterpolateVectorFieldInternal(Vector3d[] vectorField, Point3d[] gridPoints, Point3d query, int resolution, BoundingBox bounds) {
-        Result<Vector3d> trilinear = InterpolateTrilinearVector(query: query, vectorField: vectorField, resolution: resolution, bounds: bounds);
-        return trilinear.Match(
+    private static Vector3d InterpolateVectorFieldInternal(Vector3d[] vectorField, Point3d[] gridPoints, Point3d query, int resolution, BoundingBox bounds) =>
+    InterpolateTrilinearVector(query: query, vectorField: vectorField, resolution: resolution, bounds: bounds)
+        .OnError(_ => InterpolateNearest(query: query, field: vectorField, grid: gridPoints))
+        .Match(
             onSuccess: value => value,
-            onFailure: _ => InterpolateNearest(query: query, field: vectorField, grid: gridPoints).Match(onSuccess: value => value, onFailure: _ => Vector3d.Zero));
-    }
+            onFailure: _ => Vector3d.Zero);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Mesh[]> ExtractIsosurfaces(

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -26,7 +26,6 @@ internal static class FieldsConfig {
     internal static readonly double[] RK4HalfSteps = [0.5, 0.5, 1.0,];
     internal const double RK2HalfStep = 0.5;
 
-    internal const int StreamlineRTreeThreshold = 1000;
     internal const int FieldRTreeThreshold = 100;
 
     internal const byte CriticalPointMinimum = 0;


### PR DESCRIPTION
## Summary
- ensure streamline integration samples the vector field with trilinear interpolation regardless of grid size and fall back to nearest-neighbor only if interpolation fails
- remove the unused streamline-specific RTree threshold constant now that we no longer build a tree per integration run

## Testing
- `dotnet build` *(fails: `dotnet` is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919387dce1883219ba929dc94ab3830)