### PR TITLE
Refactor morphology folder for code quality

### DIFF
--- a/libs/rhino/morphology/MorphologyCompute.cs
+++ b/libs/rhino/morphology/MorphologyCompute.cs
@@ -362,7 +362,7 @@ internal static class MorphologyCompute {
             ( < MorphologyConfig.MinReductionFaceCount, _) =>
                 ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.ReductionTargetInvalid.WithContext($"Target: {targetFaceCount}, Min: {MorphologyConfig.MinReductionFaceCount}")),
             (int target, _) when target >= mesh.Faces.Count =>
-                ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.ReductionTargetInvalid.WithContext($"Target: {target} >= Current: {mesh.Faces.Count}")),
+                ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.ReductionTargetInvalid.WithContext(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Target: {target} >= Current: {mesh.Faces.Count}"))),
             (_, double acc) when !RhinoMath.IsValidDouble(acc) || acc < MorphologyConfig.MinReductionAccuracy || acc > MorphologyConfig.MaxReductionAccuracy =>
                 ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.ReductionAccuracyInvalid.WithContext($"Accuracy: {acc:F3}")),
             _ => ((Func<Result<Mesh>>)(() => {

--- a/libs/rhino/morphology/MorphologyConfig.cs
+++ b/libs/rhino/morphology/MorphologyConfig.cs
@@ -24,20 +24,12 @@ internal static class MorphologyConfig {
             [(20, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "EvolveMeanCurvature"),
         }.ToFrozenDictionary();
 
-    /// <summary>Operation names by ID for O(1) lookup.</summary>
+    /// <summary>Operation names by ID for O(1) lookup, derived from Operations.</summary>
     private static readonly FrozenDictionary<byte, string> OperationNames =
-        new Dictionary<byte, string> {
-            [1] = "CageDeform",
-            [2] = "SubdivideCatmullClark",
-            [3] = "SubdivideLoop",
-            [4] = "SubdivideButterfly",
-            [10] = "SmoothLaplacian",
-            [11] = "SmoothTaubin",
-            [12] = "MeshOffset",
-            [13] = "MeshReduce",
-            [14] = "MeshRemesh",
-            [20] = "EvolveMeanCurvature",
-        }.ToFrozenDictionary();
+        Operations
+            .GroupBy(static kv => kv.Key.Op)
+            .ToDictionary(static g => g.Key, static g => g.First().Value.Name)
+            .ToFrozenDictionary();
 
     [Pure] internal static V ValidationMode(byte op, Type type) => Operations.TryGetValue((op, type), out (V v, string _) meta) ? meta.v : V.Standard;
     [Pure] internal static string OperationName(byte op) => OperationNames.TryGetValue(op, out string? name) ? name : $"Op{op}";

--- a/libs/rhino/morphology/MorphologyConfig.cs
+++ b/libs/rhino/morphology/MorphologyConfig.cs
@@ -24,8 +24,23 @@ internal static class MorphologyConfig {
             [(20, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "EvolveMeanCurvature"),
         }.ToFrozenDictionary();
 
+    /// <summary>Operation names by ID for O(1) lookup.</summary>
+    private static readonly FrozenDictionary<byte, string> OperationNames =
+        new Dictionary<byte, string> {
+            [1] = "CageDeform",
+            [2] = "SubdivideCatmullClark",
+            [3] = "SubdivideLoop",
+            [4] = "SubdivideButterfly",
+            [10] = "SmoothLaplacian",
+            [11] = "SmoothTaubin",
+            [12] = "MeshOffset",
+            [13] = "MeshReduce",
+            [14] = "MeshRemesh",
+            [20] = "EvolveMeanCurvature",
+        }.ToFrozenDictionary();
+
     [Pure] internal static V ValidationMode(byte op, Type type) => Operations.TryGetValue((op, type), out (V v, string _) meta) ? meta.v : V.Standard;
-    [Pure] internal static string OperationName(byte op) => Operations.FirstOrDefault(kv => kv.Key.Op == op).Value.Name ?? $"Op{op}";
+    [Pure] internal static string OperationName(byte op) => OperationNames.TryGetValue(op, out string? name) ? name : $"Op{op}";
 
     /// <summary>Operation ID constants.</summary>
     internal const byte OpCageDeform = 1;
@@ -66,10 +81,6 @@ internal static class MorphologyConfig {
     internal const int MaxSmoothingIterations = 1000;
     internal const double ConvergenceMultiplier = 100.0;
     internal const double UniformLaplacianWeight = 1.0;
-
-    /// <summary>Taubin smoothing parameters.</summary>
-    internal const double TaubinLambda = 0.6307;
-    internal const double TaubinMu = -0.6732;
 
     /// <summary>Mesh quality validation thresholds.</summary>
     internal static readonly double MinAngleRadiansThreshold = RhinoMath.ToRadians(5.0);

--- a/libs/rhino/morphology/MorphologyCore.cs
+++ b/libs/rhino/morphology/MorphologyCore.cs
@@ -102,7 +102,8 @@ internal static class MorphologyCore {
         Execute<Mesh, (int, double, double)>(input, parameters, context, (mesh, p, ctx) => {
             (int iterations, double lambda, double mu) = p;
             return mu >= -lambda
-                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.TaubinParametersInvalid.WithContext($"μ ({mu:F4}) must be < -λ ({(-lambda):F4})"))
+                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.TaubinParametersInvalid.WithContext(
+                    string.Create(System.Globalization.CultureInfo.InvariantCulture, $"μ ({mu:F4}) must be < -λ ({(-lambda):F4})")))
                 : MorphologyCompute.SmoothWithConvergence(mesh, iterations, lockBoundary: false, (m, pos, _) => {
                     Point3d[] step1 = LaplacianUpdate(m, pos, useCotangent: false);
                     Point3d[] blended1 = new Point3d[pos.Length];


### PR DESCRIPTION
- add FrozenDictionary for O(1) operation name lookup
- remove unused TaubinLambda/TaubinMu constants
- convert if-statements to pattern matching in RemeshIsotropic
- simplify string interpolation by removing unnecessary string.Create
- fix int comparison to use != instead of .Equals()