### PR TITLE
Fix subdivision failure handling

### DIFF
--- a/libs/rhino/morphology/MorphologyCompute.cs
+++ b/libs/rhino/morphology/MorphologyCompute.cs
@@ -110,11 +110,13 @@ internal static class MorphologyCompute {
                         if (level > 0) {
                             current.Dispose();
                         }
-                        return !valid
-                            ? (level is 0
-                                ? ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.SubdivisionFailed.WithContext(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Level: {level}, Algorithm: {algorithm}")))
-                                : result)
-                            : ResultFactory.Create(value: next);
+                        if (!valid) {
+                            next?.Dispose();
+                            return ResultFactory.Create<Mesh>(
+                                error: E.Geometry.Morphology.SubdivisionFailed.WithContext(
+                                    string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Level: {level}, Algorithm: {algorithm}")));
+                        }
+                        return ResultFactory.Create(value: next);
                     }));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- ensure morphology subdivision iterations stop with an error if a later level fails validation rather than silently succeeding with an old mesh
- dispose intermediate meshes when validation fails to avoid leaking unmanaged Rhino geometry

## Testing
- dotnet build *(fails: `dotnet` not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194c66e2008321bcb89797cf499c33)