### PR TITLE
Respect mesh offset solidification flag

### DIFF
--- a/libs/rhino/morphology/MorphologyCompute.cs
+++ b/libs/rhino/morphology/MorphologyCompute.cs
@@ -347,9 +347,7 @@ internal static class MorphologyCompute {
                 ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.OffsetDistanceInvalid.WithContext(
                     string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Max: {MorphologyConfig.MaxOffsetDistance}"))),
             _ => ((Func<Result<Mesh>>)(() => {
-                Mesh? offset = bothSides
-                    ? mesh.Offset(distance: distance, solidify: true)
-                    : mesh.Offset(distance: distance);
+                Mesh? offset = mesh.Offset(distance: distance, solidify: bothSides);
                 return offset?.IsValid is true
                     ? ResultFactory.Create(value: offset)
                     : ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.MeshOffsetFailed.WithContext(offset is null ? "Offset operation returned null" : "Generated offset mesh is invalid"));

--- a/libs/rhino/morphology/MorphologyCompute.cs
+++ b/libs/rhino/morphology/MorphologyCompute.cs
@@ -337,7 +337,7 @@ internal static class MorphologyCompute {
     internal static Result<Mesh> OffsetMesh(
         Mesh mesh,
         double distance,
-        bool _,
+        bool bothSides,
         IGeometryContext __) =>
         Math.Abs(distance) switch {
             double abs when !RhinoMath.IsValidDouble(distance) || abs < MorphologyConfig.MinOffsetDistance =>
@@ -347,7 +347,9 @@ internal static class MorphologyCompute {
                 ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.OffsetDistanceInvalid.WithContext(
                     string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Max: {MorphologyConfig.MaxOffsetDistance}"))),
             _ => ((Func<Result<Mesh>>)(() => {
-                Mesh? offset = mesh.Offset(distance);
+                Mesh? offset = bothSides
+                    ? mesh.Offset(distance: distance, solidify: true)
+                    : mesh.Offset(distance: distance);
                 return offset?.IsValid is true
                     ? ResultFactory.Create(value: offset)
                     : ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.MeshOffsetFailed.WithContext(offset is null ? "Offset operation returned null" : "Generated offset mesh is invalid"));


### PR DESCRIPTION
## Summary
- ensure the mesh offset compute path honors the both-sides flag by calling the Rhino mesh offset overload that solidifies the result

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691beb63126c832180bb17e22a6069d9)