### PR TITLE
Clamp field resolution to max

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -19,9 +19,10 @@ public static class Fields {
         BoundingBox? bounds = null,
         double? stepSize = null) {
         /// <summary>Grid resolution (cube root of sample count).</summary>
-        public readonly int Resolution = resolution >= FieldsConfig.MinResolution
-            ? resolution
-            : FieldsConfig.DefaultResolution;
+        public readonly int Resolution = RhinoMath.Clamp(
+            resolution >= FieldsConfig.MinResolution ? resolution : FieldsConfig.DefaultResolution,
+            FieldsConfig.MinResolution,
+            FieldsConfig.MaxResolution);
         /// <summary>Sample region bounding box (null uses geometry bounds).</summary>
         public readonly BoundingBox? Bounds = bounds;
         /// <summary>Integration/sampling step size.</summary>

--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -19,8 +19,12 @@ public static class Fields {
         BoundingBox? bounds = null,
         double? stepSize = null) {
         /// <summary>Grid resolution (cube root of sample count).</summary>
+        private static int NormalizeResolution(int resolution) =>
+            resolution >= FieldsConfig.MinResolution
+                ? resolution
+                : FieldsConfig.DefaultResolution;
         public readonly int Resolution = RhinoMath.Clamp(
-            resolution >= FieldsConfig.MinResolution ? resolution : FieldsConfig.DefaultResolution,
+            NormalizeResolution(resolution),
             FieldsConfig.MinResolution,
             FieldsConfig.MaxResolution);
         /// <summary>Sample region bounding box (null uses geometry bounds).</summary>


### PR DESCRIPTION
## Summary
- clamp `FieldSpec.Resolution` to the Rhino field limits so downstream computations always receive grid dimensions that match the generated field data

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919387dce1883219ba929dc94ab3830)