### PR TITLE
Fix distance field config lookup for derived types

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -49,7 +49,10 @@ public static class Fields {
         T geometry,
         FieldSpec spec,
         IGeometryContext context) where T : GeometryBase =>
-        FieldsCore.OperationRegistry.TryGetValue((FieldsConfig.OperationDistance, typeof(T)), out (Func<object, FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, Core.Validation.V ValidationMode, int BufferSize, byte IntegrationMethod) config) switch {
+        FieldsCore.TryGetOperationConfig(
+            operation: FieldsConfig.OperationDistance,
+            geometryType: geometry.GetType(),
+            out (Func<object, FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, Core.Validation.V ValidationMode, int BufferSize, byte IntegrationMethod) config) switch {
             true => UnifiedOperation.Apply(
                 input: geometry,
                 operation: (Func<T, Result<IReadOnlyList<(Point3d[], double[])>>>)(item =>


### PR DESCRIPTION
## Summary
- add a helper that resolves field operation configs by walking the Rhino geometry type hierarchy
- update `Fields.DistanceField` to use runtime geometry types so derived RhinoCommon classes (e.g., `NurbsCurve`) dispatch correctly

## Testing
- `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194c6aed7c83218118299d878afa23)