### PR TITLE
Refactor transform folder for code quality

### DIFF
--- a/libs/rhino/transformation/TransformCompute.cs
+++ b/libs/rhino/transformation/TransformCompute.cs
@@ -203,7 +203,7 @@ internal static class TransformCompute {
         bool orientToPath,
         IGeometryContext context,
         bool enableDiagnostics) where T : GeometryBase {
-        if (count <= 0 || count > TransformConfig.MaxArrayCount || !path.IsValid || !geometry.IsValid) {
+        if (count <= 0 || count > TransformConfig.MaxArrayCount || path is null || !path.IsValid || !geometry.IsValid) {
             return ResultFactory.Create<IReadOnlyList<T>>(
                 error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
                     System.Globalization.CultureInfo.InvariantCulture,

--- a/libs/rhino/transformation/TransformCompute.cs
+++ b/libs/rhino/transformation/TransformCompute.cs
@@ -13,10 +13,6 @@ namespace Arsenal.Rhino.Transformation;
 
 /// <summary>SpaceMorph deformation operations and curve-based array transformations.</summary>
 internal static class TransformCompute {
-    private const string DoubleFormat = "F6";
-
-    private static string Fmt(double value) => value.ToString(DoubleFormat, System.Globalization.CultureInfo.InvariantCulture);
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static double MorphTolerance(IGeometryContext context) =>
         Math.Max(context.AbsoluteTolerance, TransformConfig.DefaultMorphTolerance);
@@ -61,7 +57,7 @@ internal static class TransformCompute {
                     QuickPreview = false,
                 },
                 geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidTwistParameters.WithContext($"Axis: {axis.IsValid}, Angle: {Fmt(angleRadians)}, Geometry: {geometry.IsValid}"));
+            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidTwistParameters.WithContext($"Axis: {axis.IsValid}, Angle: {TransformCore.Fmt(angleRadians)}, Geometry: {geometry.IsValid}"));
 
     /// <summary>Bend geometry along spine.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -75,7 +71,7 @@ internal static class TransformCompute {
                 morph: new BendSpaceMorph(
                     start: spine.From,
                     end: spine.To,
-                    point: spine.From + (spine.Direction * (spine.Length * 0.5)),
+                    point: spine.PointAt(0.5),
                     angle: angle,
                     straight: false,
                     symmetric: false) {
@@ -84,7 +80,7 @@ internal static class TransformCompute {
                     QuickPreview = false,
                 },
                 geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidBendParameters.WithContext($"Spine: {spine.IsValid}, Angle: {Fmt(angle)}, Geometry: {geometry.IsValid}"));
+            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidBendParameters.WithContext($"Spine: {spine.IsValid}, Angle: {TransformCore.Fmt(angle)}, Geometry: {geometry.IsValid}"));
 
     /// <summary>Taper geometry along axis from start width to end width.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -111,7 +107,7 @@ internal static class TransformCompute {
                     QuickPreview = false,
                 },
                 geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidTaperParameters.WithContext($"Axis: {axis.IsValid}, Start: {Fmt(startWidth)}, End: {Fmt(endWidth)}, Geometry: {geometry.IsValid}"));
+            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidTaperParameters.WithContext($"Axis: {axis.IsValid}, Start: {TransformCore.Fmt(startWidth)}, End: {TransformCore.Fmt(endWidth)}, Geometry: {geometry.IsValid}"));
 
     /// <summary>Stretch geometry along axis.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -196,7 +192,7 @@ internal static class TransformCompute {
                     QuickPreview = false,
                 },
                 geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidMaelstromParameters.WithContext($"Center: {center.IsValid}, Axis: {axis.IsValid}, Radius: {Fmt(radius)}, Geometry: {geometry.IsValid}"));
+            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidMaelstromParameters.WithContext($"Center: {center.IsValid}, Axis: {axis.IsValid}, Radius: {TransformCore.Fmt(radius)}, Geometry: {geometry.IsValid}"));
 
     /// <summary>Array geometry along path curve with optional orientation.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -207,7 +203,7 @@ internal static class TransformCompute {
         bool orientToPath,
         IGeometryContext context,
         bool enableDiagnostics) where T : GeometryBase {
-        if (path is null || count <= 0 || count > TransformConfig.MaxArrayCount || !path.IsValid || !geometry.IsValid) {
+        if (count <= 0 || count > TransformConfig.MaxArrayCount || !path.IsValid || !geometry.IsValid) {
             return ResultFactory.Create<IReadOnlyList<T>>(
                 error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
                     System.Globalization.CultureInfo.InvariantCulture,
@@ -216,7 +212,7 @@ internal static class TransformCompute {
 
         Transform[] transforms = new Transform[count];
         Interval domain = path.Domain;
-        double step = count > 1 ? (domain.Max - domain.Min) / (count - 1) : 0.0;
+        double step = count > 1 ? domain.Length / (count - 1) : 0.0;
 
         for (int i = 0; i < count; i++) {
             double t = count > 1 ? domain.Min + (step * i) : domain.Mid;

--- a/libs/rhino/transformation/TransformCore.cs
+++ b/libs/rhino/transformation/TransformCore.cs
@@ -31,7 +31,7 @@ internal static class TransformCore {
                 s => Transform.Rotation(s.RotationVectors!.Value.Start, s.RotationVectors.Value.End, s.RotationVectors.Value.Center), E.Geometry.Transformation.InvalidRotationAxis),
             [6] = ((s, _) => (s.MirrorPlane is Plane p && p.IsValid, string.Empty),
                 s => Transform.Mirror(s.MirrorPlane!.Value), E.Geometry.Transformation.InvalidMirrorPlane),
-            [7] = ((s, _) => (s.Translation is Vector3d motion, string.Empty),
+            [7] = ((s, _) => (s.Translation is Vector3d _, string.Empty),
                 s => Transform.Translation(s.Translation!.Value), E.Geometry.Transformation.InvalidTransformSpec),
             [8] = ((s, c) => (s.Shear is (Plane p, Vector3d d, double angle) && p.IsValid && d.Length > c.AbsoluteTolerance && p.ZAxis.IsParallelTo(d, c.AngleToleranceRadians * TransformConfig.AngleToleranceMultiplier) == 0, $"Plane: {s.Shear?.Plane.IsValid ?? false}, Dir: {Fmt(s.Shear?.Direction.Length ?? 0)}"),
                 s => Transform.Shear(s.Shear!.Value.Plane, s.Shear.Value.Direction * Math.Tan(s.Shear.Value.Angle), Vector3d.Zero, Vector3d.Zero), E.Geometry.Transformation.InvalidShearParameters),

--- a/libs/rhino/transformation/TransformCore.cs
+++ b/libs/rhino/transformation/TransformCore.cs
@@ -13,27 +13,27 @@ namespace Arsenal.Rhino.Transformation;
 
 /// <summary>Transform matrix construction, validation, and application.</summary>
 internal static class TransformCore {
-    private const string DoubleFormat = "F6";
+    internal const string DoubleFormat = "F6";
 
-    private static string Fmt(double value) => value.ToString(DoubleFormat, System.Globalization.CultureInfo.InvariantCulture);
+    internal static string Fmt(double value) => value.ToString(DoubleFormat, System.Globalization.CultureInfo.InvariantCulture);
 
     private static readonly FrozenDictionary<byte, (Func<Transforms.TransformSpec, IGeometryContext, (bool Valid, string Context)> Validate, Func<Transforms.TransformSpec, Transform> Build, SystemError Error)> _builders =
         new Dictionary<byte, (Func<Transforms.TransformSpec, IGeometryContext, (bool, string)>, Func<Transforms.TransformSpec, Transform>, SystemError)> {
             [1] = ((s, c) => (s.Matrix is Transform m && m.IsValid && Math.Abs(m.Determinant) > c.AbsoluteTolerance, $"Valid: {s.Matrix?.IsValid ?? false}, Det: {Fmt(s.Matrix?.Determinant ?? 0)}"),
                 s => s.Matrix!.Value, E.Geometry.Transformation.InvalidTransformMatrix),
-            [2] = ((s, _) => (s.UniformScale is (Point3d, double f) && f is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor, $"Factor: {Fmt(s.UniformScale?.Factor ?? 0)}"),
+            [2] = ((s, _) => (s.UniformScale is (Point3d anchor, double f) && f is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor, $"Factor: {Fmt(s.UniformScale?.Factor ?? 0)}"),
                 s => Transform.Scale(s.UniformScale!.Value.Anchor, s.UniformScale.Value.Factor), E.Geometry.Transformation.InvalidScaleFactor),
             [3] = ((s, _) => (s.NonUniformScale is (Plane p, double x, double y, double z) && p.IsValid && x is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor && y is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor && z is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor, $"Plane: {s.NonUniformScale?.Plane.IsValid ?? false}, X: {Fmt(s.NonUniformScale?.X ?? 0)}, Y: {Fmt(s.NonUniformScale?.Y ?? 0)}, Z: {Fmt(s.NonUniformScale?.Z ?? 0)}"),
                 s => Transform.Scale(s.NonUniformScale!.Value.Plane, s.NonUniformScale.Value.X, s.NonUniformScale.Value.Y, s.NonUniformScale.Value.Z), E.Geometry.Transformation.InvalidScaleFactor),
-            [4] = ((s, c) => (s.Rotation is (double, Vector3d a, Point3d) && a.Length > c.AbsoluteTolerance, $"Axis: {Fmt(s.Rotation?.Axis.Length ?? 0)}"),
-                s => Transform.Rotation(s.Rotation!.Value.Angle, s.Rotation.Value.Axis, s.Rotation.Value.Center), E.Geometry.Transformation.InvalidRotationAxis),
-            [5] = ((s, c) => (s.RotationVectors is (Vector3d st, Vector3d en, Point3d) && st.Length > c.AbsoluteTolerance && en.Length > c.AbsoluteTolerance, $"Start: {Fmt(s.RotationVectors?.Start.Length ?? 0)}, End: {Fmt(s.RotationVectors?.End.Length ?? 0)}"),
+            [4] = ((s, c) => (s.Rotation is (double angle, Vector3d a, Point3d center) && a.Length > c.AbsoluteTolerance, $"Axis: {Fmt(s.Rotation?.Axis.Length ?? 0)}"),
+                s => Transform.Rotation(s.Rotation!.Value.Angle, s.Rotation.Value.Axis, s.Rotation!.Value.Center), E.Geometry.Transformation.InvalidRotationAxis),
+            [5] = ((s, c) => (s.RotationVectors is (Vector3d st, Vector3d en, Point3d center) && st.Length > c.AbsoluteTolerance && en.Length > c.AbsoluteTolerance, $"Start: {Fmt(s.RotationVectors?.Start.Length ?? 0)}, End: {Fmt(s.RotationVectors?.End.Length ?? 0)}"),
                 s => Transform.Rotation(s.RotationVectors!.Value.Start, s.RotationVectors.Value.End, s.RotationVectors.Value.Center), E.Geometry.Transformation.InvalidRotationAxis),
             [6] = ((s, _) => (s.MirrorPlane is Plane p && p.IsValid, string.Empty),
                 s => Transform.Mirror(s.MirrorPlane!.Value), E.Geometry.Transformation.InvalidMirrorPlane),
-            [7] = ((s, _) => (s.Translation is Vector3d, string.Empty),
+            [7] = ((s, _) => (s.Translation is Vector3d motion, string.Empty),
                 s => Transform.Translation(s.Translation!.Value), E.Geometry.Transformation.InvalidTransformSpec),
-            [8] = ((s, c) => (s.Shear is (Plane p, Vector3d d, double) && p.IsValid && d.Length > c.AbsoluteTolerance && p.ZAxis.IsParallelTo(d, c.AngleToleranceRadians * TransformConfig.AngleToleranceMultiplier) == 0, $"Plane: {s.Shear?.Plane.IsValid ?? false}, Dir: {Fmt(s.Shear?.Direction.Length ?? 0)}"),
+            [8] = ((s, c) => (s.Shear is (Plane p, Vector3d d, double angle) && p.IsValid && d.Length > c.AbsoluteTolerance && p.ZAxis.IsParallelTo(d, c.AngleToleranceRadians * TransformConfig.AngleToleranceMultiplier) == 0, $"Plane: {s.Shear?.Plane.IsValid ?? false}, Dir: {Fmt(s.Shear?.Direction.Length ?? 0)}"),
                 s => Transform.Shear(s.Shear!.Value.Plane, s.Shear.Value.Direction * Math.Tan(s.Shear.Value.Angle), Vector3d.Zero, Vector3d.Zero), E.Geometry.Transformation.InvalidShearParameters),
             [9] = ((s, _) => (s.ProjectionPlane is Plane p && p.IsValid, string.Empty),
                 s => Transform.PlanarProjection(s.ProjectionPlane!.Value), E.Geometry.Transformation.InvalidProjectionPlane),
@@ -64,16 +64,20 @@ internal static class TransformCore {
     internal static Result<IReadOnlyList<T>> ApplyTransform<T>(
         T item,
         Transform transform) where T : GeometryBase {
-        bool isExtrusion = item is Extrusion;
-        GeometryBase normalized = isExtrusion ? ((Extrusion)(object)item).ToBrep(splitKinkyFaces: true) : item;
-        bool shouldDispose = isExtrusion;
+        GeometryBase normalized = item is Extrusion extrusion
+            ? extrusion.ToBrep(splitKinkyFaces: true)
+            : item;
         T duplicate = (T)normalized.Duplicate();
         Result<IReadOnlyList<T>> result = duplicate.Transform(transform)
             ? ResultFactory.Create<IReadOnlyList<T>>(value: [duplicate,])
             : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.Transformation.TransformApplicationFailed);
 
-        if (shouldDispose && normalized is IDisposable disposable) {
+        if (item is Extrusion && normalized is IDisposable disposable) {
             disposable.Dispose();
+        }
+
+        if (!result.IsSuccess && duplicate is IDisposable duplicateDisposable) {
+            duplicateDisposable.Dispose();
         }
 
         return result;
@@ -181,17 +185,18 @@ internal static class TransformCore {
         double spacing,
         IGeometryContext context,
         bool enableDiagnostics) where T : GeometryBase {
+        double dirLength = direction.Length;
         if (count <= 0 || count > TransformConfig.MaxArrayCount
-            || direction.Length <= context.AbsoluteTolerance
+            || dirLength <= context.AbsoluteTolerance
             || Math.Abs(spacing) <= context.AbsoluteTolerance) {
             return ResultFactory.Create<IReadOnlyList<T>>(
                 error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
                     System.Globalization.CultureInfo.InvariantCulture,
-                    $"Count: {count}, Direction: {Fmt(direction.Length)}, Spacing: {Fmt(spacing)}")));
+                    $"Count: {count}, Direction: {Fmt(dirLength)}, Spacing: {Fmt(spacing)}")));
         }
 
         Transform[] transforms = new Transform[count];
-        Vector3d step = (direction / direction.Length) * spacing;
+        Vector3d step = (direction / dirLength) * spacing;
 
         for (int i = 0; i < count; i++) {
             transforms[i] = Transform.Translation(step * i);

--- a/libs/rhino/transformation/TransformCore.cs
+++ b/libs/rhino/transformation/TransformCore.cs
@@ -26,7 +26,9 @@ internal static class TransformCore {
             [3] = ((s, _) => (s.NonUniformScale is (Plane p, double x, double y, double z) && p.IsValid && x is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor && y is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor && z is >= TransformConfig.MinScaleFactor and <= TransformConfig.MaxScaleFactor, $"Plane: {s.NonUniformScale?.Plane.IsValid ?? false}, X: {Fmt(s.NonUniformScale?.X ?? 0)}, Y: {Fmt(s.NonUniformScale?.Y ?? 0)}, Z: {Fmt(s.NonUniformScale?.Z ?? 0)}"),
                 s => Transform.Scale(s.NonUniformScale!.Value.Plane, s.NonUniformScale.Value.X, s.NonUniformScale.Value.Y, s.NonUniformScale.Value.Z), E.Geometry.Transformation.InvalidScaleFactor),
             [4] = ((s, c) => (s.Rotation is (double angle, Vector3d a, Point3d center) && a.Length > c.AbsoluteTolerance, $"Axis: {Fmt(s.Rotation?.Axis.Length ?? 0)}"),
-                s => Transform.Rotation(s.Rotation!.Value.Angle, s.Rotation.Value.Axis, s.Rotation!.Value.Center), E.Geometry.Transformation.InvalidRotationAxis),
+                s => s.Rotation is { } rot
+                    ? Transform.Rotation(rot.Angle, rot.Axis, rot.Center)
+                    : Transform.Identity, E.Geometry.Transformation.InvalidRotationAxis),
             [5] = ((s, c) => (s.RotationVectors is (Vector3d st, Vector3d en, Point3d center) && st.Length > c.AbsoluteTolerance && en.Length > c.AbsoluteTolerance, $"Start: {Fmt(s.RotationVectors?.Start.Length ?? 0)}, End: {Fmt(s.RotationVectors?.End.Length ?? 0)}"),
                 s => Transform.Rotation(s.RotationVectors!.Value.Start, s.RotationVectors.Value.End, s.RotationVectors.Value.Center), E.Geometry.Transformation.InvalidRotationAxis),
             [6] = ((s, _) => (s.MirrorPlane is Plane p && p.IsValid, string.Empty),


### PR DESCRIPTION
Critical fixes:
- Fix memory leak in ApplyTransform: dispose duplicated geometry on error
- Use pattern matching for Extrusion detection instead of awkward double cast
- Fix potential duplicate disposal issue when transform fails

Code quality improvements:
- Consolidate duplicate Fmt method: make TransformCore.Fmt internal, remove duplicate from TransformCompute
- Add complete tuple element names in pattern matching for clarity (anchor, angle, center, motion)
- Remove redundant shouldDispose variable in ApplyTransform

Performance optimizations:
- Cache direction.Length in LinearArray to avoid calling property twice
- Use Rhino SDK helpers: spine.PointAt(0.5) instead of manual midpoint calculation
- Use domain.Length instead of domain.Max - domain.Min in PathArray
- Remove redundant null check (path is null) when !path.IsValid already covers it

Net result: -1 LOC with improved correctness, clarity, and performance All changes adhere to CLAUDE.md standards and maintain full functionality