### PR TITLE
Refactor topology healing APIs to algebraic types

### DIFF
--- a/libs/rhino/topology/TopologyCompute.cs
+++ b/libs/rhino/topology/TopologyCompute.cs
@@ -12,15 +12,15 @@ namespace Arsenal.Rhino.Topology;
 /// <summary>Topology diagnosis, progressive healing, and topological feature extraction.</summary>
 [Pure]
 internal static class TopologyCompute {
-    internal static Result<(double[] EdgeGaps, (int EdgeA, int EdgeB, double Distance)[] NearMisses, byte[] SuggestedRepairs)> Diagnose(
+    internal static Result<Topology.TopologyDiagnosis> Diagnose(
         Brep brep,
         IGeometryContext context) =>
         !brep.IsValidTopology(out string topologyLog)
-            ? ResultFactory.Create<(double[], (int, int, double)[], byte[])>(
+            ? ResultFactory.Create<Topology.TopologyDiagnosis>(
                 error: E.Topology.DiagnosisFailed.WithContext($"Topology validation failed: {topologyLog}"))
             : ResultFactory.Create(value: brep)
                 .Validate(args: [context, V.Standard | V.Topology | V.BrepGranular,])
-                .Bind(validBrep => ((Func<Result<(double[], (int, int, double)[], byte[])>>)(() => {
+                .Bind(validBrep => ((Func<Result<Topology.TopologyDiagnosis>>)(() => {
                     (int Index, Point3d Start, Point3d End)[] nakedEdges = [.. Enumerable.Range(0, validBrep.Edges.Count)
                         .Where(i => validBrep.Edges[i].Valence == EdgeAdjacency.Naked && validBrep.Edges[i].EdgeCurve is not null)
                         .Select(i => (Index: i, Start: validBrep.Edges[i].PointAtStart, End: validBrep.Edges[i].PointAtEnd)),
@@ -39,55 +39,58 @@ internal static class TopologyCompute {
                     int nakedEdgeCount = nakedEdges.Length;
                     int nonManifoldEdgeCount = validBrep.Edges.Count(e => e.Valence == EdgeAdjacency.NonManifold);
 
-                    (int EdgeA, int EdgeB, double Distance)[] nearMisses = nakedEdges.Length < TopologyConfig.MaxEdgesForNearMissAnalysis
+                    Topology.NearEdgeMiss[] nearMisses = nakedEdges.Length < TopologyConfig.MaxEdgesForNearMissAnalysis
                         ? [.. (from i in Enumerable.Range(0, nakedEdges.Length)
                                from j in Enumerable.Range(i + 1, nakedEdges.Length - i - 1)
                                let edgeI = validBrep.Edges[nakedEdges[i].Index]
                                let edgeJ = validBrep.Edges[nakedEdges[j].Index]
                                let dist = edgeI.EdgeCurve.ClosestPoints(edgeJ.EdgeCurve, out Point3d ptA, out Point3d ptB) ? ptA.DistanceTo(ptB) : double.MaxValue
                                where dist < context.AbsoluteTolerance * TopologyConfig.NearMissMultiplier && dist > context.AbsoluteTolerance
-                               select (EdgeA: nakedEdges[i].Index, EdgeB: nakedEdges[j].Index, Distance: dist)),
+                               select new Topology.NearEdgeMiss(EdgeA: nakedEdges[i].Index, EdgeB: nakedEdges[j].Index, Distance: dist)),
                         ]
                         : [];
 
-                    byte[] repairs = (nakedEdgeCount, nonManifoldEdgeCount, nearMisses.Length) switch {
-                        ( > 0, > 0, > 0) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin, TopologyConfig.StrategyAggressiveJoin, TopologyConfig.StrategyCombined,],
-                        ( > 0, > 0, _) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin, TopologyConfig.StrategyAggressiveJoin,],
-                        ( > 0, _, > 0) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin, TopologyConfig.StrategyCombined,],
-                        (_, > 0, > 0) => [TopologyConfig.StrategyAggressiveJoin, TopologyConfig.StrategyCombined,],
-                        ( > 0, _, _) => [TopologyConfig.StrategyConservativeRepair, TopologyConfig.StrategyModerateJoin,],
-                        (_, > 0, _) => [TopologyConfig.StrategyAggressiveJoin,],
-                        (_, _, > 0) => [TopologyConfig.StrategyCombined,],
+                    Topology.HealingStrategy[] repairs = (nakedEdgeCount, nonManifoldEdgeCount, nearMisses.Length) switch {
+                        ( > 0, > 0, > 0) => [new Topology.ConservativeRepairStrategy(), new Topology.ModerateJoinStrategy(), new Topology.AggressiveJoinStrategy(), new Topology.CombinedRepairStrategy(),],
+                        ( > 0, > 0, _) => [new Topology.ConservativeRepairStrategy(), new Topology.ModerateJoinStrategy(), new Topology.AggressiveJoinStrategy(),],
+                        ( > 0, _, > 0) => [new Topology.ConservativeRepairStrategy(), new Topology.ModerateJoinStrategy(), new Topology.CombinedRepairStrategy(),],
+                        (_, > 0, > 0) => [new Topology.AggressiveJoinStrategy(), new Topology.CombinedRepairStrategy(),],
+                        ( > 0, _, _) => [new Topology.ConservativeRepairStrategy(), new Topology.ModerateJoinStrategy(),],
+                        (_, > 0, _) => [new Topology.AggressiveJoinStrategy(),],
+                        (_, _, > 0) => [new Topology.CombinedRepairStrategy(),],
                         _ => [],
                     };
 
-                    return ResultFactory.Create<(double[], (int, int, double)[], byte[])>(value: (gaps, nearMisses, repairs));
+                    return ResultFactory.Create(value: new Topology.TopologyDiagnosis(
+                        EdgeGaps: gaps,
+                        NearMisses: nearMisses,
+                        SuggestedStrategies: repairs));
                 }))());
 
-    internal static Result<(Brep Healed, byte Strategy, bool Success)> Heal(
+    internal static Result<Topology.HealingResult> Heal(
         Brep brep,
-        byte maxStrategy,
+        Topology.HealingPlan plan,
         IGeometryContext context) =>
         !brep.IsValidTopology(out string _)
-            ? ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.DiagnosisFailed.WithContext("Topology invalid before healing"))
+            ? ResultFactory.Create<Topology.HealingResult>(error: E.Topology.DiagnosisFailed.WithContext("Topology invalid before healing"))
             : ResultFactory.Create(value: brep)
                 .Validate(args: [context, V.Standard | V.Topology,])
-                .Bind(validBrep => ((Func<Result<(Brep, byte, bool)>>)(() => {
+                .Bind(validBrep => ((Func<Result<Topology.HealingResult>>)(() => {
                     int originalNakedEdges = validBrep.Edges.Count(e => e.Valence == EdgeAdjacency.Naked);
-                    int strategyCount = RhinoMath.Clamp(maxStrategy + 1, 0, TopologyConfig.MaxHealingStrategies);
+                    int strategyCount = plan.Strategies.Count;
                     Brep? bestHealed = null;
-                    byte bestStrategy = 0;
+                    Topology.HealingStrategy? bestStrategy = null;
                     int bestNakedEdges = int.MaxValue;
 
                     for (int index = 0; index < strategyCount; index++) {
-                        byte currentStrategy = (byte)index;
+                        Topology.HealingStrategy strategy = plan.Strategies[index];
                         Brep copy = validBrep.DuplicateBrep();
-                        bool success = currentStrategy switch {
-                            TopologyConfig.StrategyConservativeRepair => copy.Repair(TopologyConfig.HealingToleranceMultipliers[0] * context.AbsoluteTolerance),
-                            TopologyConfig.StrategyModerateJoin => copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[1] * context.AbsoluteTolerance) > 0,
-                            TopologyConfig.StrategyAggressiveJoin => copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[2] * context.AbsoluteTolerance) > 0,
-                            TopologyConfig.StrategyCombined => copy.Repair(TopologyConfig.HealingToleranceMultipliers[0] * context.AbsoluteTolerance) && copy.JoinNakedEdges(TopologyConfig.HealingToleranceMultipliers[1] * context.AbsoluteTolerance) > 0,
-                            TopologyConfig.StrategyTargetedJoin => ((Func<bool>)(() => {
+                        bool success = strategy switch {
+                            Topology.ConservativeRepairStrategy => copy.Repair(TopologyConfig.ConservativeRepairMultiplier * context.AbsoluteTolerance),
+                            Topology.ModerateJoinStrategy => copy.JoinNakedEdges(TopologyConfig.ModerateJoinMultiplier * context.AbsoluteTolerance) > 0,
+                            Topology.AggressiveJoinStrategy => copy.JoinNakedEdges(TopologyConfig.AggressiveJoinMultiplier * context.AbsoluteTolerance) > 0,
+                            Topology.CombinedRepairStrategy => copy.Repair(TopologyConfig.ConservativeRepairMultiplier * context.AbsoluteTolerance) && copy.JoinNakedEdges(TopologyConfig.ModerateJoinMultiplier * context.AbsoluteTolerance) > 0,
+                            Topology.TargetedJoinStrategy => ((Func<bool>)(() => {
                                 double threshold = context.AbsoluteTolerance * TopologyConfig.NearMissMultiplier;
                                 bool joinedAny = false;
                                 for (int iteration = 0; iteration < TopologyConfig.MaxEdgesForNearMissAnalysis; iteration++) {
@@ -111,7 +114,7 @@ internal static class TopologyCompute {
                                 copy.Compact();
                                 return joinedAny;
                             }))(),
-                            _ => ((Func<bool>)(() => {
+                            Topology.ComponentJoinStrategy => ((Func<bool>)(() => {
                                 Brep[] components = copy.GetConnectedComponents() ?? [];
                                 return components.Length > 1 && Brep.JoinBreps(brepsToJoin: components, tolerance: context.AbsoluteTolerance) switch {
                                     null or { Length: 0 } => false,
@@ -119,6 +122,7 @@ internal static class TopologyCompute {
                                     Brep[] joined => ((Func<bool>)(() => { Array.ForEach(joined, b => b.Dispose()); return false; }))(),
                                 };
                             }))(),
+                            _ => false,
                         };
                         (bool isValid, int nakedEdges) = success && copy.IsValidTopology(out string _)
                             ? (true, copy.Edges.Count(e => e.Valence == EdgeAdjacency.Naked))
@@ -128,38 +132,39 @@ internal static class TopologyCompute {
                         Brep? toDispose = isImprovement ? bestHealed : copy;
                         toDispose?.Dispose();
                         (bestHealed, bestStrategy, bestNakedEdges) = isImprovement
-                            ? (copy, currentStrategy, nakedEdges)
+                            ? (copy, strategy, nakedEdges)
                             : (bestHealed, bestStrategy, bestNakedEdges);
                     }
 
-                    return bestHealed is Brep healed
-                        ? ResultFactory.Create<(Brep, byte, bool)>(value: (healed, bestStrategy, bestNakedEdges < originalNakedEdges))
-                        : ResultFactory.Create<(Brep, byte, bool)>(error: E.Topology.HealingFailed.WithContext($"All {strategyCount.ToString(CultureInfo.InvariantCulture)} strategies failed"));
+                    return bestHealed is Brep healed && bestStrategy is Topology.HealingStrategy chosen
+                        ? ResultFactory.Create(value: new Topology.HealingResult(Healed: healed, Strategy: chosen, Success: bestNakedEdges < originalNakedEdges))
+                        : ResultFactory.Create<Topology.HealingResult>(error: E.Topology.HealingFailed.WithContext($"All {strategyCount.ToString(CultureInfo.InvariantCulture)} strategies failed"));
                 }))());
 
-    internal static Result<(int Genus, (int LoopIndex, bool IsHole)[] Loops, bool IsSolid, int HandleCount)> ExtractFeatures(
+    internal static Result<Topology.TopologicalFeatures> ExtractFeatures(
         Brep brep,
         IGeometryContext context) =>
         !brep.IsValidTopology(out string _)
-            ? ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.DiagnosisFailed.WithContext("Topology invalid for feature extraction"))
+            ? ResultFactory.Create<Topology.TopologicalFeatures>(error: E.Topology.DiagnosisFailed.WithContext("Topology invalid for feature extraction"))
             : ResultFactory.Create(value: brep)
                 .Validate(args: [context, V.Standard | V.Topology | V.MassProperties,])
-                .Map<(int V, int E, int F, bool Solid, (int LoopIndex, bool IsHole)[] Loops)>(validBrep => (
+                .Map<(int V, int E, int F, bool Solid, Topology.LoopClassification[] Loops)>(validBrep => (
                     V: validBrep.Vertices.Count,
                     E: validBrep.Edges.Count,
                     F: validBrep.Faces.Count,
                     Solid: validBrep.IsSolid && validBrep.IsManifold,
                     Loops: [.. validBrep.Loops.Select((l, i) => {
                         using Curve? loopCurve = l.To3dCurve();
-                        return (LoopIndex: i, IsHole: l.LoopType == BrepLoopType.Inner && (loopCurve?.GetLength() ?? 0.0) > Math.Max(context.AbsoluteTolerance, TopologyConfig.MinLoopLength));
+                        bool isHole = l.LoopType == BrepLoopType.Inner && (loopCurve?.GetLength() ?? 0.0) > Math.Max(context.AbsoluteTolerance, TopologyConfig.MinLoopLength);
+                        return new Topology.LoopClassification(LoopIndex: i, IsHole: isHole);
                     }),
                     ]))
                 .Bind(data => data switch {
-                    (int v, int e, int f, bool solid, (int LoopIndex, bool IsHole)[] loops) when v > 0 && e > 0 && f > 0 => (solid, Numerator: e - v - f + 2) switch {
-                        (true, int numerator) when numerator >= 0 && (numerator & 1) == 0 => ResultFactory.Create(value: (Genus: numerator / 2, Loops: loops, IsSolid: solid, HandleCount: numerator / 2)),
-                        (true, _) => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Euler characteristic invalid for solid brep")),
-                        (false, _) => ResultFactory.Create(value: (Genus: 0, Loops: loops, IsSolid: solid, HandleCount: 0)),
+                    (int v, int e, int f, bool solid, Topology.LoopClassification[] loops) when v > 0 && e > 0 && f > 0 => (solid, Numerator: e - v - f + 2) switch {
+                        (true, int numerator) when numerator >= 0 && (numerator & 1) == 0 => ResultFactory.Create(value: new Topology.TopologicalFeatures(Genus: numerator / 2, Loops: loops, IsSolid: solid, HandleCount: numerator / 2)),
+                        (true, _) => ResultFactory.Create<Topology.TopologicalFeatures>(error: E.Topology.FeatureExtractionFailed.WithContext("Euler characteristic invalid for solid brep")),
+                        (false, _) => ResultFactory.Create(value: new Topology.TopologicalFeatures(Genus: 0, Loops: loops, IsSolid: solid, HandleCount: 0)),
                     },
-                    _ => ResultFactory.Create<(int, (int, bool)[], bool, int)>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),
+                    _ => ResultFactory.Create<Topology.TopologicalFeatures>(error: E.Topology.FeatureExtractionFailed.WithContext("Invalid vertex/edge/face counts")),
                 });
 }

--- a/libs/rhino/topology/TopologyConfig.cs
+++ b/libs/rhino/topology/TopologyConfig.cs
@@ -28,8 +28,10 @@ internal static class TopologyConfig {
             [(typeof(Mesh), OpType.NgonTopology)] = (V.Standard | V.MeshSpecific, "Topology.GetNgonTopology.Mesh"),
         }.ToFrozenDictionary();
 
-    /// <summary>Healing strategy tolerance multipliers: [Conservative=0.1×, Moderate=1.0×, Aggressive=10.0×].</summary>
-    internal static readonly double[] HealingToleranceMultipliers = [0.1, 1.0, 10.0,];
+    /// <summary>Healing strategy tolerance multipliers.</summary>
+    internal const double ConservativeRepairMultiplier = 0.1;
+    internal const double ModerateJoinMultiplier = 1.0;
+    internal const double AggressiveJoinMultiplier = 10.0;
 
     /// <summary>Topology operation types for dispatch lookup.</summary>
     internal enum OpType { NakedEdges = 0, BoundaryLoops = 1, NonManifold = 2, Connectivity = 3, EdgeClassification = 4, Adjacency = 5, VertexData = 6, NgonTopology = 7 }
@@ -44,12 +46,4 @@ internal static class TopologyConfig {
     /// <summary>Maximum edges analyzed for near-miss detection to prevent O(n²) performance degradation on large models.</remarks>
     internal const int MaxEdgesForNearMissAnalysis = 100;
 
-    /// <summary>Healing strategy identifiers for progressive topology repair.</summary>
-    internal const byte StrategyConservativeRepair = 0;
-    internal const byte StrategyModerateJoin = 1;
-    internal const byte StrategyAggressiveJoin = 2;
-    internal const byte StrategyCombined = 3;
-    internal const byte StrategyTargetedJoin = 4;
-    internal const byte StrategyComponentJoin = 5;
-    internal const int MaxHealingStrategies = 6;
 }


### PR DESCRIPTION
## Summary
- model topology diagnosis data, healing strategies, and result plans as nested records on the public API
- rework the compute layer to operate on the new algebraic types and emit strongly typed diagnoses, healing results, and feature summaries
- align topology configuration constants with the new strategy representation

## Testing
- dotnet build *(fails: dotnet is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c175be2b88321962267e1fa8ac14f)