### PR TITLE
Refactor spatial domain to algebraic requests

### DIFF
--- a/libs/rhino/spatial/SpatialCompute.cs
+++ b/libs/rhino/spatial/SpatialCompute.cs
@@ -15,31 +15,36 @@ internal static class SpatialCompute {
     private static readonly IComparer<Type> _typeSpecificity = Comparer<Type>.Create(static (left, right) =>
         left == right ? 0 : left.IsAssignableFrom(right) ? 1 : right.IsAssignableFrom(left) ? -1 : 0);
 
-    private static readonly (Type GeometryType, Func<object, object> Extractor)[] _centroidFallbacks =
-        [.. SpatialConfig.TypeExtractors
-            .Where(static kv => string.Equals(kv.Key.Operation, "Centroid", StringComparison.Ordinal))
-            .OrderByDescending(static kv => kv.Key.GeometryType, _typeSpecificity)
-            .Select(static kv => (kv.Key.GeometryType, kv.Value)),
+    private static readonly (Type GeometryType, Func<GeometryBase, Point3d> Extractor)[] _centroidFallbacks =
+        [.. SpatialConfig.CentroidExtractors
+            .OrderByDescending(static kv => kv.Key, _typeSpecificity)
+            .Select(static kv => (kv.Key, kv.Value)),
         ];
 
-    private static readonly ConcurrentDictionary<Type, Func<object, object>> _centroidExtractorCache = new();
-    internal static Result<(Point3d, double[])[]> Cluster<T>(T[] geometry, byte algorithm, int k, double epsilon, IGeometryContext context) where T : GeometryBase =>
-        (geometry.Length, algorithm, k, epsilon) switch {
-            (0, _, _, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Geometry.InvalidCount.WithContext("Cluster requires at least one geometry")),
-            (_, > 2, _, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed.WithContext($"Unknown algorithm: {algorithm}")),
-            (_, 0 or 2, <= 0, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidClusterK),
-            (_, 1, _, <= 0) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidEpsilon),
+    private static readonly ConcurrentDictionary<Type, Func<GeometryBase, Point3d>> _centroidExtractorCache = new();
+    internal static Result<(Point3d Centroid, double[] Radii)[]> Cluster<T>(T[] geometry, byte algorithm, int k, double epsilon, int minPoints, IGeometryContext context) where T : GeometryBase =>
+        (geometry.Length, algorithm, k, epsilon, minPoints) switch {
+            (0, _, _, _, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Geometry.InvalidCount.WithContext("Cluster requires at least one geometry")),
+            (_, > 2, _, _, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.ClusteringFailed.WithContext($"Unknown algorithm: {algorithm}")),
+            (_, 0 or 2, <= 0, _, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidClusterK),
+            (_, 1, _, <= 0, _) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidEpsilon),
+            (_, 1, _, _, <= 1) => ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.InvalidClusterK.WithContext("MinPoints")),
             _ => ((Func<Result<(Point3d, double[])[]>>)(() => {
                 Point3d[] pts = new Point3d[geometry.Length];
                 for (int i = 0; i < geometry.Length; i++) {
                     GeometryBase current = geometry[i];
                     Type geometryType = current.GetType();
-                    Func<object, object> extractor = _centroidExtractorCache.GetOrAdd(geometryType, ResolveCentroidExtractor);
-                    pts[i] = (Point3d)extractor(current);
+                    Func<GeometryBase, Point3d> extractor = _centroidExtractorCache.GetOrAdd(geometryType, ResolveCentroidExtractor);
+                    pts[i] = extractor(current);
                 }
                 return (algorithm is 0 or 2) && k > pts.Length
                     ? ResultFactory.Create<(Point3d, double[])[]>(error: E.Spatial.KExceedsPointCount)
-                    : SpatialConfig.TypeExtractors.TryGetValue(("ClusterAssign", typeof(void)), out Func<object, object>? assignFunc) && assignFunc((algorithm, pts, k, epsilon, context)) is int[] assigns && assigns.Length > 0
+                    : (algorithm switch {
+                        0 => SpatialCompute.KMeansAssign(pts, k, context.AbsoluteTolerance, SpatialConfig.KMeansMaxIterations),
+                        1 => SpatialCompute.DBSCANAssign(pts, epsilon, minPoints),
+                        2 => SpatialCompute.HierarchicalAssign(pts, k),
+                        _ => Array.Empty<int>(),
+                    }) is int[] assigns && assigns.Length > 0
                         ? (algorithm is 1 ? assigns.Where(a => a >= 0).DefaultIfEmpty(-1).Max() + 1 : k) is int clusterCount && clusterCount > 0
                             ? ResultFactory.Create<(Point3d, double[])[]>(value: [.. Enumerable.Range(0, clusterCount).Select(c => {
                                 int[] members = [.. Enumerable.Range(0, pts.Length).Where(i => assigns[i] == c),];
@@ -504,10 +509,10 @@ internal static class SpatialCompute {
                 return ResultFactory.Create(value: cells);
             }))());
 
-    private static Func<object, object> ResolveCentroidExtractor(Type geometryType) =>
-        SpatialConfig.TypeExtractors.TryGetValue(("Centroid", geometryType), out Func<object, object>? exact)
-            ? exact!
+    private static Func<GeometryBase, Point3d> ResolveCentroidExtractor(Type geometryType) =>
+        SpatialConfig.CentroidExtractors.TryGetValue(geometryType, out Func<GeometryBase, Point3d>? exact)
+            ? exact
             : Array.FindIndex(_centroidFallbacks, entry => entry.GeometryType.IsAssignableFrom(geometryType)) is int match and >= 0
                 ? _centroidFallbacks[match].Extractor
-                : static geometry => geometry is GeometryBase baseGeometry ? baseGeometry.GetBoundingBox(accurate: false).Center : Point3d.Origin;
+                : static geometry => geometry.GetBoundingBox(accurate: false).Center;
 }

--- a/libs/rhino/spatial/SpatialConfig.cs
+++ b/libs/rhino/spatial/SpatialConfig.cs
@@ -1,6 +1,5 @@
 using System.Collections.Frozen;
 using System.Diagnostics.Contracts;
-using Arsenal.Core.Context;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Spatial;
@@ -8,25 +7,30 @@ namespace Arsenal.Rhino.Spatial;
 /// <summary>Spatial configuration: algorithmic constants and polymorphic dispatch tables.</summary>
 [Pure]
 internal static class SpatialConfig {
-    /// <summary>Polymorphic type extractors for centroids, RTree factories, and clustering dispatch.</summary>
-    internal static readonly FrozenDictionary<(string Operation, Type GeometryType), Func<object, object>> TypeExtractors =
-        new Dictionary<(string, Type), Func<object, object>> {
-            [("Centroid", typeof(Curve))] = static g => g is Curve c ? (AreaMassProperties.Compute(c) is { Centroid: { IsValid: true } ct } ? ct : c.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(Surface))] = static g => g is Surface s ? (AreaMassProperties.Compute(s) is { Centroid: { IsValid: true } ct } ? ct : s.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(Brep))] = static g => g is Brep b ? (VolumeMassProperties.Compute(b) is { Centroid: { IsValid: true } ct } ? ct : b.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(Mesh))] = static g => g is Mesh m ? (VolumeMassProperties.Compute(m) is { Centroid: { IsValid: true } ct } ? ct : m.GetBoundingBox(accurate: false).Center) : Point3d.Origin,
-            [("Centroid", typeof(GeometryBase))] = static g => g is GeometryBase gb ? gb.GetBoundingBox(accurate: false).Center : Point3d.Origin,
-            [("RTreeFactory", typeof(Point3d[]))] = static s => RTree.CreateFromPointArray((Point3d[])s) ?? new RTree(),
-            [("RTreeFactory", typeof(PointCloud))] = static s => RTree.CreatePointCloudTree((PointCloud)s) ?? new RTree(),
-            [("RTreeFactory", typeof(Mesh))] = static s => RTree.CreateMeshFaceTree((Mesh)s) ?? new RTree(),
-            [("ClusterAssign", typeof(void))] = static input => input is (byte alg, Point3d[] pts, int k, double eps, IGeometryContext ctx)
-                ? alg switch {
-                    0 => SpatialCompute.KMeansAssign(pts, k, ctx.AbsoluteTolerance, KMeansMaxIterations),
-                    1 => SpatialCompute.DBSCANAssign(pts, eps, DBSCANMinPoints),
-                    2 => SpatialCompute.HierarchicalAssign(pts, k),
-                    _ => [],
-                }
-                : [],
+    /// <summary>Centroid extractors keyed by geometry type for clustering operations.</summary>
+    internal static readonly FrozenDictionary<Type, Func<GeometryBase, Point3d>> CentroidExtractors =
+        new Dictionary<Type, Func<GeometryBase, Point3d>> {
+            [typeof(Curve)] = static geometry => geometry is Curve curve
+                ? AreaMassProperties.Compute(curve) is { Centroid: { IsValid: true } centroid }
+                    ? centroid
+                    : curve.GetBoundingBox(accurate: false).Center
+                : Point3d.Origin,
+            [typeof(Surface)] = static geometry => geometry is Surface surface
+                ? AreaMassProperties.Compute(surface) is { Centroid: { IsValid: true } centroid }
+                    ? centroid
+                    : surface.GetBoundingBox(accurate: false).Center
+                : Point3d.Origin,
+            [typeof(Brep)] = static geometry => geometry is Brep brep
+                ? VolumeMassProperties.Compute(brep) is { Centroid: { IsValid: true } centroid }
+                    ? centroid
+                    : brep.GetBoundingBox(accurate: false).Center
+                : Point3d.Origin,
+            [typeof(Mesh)] = static geometry => geometry is Mesh mesh
+                ? VolumeMassProperties.Compute(mesh) is { Centroid: { IsValid: true } centroid }
+                    ? centroid
+                    : mesh.GetBoundingBox(accurate: false).Center
+                : Point3d.Origin,
+            [typeof(GeometryBase)] = static geometry => geometry.GetBoundingBox(accurate: false).Center,
         }.ToFrozenDictionary();
 
     /// <summary>Buffer sizes for RTree spatial query operations.</summary>


### PR DESCRIPTION
## Summary
- replace the Spatial public surface with algebraic request/response records and route every entry point through SpatialCore
- rebuild SpatialCore dispatch to work with the new records, including a typed FrozenDictionary for RTree queries and UnifiedOperation orchestration for all operations
- simplify SpatialConfig/SpatialCompute by introducing centroid extractor metadata and strongly typed clustering flows

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2634e02483218e2b919a5035a4b9)