### PR TITLE
Improve vector potential solver

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -113,7 +113,7 @@ public static class Fields {
             .Ensure(v => v.scalarField.Length == v.gridPoints.Length, error: E.Geometry.InvalidLaplacianComputation.WithContext("Scalar field length must match grid points"))
             .Bind(_ => FieldsCompute.ComputeLaplacian(scalarField: scalarField, grid: gridPoints, resolution: spec.Resolution, gridDelta: (bounds.Max - bounds.Min) / (spec.Resolution - 1)));
 
-    /// <summary>Compute vector potential field: magnetic field B → (grid points[], vector potential A[]) where B = ∇×A. Uses Coulomb gauge approximation via x-axis line integral (accurate only for fields with simple structure aligned with x-axis; general 3D magnetic fields require full volume integral).</summary>
+    /// <summary>Compute vector potential field: magnetic field B → (grid points[], vector potential A[]) where B = ∇×A. Solves the Coulomb-gauge Poisson system (∇²A = -∇×B) with zero boundary conditions for robust 3D fields.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<(Point3d[] Grid, Vector3d[] Potential)> VectorPotentialField(
         Vector3d[] magneticField,

--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -297,9 +297,6 @@ internal static class FieldsCompute {
                         (ax, axNext) = (axNext, ax);
                         (ay, ayNext) = (ayNext, ay);
                         (az, azNext) = (azNext, az);
-                        Array.Clear(axNext, 0, totalSamples);
-                        Array.Clear(ayNext, 0, totalSamples);
-                        Array.Clear(azNext, 0, totalSamples);
                         if (maxChange < FieldsConfig.VectorPotentialTolerance) {
                             converged = true;
                             iteration = FieldsConfig.VectorPotentialMaxIterations;

--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -299,7 +299,7 @@ internal static class FieldsCompute {
                         (az, azNext) = (azNext, az);
                         if (maxChange < FieldsConfig.VectorPotentialTolerance) {
                             converged = true;
-                            iteration = FieldsConfig.VectorPotentialMaxIterations;
+                            break;
                         }
                     }
                     return converged switch {

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -21,6 +21,8 @@ internal static class FieldsConfig {
     internal const double MaxStepSize = 1.0;
     internal const int MaxStreamlineSteps = 10000;
     internal const double MinFieldMagnitude = 1e-10;
+    internal const int VectorPotentialMaxIterations = 256;
+    internal const double VectorPotentialTolerance = 1e-6;
 
     internal static readonly double[] RK4Weights = [1.0 / 6.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 6.0,];
     internal static readonly double[] RK4HalfSteps = [0.5, 0.5, 1.0,];


### PR DESCRIPTION
## Summary
- replace the ad-hoc line-integration vector potential routine with a Coulomb-gauge Poisson solver that derives A from the curl of B and enforces convergence/tolerance controls
- add iteration/tolerance configuration constants for the solver and document the strengthened VectorPotentialField contract

## Testing
- `dotnet build` *(fails: dotnet is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba8b92bc4832183d6a006cab47a18)