### PR TITLE
Refine morphology metric computations

### DIFF
--- a/libs/rhino/morphology/MorphologyCore.cs
+++ b/libs/rhino/morphology/MorphologyCore.cs
@@ -216,21 +216,7 @@ internal static class MorphologyCore {
         Mesh original,
         Mesh subdivided,
         IGeometryContext context) {
-        double[] edgeLengths = [.. Enumerable.Range(0, subdivided.TopologyEdges.Count).Select(i => subdivided.TopologyEdges.EdgeLine(i).Length),];
-        (double aspectRatio, double[] angles)[] metrics = [.. Enumerable.Range(0, subdivided.Faces.Count).Select(i => {
-            (Point3d a, Point3d b, Point3d c) = (subdivided.Vertices[subdivided.Faces[i].A], subdivided.Vertices[subdivided.Faces[i].B], subdivided.Vertices[subdivided.Faces[i].C]);
-            (double ab, double bc, double ca) = (a.DistanceTo(b), b.DistanceTo(c), c.DistanceTo(a));
-            (double maxEdge, double minEdge) = (Math.Max(Math.Max(ab, bc), ca), Math.Min(Math.Min(ab, bc), ca));
-            return (
-                aspectRatio: minEdge > context.AbsoluteTolerance ? maxEdge / minEdge : double.MaxValue,
-                angles: new[] {
-                    Vector3d.VectorAngle(b - a, c - a),
-                    Vector3d.VectorAngle(a - b, c - b),
-                    Vector3d.VectorAngle(a - c, b - c),
-                }
-            );
-        }),
-        ];
+        (double[] edgeLengths, double[] aspectRatios, double[] minAngles) = ComputeMeshMetrics(subdivided, context);
         return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(value: [
             new Morphology.SubdivisionResult(
                 subdivided,
@@ -239,8 +225,8 @@ internal static class MorphologyCore {
                 edgeLengths.Min(),
                 edgeLengths.Max(),
                 edgeLengths.Average(),
-                metrics.Average(m => m.aspectRatio),
-                metrics.SelectMany(m => m.angles).Min()),
+                aspectRatios.Average(),
+                minAngles.Min()),
         ]);
     }
 
@@ -273,16 +259,20 @@ internal static class MorphologyCore {
         Mesh original,
         Mesh offset,
         double _,
-        IGeometryContext context) {
-        int minCount = Math.Min(original.Vertices.Count, offset.Vertices.Count);
-        double actualDist = minCount > 0
-            ? Enumerable.Range(0, minCount).Average(i => ((Point3d)original.Vertices[i]).DistanceTo(offset.Vertices[i]))
-            : 0.0;
-        bool hasDegen = !MorphologyCompute.ValidateMeshQuality(offset, context).IsSuccess;
-
-        return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
-            value: [new Morphology.OffsetResult(offset, actualDist, hasDegen, original.Vertices.Count, offset.Vertices.Count, original.Faces.Count, offset.Faces.Count),]);
-    }
+        IGeometryContext context) =>
+        ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(value: [
+            new Morphology.OffsetResult(
+                offset,
+                Math.Min(original.Vertices.Count, offset.Vertices.Count) switch {
+                    0 => 0.0,
+                    int sampleCount => Enumerable.Range(0, sampleCount).Average(i => ((Point3d)original.Vertices[i]).DistanceTo(offset.Vertices[i])),
+                },
+                !MorphologyCompute.ValidateMeshQuality(offset, context).IsSuccess,
+                original.Vertices.Count,
+                offset.Vertices.Count,
+                original.Faces.Count,
+                offset.Faces.Count),
+        ]);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeReductionMetrics(
@@ -290,15 +280,13 @@ internal static class MorphologyCore {
         Mesh reduced,
         IGeometryContext context) {
         (double[] edgeLengths, double[] aspectRatios, double[] _) = ComputeMeshMetrics(reduced, context);
-        double reductionRatio = original.Faces.Count > 0 ? (double)reduced.Faces.Count / original.Faces.Count : 1.0;
-        double quality = MorphologyCompute.ValidateMeshQuality(reduced, context).IsSuccess ? 1.0 : 0.0;
         return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
             value: [new Morphology.ReductionResult(
                 reduced,
                 original.Faces.Count,
                 reduced.Faces.Count,
-                reductionRatio,
-                quality,
+                original.Faces.Count > 0 ? (double)reduced.Faces.Count / original.Faces.Count : 1.0,
+                MorphologyCompute.ValidateMeshQuality(reduced, context).IsSuccess ? 1.0 : 0.0,
                 aspectRatios.Length > 0 ? aspectRatios.Average() : 0.0,
                 edgeLengths.Length > 0 ? edgeLengths.Min() : 0.0,
                 edgeLengths.Length > 0 ? edgeLengths.Max() : 0.0),

--- a/libs/rhino/morphology/MorphologyCore.cs
+++ b/libs/rhino/morphology/MorphologyCore.cs
@@ -265,7 +265,7 @@ internal static class MorphologyCore {
                 offset,
                 Math.Min(original.Vertices.Count, offset.Vertices.Count) switch {
                     0 => 0.0,
-                    int sampleCount => Enumerable.Range(0, sampleCount).Average(i => ((Point3d)original.Vertices[i]).DistanceTo(offset.Vertices[i])),
+                    int sampleCount => Enumerable.Range(0, sampleCount).Average((int i) => ((Point3d)original.Vertices[i]).DistanceTo(offset.Vertices[i])),
                 },
                 !MorphologyCompute.ValidateMeshQuality(offset, context).IsSuccess,
                 original.Vertices.Count,


### PR DESCRIPTION
## Summary
- reuse the shared mesh metric calculator for subdivision reports to avoid recomputing identical values
- streamline offset metrics by computing displacement directly inside the result expression and removing temporary variables
- inline reduction ratio/quality calculations so the reduction summary stays dense and expression oriented

## Testing
- `dotnet build` *(fails: `dotnet` CLI is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bbcb0955c8321911899e9ba66a102)