### PR TITLE
Fix topology lookups in morphology operations

### DIFF
--- a/libs/rhino/morphology/MorphologyCompute.cs
+++ b/libs/rhino/morphology/MorphologyCompute.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Buffers;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
@@ -129,7 +130,8 @@ internal static class MorphologyCompute {
 
         Point3d[] newVerts = new Point3d[vertCount];
         for (int i = 0; i < vertCount; i++) {
-            int[] neighbors = mesh.TopologyVertices.ConnectedTopologyVertices(i);
+            int topologyIndex = mesh.TopologyVertices.TopologyVertexIndex(i);
+            int[] neighbors = topologyIndex >= 0 ? mesh.TopologyVertices.ConnectedTopologyVertices(topologyIndex) : Array.Empty<int>();
             int valence = neighbors.Length;
             double beta = valence is 3
                 ? MorphologyConfig.LoopBetaValence3
@@ -204,8 +206,10 @@ internal static class MorphologyCompute {
                 } else {
                     (int v1, int v2) = (edges[e].Item1, edges[e].Item2);
                     Point3d mid = MorphologyConfig.ButterflyMidpointWeight * (originalVerts[v1] + originalVerts[v2]);
-                    int[] v1Neighbors = mesh.TopologyVertices.ConnectedTopologyVertices(v1);
-                    int[] v2Neighbors = mesh.TopologyVertices.ConnectedTopologyVertices(v2);
+                    int v1TopologyIndex = mesh.TopologyVertices.TopologyVertexIndex(v1);
+                    int v2TopologyIndex = mesh.TopologyVertices.TopologyVertexIndex(v2);
+                    int[] v1Neighbors = v1TopologyIndex >= 0 ? mesh.TopologyVertices.ConnectedTopologyVertices(v1TopologyIndex) : Array.Empty<int>();
+                    int[] v2Neighbors = v2TopologyIndex >= 0 ? mesh.TopologyVertices.ConnectedTopologyVertices(v2TopologyIndex) : Array.Empty<int>();
                     (int opposite1, int opposite2) = v1Neighbors.Length >= 4 && v2Neighbors.Length >= 4
                         ? FindButterflyOpposites(mesh, v1, v2)
                         : (-1, -1);
@@ -291,7 +295,9 @@ internal static class MorphologyCompute {
                         Point3d[] updated = updateFunc(smoothed, positions, context);
 
                         for (int i = 0; i < smoothed.Vertices.Count; i++) {
-                            bool isBoundary = lockBoundary && (mesh.TopologyVertices.ConnectedFaces(i).Length < 2);
+                            int topologyIndex = mesh.TopologyVertices.TopologyVertexIndex(i);
+                            int[] connectedFaces = topologyIndex >= 0 ? mesh.TopologyVertices.ConnectedFaces(topologyIndex) : Array.Empty<int>();
+                            bool isBoundary = lockBoundary && (connectedFaces.Length < 2);
                             positions[i] = isBoundary ? positions[i] : updated[i];
                             _ = smoothed.Vertices.SetVertex(i, positions[i]);
                         }

--- a/libs/rhino/morphology/MorphologyCore.cs
+++ b/libs/rhino/morphology/MorphologyCore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Frozen;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
@@ -150,7 +151,8 @@ internal static class MorphologyCore {
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Point3d[] LaplacianUpdate(Mesh mesh, Point3d[] positions, bool useCotangent) =>
         [.. Enumerable.Range(0, positions.Length).Select(i => {
-            int[] neighbors = mesh.TopologyVertices.ConnectedTopologyVertices(i);
+            int topologyIndex = mesh.TopologyVertices.TopologyVertexIndex(i);
+            int[] neighbors = topologyIndex >= 0 ? mesh.TopologyVertices.ConnectedTopologyVertices(topologyIndex) : Array.Empty<int>();
             return neighbors.Length is 0
                 ? positions[i]
                 : neighbors.Aggregate(
@@ -170,7 +172,8 @@ internal static class MorphologyCore {
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Point3d[] MeanCurvatureFlowUpdate(Mesh mesh, Point3d[] positions, double timeStep, IGeometryContext _) =>
         [.. Enumerable.Range(0, positions.Length).Select(i => {
-            int[] neighbors = mesh.TopologyVertices.ConnectedTopologyVertices(i);
+            int topologyIndex = mesh.TopologyVertices.TopologyVertexIndex(i);
+            int[] neighbors = topologyIndex >= 0 ? mesh.TopologyVertices.ConnectedTopologyVertices(topologyIndex) : Array.Empty<int>();
             return neighbors.Length is 0
                 ? positions[i]
                 : positions[i] + ((timeStep * (mesh.Normals.Count > i ? mesh.Normals[i] : Vector3d.ZAxis) *


### PR DESCRIPTION
## Summary
- ensure Laplacian and mean-curvature updates pull adjacency data from the correct topology vertices
- update Loop and Butterfly subdivision along with smoothing boundary locks to use topology indices
- add missing System namespace imports for the new Array.Empty usage

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919387672348321a6ee7df4b9430517)