### PR TITLE
Fix genus extraction parity validation

### DIFF
--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -157,8 +157,11 @@ internal static class TopologyCompute {
                     }),
                     ]))
                 .Bind(data => data switch {
-                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 && solid && (e - v - f + 2) / 2 is int genus && genus >= 0 => ResultFactory.Create(value: (Genus: genus, Loops: loops, IsSolid: solid, HandleCount: genus)),
-                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 => ResultFactory.Create(value: (Genus: 0, Loops: loops, IsSolid: solid, HandleCount: 0)),
+                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 => (solid, Numerator: e - v - f + 2, loops) switch {
+                        (true, int numerator, (int LoopIndex, bool IsHole)[] resultLoops) when numerator >= 0 && (numerator & 1) == 0 => ResultFactory.Create(value: (Genus: numerator / 2, Loops: resultLoops, IsSolid: solid, HandleCount: numerator / 2)),
+                        (true, _, _) => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Euler characteristic invalid for solid brep")),
+                        (false, _, (int LoopIndex, bool IsHole)[] resultLoops) => ResultFactory.Create(value: (Genus: 0, Loops: resultLoops, IsSolid: solid, HandleCount: 0)),
+                    },
                     _ => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),
                 });
 }

--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -157,10 +157,10 @@ internal static class TopologyCompute {
                     }),
                     ]))
                 .Bind(data => data switch {
-                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 => (solid, Numerator: e - v - f + 2, loops) switch {
-                        (true, int numerator, (int LoopIndex, bool IsHole)[] resultLoops) when numerator >= 0 && (numerator & 1) == 0 => ResultFactory.Create(value: (Genus: numerator / 2, Loops: resultLoops, IsSolid: solid, HandleCount: numerator / 2)),
+                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 => (solid, Numerator: e - v - f + 2) switch {
+                        (true, int numerator) when numerator >= 0 && (numerator & 1) == 0 => ResultFactory.Create(value: (Genus: numerator / 2, Loops: loops, IsSolid: solid, HandleCount: numerator / 2)),
                         (true, _, _) => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Euler characteristic invalid for solid brep")),
-                        (false, _, (int LoopIndex, bool IsHole)[] resultLoops) => ResultFactory.Create(value: (Genus: 0, Loops: resultLoops, IsSolid: solid, HandleCount: 0)),
+                        (false, _) => ResultFactory.Create(value: (Genus: 0, Loops: loops, IsSolid: solid, HandleCount: 0)),
                     },
                     _ => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),
                 });

--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -159,7 +159,7 @@ internal static class TopologyCompute {
                 .Bind(data => data switch {
                     (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 => (solid, Numerator: e - v - f + 2) switch {
                         (true, int numerator) when numerator >= 0 && (numerator & 1) == 0 => ResultFactory.Create(value: (Genus: numerator / 2, Loops: loops, IsSolid: solid, HandleCount: numerator / 2)),
-                        (true, _, _) => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Euler characteristic invalid for solid brep")),
+                        (true, _) => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Euler characteristic invalid for solid brep")),
                         (false, _) => ResultFactory.Create(value: (Genus: 0, Loops: loops, IsSolid: solid, HandleCount: 0)),
                     },
                     _ => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),


### PR DESCRIPTION
## Summary
- ensure topology feature extraction validates Euler characteristic parity before computing genus and handle counts
- emit an explicit error when the solid Brep’s Euler characteristic cannot produce a non-negative integer genus
- preserve the existing non-solid fallback path for open Breps

## Testing
- `dotnet build` *(fails: dotnet is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691beb6889808321a782bba893b9c226)