### PR TITLE
Fix distance field dispatch for runtime geometry types

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -48,8 +48,9 @@ public static class Fields {
     public static Result<(Point3d[] Grid, double[] Distances)> DistanceField<T>(
         T geometry,
         FieldSpec spec,
-        IGeometryContext context) where T : GeometryBase =>
-        FieldsCore.OperationRegistry.TryGetValue((FieldsConfig.OperationDistance, typeof(T)), out (Func<object, FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, Core.Validation.V ValidationMode, int BufferSize, byte IntegrationMethod) config) switch {
+        IGeometryContext context) where T : GeometryBase {
+        System.Type geometryType = geometry is null ? typeof(T) : geometry.GetType();
+        return FieldsCore.OperationRegistry.TryGetValue((FieldsConfig.OperationDistance, geometryType), out (Func<object, FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, Core.Validation.V ValidationMode, int BufferSize, byte IntegrationMethod) config) switch {
             true => UnifiedOperation.Apply(
                 input: geometry,
                 operation: (Func<T, Result<IReadOnlyList<(Point3d[], double[])>>>)(item =>
@@ -57,12 +58,13 @@ public static class Fields {
                 config: new OperationConfig<T, (Point3d[], double[])> {
                     Context = context,
                     ValidationMode = config.ValidationMode,
-                    OperationName = $"Fields.DistanceField.{typeof(T).Name}",
+                    OperationName = $"Fields.DistanceField.{geometryType.Name}",
                     EnableDiagnostics = false,
                 }).Map(results => results[0]),
             false => ResultFactory.Create<(Point3d[], double[])>(
-                error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {typeof(T).Name}")),
+                error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {geometryType.Name}")),
         };
+    }
 
     /// <summary>Compute gradient field: geometry → (grid points[], gradient vectors[]).</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -49,7 +49,7 @@ public static class Fields {
         T geometry,
         FieldSpec spec,
         IGeometryContext context) where T : GeometryBase {
-        System.Type geometryType = geometry is null ? typeof(T) : geometry.GetType();
+        Type geometryType = geometry is null ? typeof(T) : geometry.GetType();
         return FieldsCore.OperationRegistry.TryGetValue((FieldsConfig.OperationDistance, geometryType), out (Func<object, FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, Core.Validation.V ValidationMode, int BufferSize, byte IntegrationMethod) config) switch {
             true => UnifiedOperation.Apply(
                 input: geometry,


### PR DESCRIPTION
## Summary
- make the distance field dispatcher look up runtime geometry types so Mesh/Brep/etc. inputs work even when passed as `GeometryBase`
- keep operation diagnostics aligned with the runtime type and improve the unsupported error message so it reflects the dispatched type

## Testing
- `dotnet build` *(fails: `dotnet` is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691beb5c54588321af34a0e694c37cb5)