### PR TITLE
Ensure mesh topology operations compute face normals

### DIFF
--- a/libs/rhino/topology/TopologyCore.cs
+++ b/libs/rhino/topology/TopologyCore.cs
@@ -284,8 +284,7 @@ internal static class TopologyCore {
 
     private static Result<IReadOnlyList<Topology.EdgeClassificationData>> ClassifyMeshEdges(Mesh mesh, double angleThreshold) {
         _ = mesh.FaceNormals.Count == mesh.Faces.Count
-            ? true
-            : mesh.FaceNormals.ComputeFaceNormals();
+            || mesh.FaceNormals.ComputeFaceNormals();
         _ = mesh.FaceNormals.UnitizeFaceNormals();
         double curvatureThreshold = angleThreshold * TopologyConfig.CurvatureThresholdRatio;
         IReadOnlyList<int> edgeIndices = [.. Enumerable.Range(0, mesh.TopologyEdges.Count),];

--- a/libs/rhino/topology/TopologyCore.cs
+++ b/libs/rhino/topology/TopologyCore.cs
@@ -188,30 +188,34 @@ internal static class TopologyCore {
                 }))(),
                 (Brep brep, int idx) => ResultFactory.Create<IReadOnlyList<Topology.AdjacencyData>>(error: E.Geometry.InvalidEdgeIndex.WithContext(string.Create(CultureInfo.InvariantCulture, $"EdgeIndex: {idx.ToString(CultureInfo.InvariantCulture)}, Max: {(brep.Edges.Count - 1).ToString(CultureInfo.InvariantCulture)}"))),
                 (Mesh mesh, int idx) when idx >= 0 && idx < mesh.TopologyEdges.Count => ((Func<Result<IReadOnlyList<Topology.AdjacencyData>>>)(() => {
-                    _ = mesh.FaceNormals.Count == mesh.Faces.Count
+                    bool normalsValid = mesh.FaceNormals.Count == mesh.Faces.Count
                         ? true
                         : mesh.FaceNormals.ComputeFaceNormals();
                     _ = mesh.FaceNormals.UnitizeFaceNormals();
-                    return mesh.TopologyEdges.GetConnectedFaces(idx) switch {
-                        int[] { Length: 2 } af => ResultFactory.Create(value: (IReadOnlyList<Topology.AdjacencyData>)[
-                            new Topology.AdjacencyData(
-                                EdgeIndex: idx,
-                                AdjacentFaceIndices: af,
-                                FaceNormals: [mesh.FaceNormals[af[0]], mesh.FaceNormals[af[1]],],
-                                DihedralAngle: Vector3d.VectorAngle(mesh.FaceNormals[af[0]], mesh.FaceNormals[af[1]]),
-                                IsManifold: true,
-                                IsBoundary: false),
-                        ]),
-                        int[] af => ResultFactory.Create(value: (IReadOnlyList<Topology.AdjacencyData>)[
-                            new Topology.AdjacencyData(
-                                EdgeIndex: idx,
-                                AdjacentFaceIndices: af,
-                                FaceNormals: [.. af.Select(i => mesh.FaceNormals[i]),],
-                                DihedralAngle: 0.0,
-                                IsManifold: af.Length == 2,
-                                IsBoundary: af.Length == 1),
-                        ]),
-                    };
+                    return !normalsValid
+                        ? ResultFactory.Create<IReadOnlyList<Topology.AdjacencyData>>(
+                            error: E.Geometry.InvalidGeometry.WithContext("Failed to compute mesh face normals"),
+                        )
+                        : mesh.TopologyEdges.GetConnectedFaces(idx) switch {
+                            int[] { Length: 2 } af => ResultFactory.Create(value: (IReadOnlyList<Topology.AdjacencyData>)[
+                                new Topology.AdjacencyData(
+                                    EdgeIndex: idx,
+                                    AdjacentFaceIndices: af,
+                                    FaceNormals: [mesh.FaceNormals[af[0]], mesh.FaceNormals[af[1]],],
+                                    DihedralAngle: Vector3d.VectorAngle(mesh.FaceNormals[af[0]], mesh.FaceNormals[af[1]]),
+                                    IsManifold: true,
+                                    IsBoundary: false),
+                            ]),
+                            int[] af => ResultFactory.Create(value: (IReadOnlyList<Topology.AdjacencyData>)[
+                                new Topology.AdjacencyData(
+                                    EdgeIndex: idx,
+                                    AdjacentFaceIndices: af,
+                                    FaceNormals: [.. af.Select(i => mesh.FaceNormals[i]),],
+                                    DihedralAngle: 0.0,
+                                    IsManifold: af.Length == 2,
+                                    IsBoundary: af.Length == 1),
+                            ]),
+                        };
                 }))(),
                 (Mesh mesh, int idx) => ResultFactory.Create<IReadOnlyList<Topology.AdjacencyData>>(error: E.Geometry.InvalidEdgeIndex.WithContext(string.Create(CultureInfo.InvariantCulture, $"EdgeIndex: {idx.ToString(CultureInfo.InvariantCulture)}, Max: {(mesh.TopologyEdges.Count - 1).ToString(CultureInfo.InvariantCulture)}"))),
                 _ => ResultFactory.Create<IReadOnlyList<Topology.AdjacencyData>>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Type: {typeof(T).Name}")),

--- a/libs/rhino/topology/TopologyCore.cs
+++ b/libs/rhino/topology/TopologyCore.cs
@@ -189,8 +189,7 @@ internal static class TopologyCore {
                 (Brep brep, int idx) => ResultFactory.Create<IReadOnlyList<Topology.AdjacencyData>>(error: E.Geometry.InvalidEdgeIndex.WithContext(string.Create(CultureInfo.InvariantCulture, $"EdgeIndex: {idx.ToString(CultureInfo.InvariantCulture)}, Max: {(brep.Edges.Count - 1).ToString(CultureInfo.InvariantCulture)}"))),
                 (Mesh mesh, int idx) when idx >= 0 && idx < mesh.TopologyEdges.Count => ((Func<Result<IReadOnlyList<Topology.AdjacencyData>>>)(() => {
                     bool normalsValid = mesh.FaceNormals.Count == mesh.Faces.Count
-                        ? true
-                        : mesh.FaceNormals.ComputeFaceNormals();
+                        || mesh.FaceNormals.ComputeFaceNormals();
                     _ = mesh.FaceNormals.UnitizeFaceNormals();
                     return !normalsValid
                         ? ResultFactory.Create<IReadOnlyList<Topology.AdjacencyData>>(


### PR DESCRIPTION
## Summary
- compute and unitize mesh face normals before evaluating edge adjacency
- normalize mesh face normals prior to edge continuity classification for stable RhinoCommon dihedral angles

## Testing
- `dotnet test` *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bff8ee8c483219030b135f847bc7a)