### PR TITLE
Handle invalid scalar fields in statistics

### DIFF
--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -800,24 +800,28 @@ internal static class FieldsCompute {
                     }
                 }
 
-                double mean = validCount > 0 ? sum / validCount : 0.0;
-                double sumSquaredDiff = 0.0;
-                for (int i = 0; i < scalarField.Length; i++) {
-                    double value = scalarField[i];
-                    if (RhinoMath.IsValidDouble(value)) {
-                        double diff = value - mean;
-                        sumSquaredDiff += diff * diff;
-                    }
-                }
-                double stdDev = validCount > 0 ? Math.Sqrt(sumSquaredDiff / validCount) : 0.0;
+                return validCount > 0
+                    ? ((Func<Result<Fields.FieldStatistics>>)(() => {
+                        double mean = sum / validCount;
+                        double sumSquaredDiff = 0.0;
+                        for (int i = 0; i < scalarField.Length; i++) {
+                            double value = scalarField[i];
+                            if (RhinoMath.IsValidDouble(value)) {
+                                double diff = value - mean;
+                                sumSquaredDiff += diff * diff;
+                            }
+                        }
+                        double stdDev = Math.Sqrt(sumSquaredDiff / validCount);
 
-                return ResultFactory.Create(value: new Fields.FieldStatistics(
-                    Min: min,
-                    Max: max,
-                    Mean: mean,
-                    StdDev: stdDev,
-                    MinLocation: grid[minIdx],
-                    MaxLocation: grid[maxIdx]));
+                        return ResultFactory.Create(value: new Fields.FieldStatistics(
+                            Min: min,
+                            Max: max,
+                            Mean: mean,
+                            StdDev: stdDev,
+                            MinLocation: grid[minIdx],
+                            MaxLocation: grid[maxIdx]));
+                    }))()
+                    : ResultFactory.Create<Fields.FieldStatistics>(error: E.Geometry.InvalidFieldStatistics.WithContext("Scalar field contains no valid samples"));
             }))(),
         };
     }


### PR DESCRIPTION
## Summary
- ensure field statistics report an error when every scalar sample is invalid
- only compute mean and standard deviation once at least one valid sample exists

## Testing
- `dotnet build` *(fails: `dotnet` command is unavailable in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba8b92bc4832183d6a006cab47a18)