### PR TITLE
Validate Hessian input before critical point detection

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -318,12 +318,30 @@ public static class Fields {
         double[,][] hessian,
         Point3d[] gridPoints,
         FieldSpec spec) =>
-        (scalarField.Length == gridPoints.Length, gradientField.Length == gridPoints.Length) switch {
-            (false, _) => ResultFactory.Create<CriticalPoint[]>(
+        ((Func<(bool ScalarLengthMatches, bool GradientLengthMatches, bool HessianValid)>)(() => {
+            bool has3Rows = hessian.GetLength(0) == 3;
+            bool has3Columns = hessian.GetLength(1) == 3;
+            bool hessianEntriesValid = has3Rows && has3Columns;
+            if (hessianEntriesValid) {
+                for (int row = 0; row < 3 && hessianEntriesValid; row++) {
+                    for (int column = 0; column < 3 && hessianEntriesValid; column++) {
+                        double[] entry = hessian[row, column];
+                        hessianEntriesValid = entry is not null && entry.Length == gridPoints.Length;
+                    }
+                }
+            }
+            return (
+                ScalarLengthMatches: scalarField.Length == gridPoints.Length,
+                GradientLengthMatches: gradientField.Length == gridPoints.Length,
+                HessianValid: hessianEntriesValid);
+        }))() switch {
+            (false, _, _) => ResultFactory.Create<CriticalPoint[]>(
                 error: E.Geometry.InvalidCriticalPointDetection.WithContext("Scalar field length must match grid points")),
-            (_, false) => ResultFactory.Create<CriticalPoint[]>(
+            (_, false, _) => ResultFactory.Create<CriticalPoint[]>(
                 error: E.Geometry.InvalidCriticalPointDetection.WithContext("Gradient field length must match grid points")),
-            (true, true) => FieldsCompute.DetectCriticalPoints(
+            (_, _, false) => ResultFactory.Create<CriticalPoint[]>(
+                error: E.Geometry.InvalidCriticalPointDetection.WithContext("Hessian must be a 3x3 tensor with entries per grid sample")),
+            (true, true, true) => FieldsCompute.DetectCriticalPoints(
                 scalarField: scalarField,
                 gradientField: gradientField,
                 hessian: hessian,


### PR DESCRIPTION
## Summary
- add structural validation so `Fields.CriticalPoints` rejects Hessian tensors that are not 3x3 or whose entries are not aligned with the grid length before dispatching to the compute pipeline

## Testing
- `dotnet build` *(fails: `dotnet` CLI is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194c6aed7c83218118299d878afa23)