### PR TITLE
Fix path array parameterization

### DIFF
--- a/libs/rhino/transformation/TransformCompute.cs
+++ b/libs/rhino/transformation/TransformCompute.cs
@@ -211,12 +211,12 @@ internal static class TransformCompute {
         }
 
         double curveLength = path.GetLength();
-        if (curveLength <= context.AbsoluteTolerance) {
-            return ResultFactory.Create<IReadOnlyList<T>>(
+        return curveLength <= context.AbsoluteTolerance
+            ? ResultFactory.Create<IReadOnlyList<T>>(
                 error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
                     System.Globalization.CultureInfo.InvariantCulture,
-                    $"Count: {count}, PathLength: {TransformCore.Fmt(curveLength)}")));
-        }
+                    $"Count: {count}, PathLength: {TransformCore.Fmt(curveLength)}")))
+            : /* continue with parameter computation logic */;
 
         double[] parameters = count == 1
             ? [path.LengthParameter(curveLength * 0.5, out double singleParameter) ? singleParameter : path.Domain.ParameterAt(0.5),]

--- a/libs/rhino/transformation/TransformCompute.cs
+++ b/libs/rhino/transformation/TransformCompute.cs
@@ -229,7 +229,8 @@ internal static class TransformCompute {
                         double targetLength = stepLength * index;
                         bool resolved = path.LengthParameter(targetLength, out double tParameter);
                         double normalized = targetLength / curveLength;
-                        double clamped = normalized > 1.0 ? 1.0 : normalized;
+                        // Clamp to [0.0, 1.0] to guard against floating-point precision errors.
+                        double clamped = Math.Clamp(normalized, 0.0, 1.0);
                         fallback[index] = resolved
                             ? tParameter
                             : path.Domain.ParameterAt(clamped);

--- a/libs/rhino/transformation/TransformCompute.cs
+++ b/libs/rhino/transformation/TransformCompute.cs
@@ -210,12 +210,37 @@ internal static class TransformCompute {
                     $"Count: {count}, Path: {path?.IsValid ?? false}, Geometry: {geometry.IsValid}")));
         }
 
-        Transform[] transforms = new Transform[count];
-        Interval domain = path.Domain;
-        double step = count > 1 ? domain.Length / (count - 1) : 0.0;
+        double curveLength = path.GetLength();
+        if (curveLength <= context.AbsoluteTolerance) {
+            return ResultFactory.Create<IReadOnlyList<T>>(
+                error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    $"Count: {count}, PathLength: {TransformCore.Fmt(curveLength)}")));
+        }
 
+        double[] parameters = count == 1
+            ? [path.LengthParameter(curveLength * 0.5, out double singleParameter) ? singleParameter : path.Domain.ParameterAt(0.5),]
+            : path.DivideByCount(count - 1, includeEnds: true) is double[] divideParameters && divideParameters.Length == count
+                ? divideParameters
+                : ((Func<double[]>)(() => {
+                    double[] fallback = new double[count];
+                    double stepLength = curveLength / (count - 1);
+                    for (int index = 0; index < count; index++) {
+                        double targetLength = stepLength * index;
+                        bool resolved = path.LengthParameter(targetLength, out double tParameter);
+                        double normalized = targetLength / curveLength;
+                        double clamped = normalized > 1.0 ? 1.0 : normalized;
+                        fallback[index] = resolved
+                            ? tParameter
+                            : path.Domain.ParameterAt(clamped);
+                    }
+
+                    return fallback;
+                }))();
+
+        Transform[] transforms = new Transform[count];
         for (int i = 0; i < count; i++) {
-            double t = count > 1 ? domain.Min + (step * i) : domain.Mid;
+            double t = parameters[i];
             Point3d pt = path.PointAt(t);
 
             transforms[i] = orientToPath && path.FrameAt(t, out Plane frame) && frame.IsValid


### PR DESCRIPTION
## Summary
- replace domain-based sampling in `TransformCompute.PathArray` with arc-length aware parameter generation using Rhino curve utilities
- add handling for degenerate path length and reuse those parameters when orienting along the curve so each transform lands at the expected physical distance

## Testing
- `dotnet build` *(fails: `dotnet` is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691beb79eb10832188754c7fe5264a59)