### PR TITLE
Refactor spatial domain configuration to algebraic types

### DIFF
--- a/libs/rhino/spatial/Spatial.cs
+++ b/libs/rhino/spatial/Spatial.cs
@@ -1,10 +1,7 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
-using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Spatial;
@@ -12,35 +9,50 @@ namespace Arsenal.Rhino.Spatial;
 /// <summary>Spatial indexing via RTree and polymorphic dispatch.</summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MA0049:Type name should not match containing namespace", Justification = "Spatial is the primary API entry point for the Spatial namespace")]
 public static class Spatial {
+    public const int DefaultDBSCANMinPoints = SpatialConfig.DBSCANMinPoints;
+
+    public abstract record Query;
+
+    public sealed record SphereQuery(Sphere Sphere) : Query;
+
+    public sealed record BoundingBoxQuery(BoundingBox BoundingBox) : Query;
+
+    public sealed record KNearestNeighborsQuery(Point3d[] Points, int Count) : Query;
+
+    public sealed record DistanceLimitedQuery(Point3d[] Points, double Distance) : Query;
+
+    public sealed record MeshOverlapQuery(double AdditionalTolerance) : Query;
+
+    public abstract record ClusteringRequest;
+
+    public sealed record KMeansClusteringRequest(int ClusterCount) : ClusteringRequest;
+
+    public sealed record HierarchicalClusteringRequest(int ClusterCount) : ClusteringRequest;
+
+    public sealed record DBSCANClusteringRequest(double Epsilon, int MinPoints = DefaultDBSCANMinPoints) : ClusteringRequest;
+
+    public sealed record ProximityFieldRequest(Vector3d Direction, double MaxDistance, double AngleWeight);
+
     /// <summary>Spatial query via type-based dispatch and RTree.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<IReadOnlyList<int>> Analyze<TInput, TQuery>(
+    public static Result<IReadOnlyList<int>> Analyze<TInput>(
         TInput input,
-        TQuery query,
+        Query query,
         IGeometryContext context,
-        int? bufferSize = null) where TInput : notnull where TQuery : notnull =>
-        SpatialCore.OperationRegistry.TryGetValue((typeof(TInput), typeof(TQuery)), out (Func<object, RTree>? _, V mode, int bufferSize, Func<object, object, IGeometryContext, int, Result<IReadOnlyList<int>>> execute) config) switch {
-            true => UnifiedOperation.Apply(
-                input: input,
-                operation: (Func<TInput, Result<IReadOnlyList<int>>>)(item => config.execute(item, query, context, bufferSize ?? config.bufferSize)),
-                config: new OperationConfig<TInput, int> {
-                    Context = context,
-                    ValidationMode = config.mode,
-                    OperationName = $"Spatial.{typeof(TInput).Name}.{typeof(TQuery).Name}",
-                    EnableDiagnostics = false,
-                }),
-            false => ResultFactory.Create<IReadOnlyList<int>>(
-                error: E.Spatial.UnsupportedTypeCombo.WithContext(
-                    $"Input: {typeof(TInput).Name}, Query: {typeof(TQuery).Name}")),
-        };
+        int? bufferSize = null) where TInput : notnull =>
+        SpatialCore.Analyze(
+            input: input,
+            query: query,
+            context: context,
+            bufferSize: bufferSize);
 
-    /// <summary>Cluster geometry by proximity: (algorithm: 0=KMeans|1=DBSCAN|2=Hierarchical, k, epsilon) → (centroid, radii[])[].</summary>
+    /// <summary>Cluster geometry by proximity via algebraic request types.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<(Point3d Centroid, double[] Radii)[]> Cluster<T>(
         T[] geometry,
-        (byte Algorithm, int K, double Epsilon) parameters,
+        ClusteringRequest request,
         IGeometryContext context) where T : GeometryBase =>
-        SpatialCompute.Cluster(geometry: geometry, algorithm: parameters.Algorithm, k: parameters.K, epsilon: parameters.Epsilon, context: context);
+        SpatialCompute.Cluster(geometry: geometry, request: request, context: context);
 
     /// <summary>Compute medial axis skeleton for planar Breps → (skeleton curves[], stability[]).</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -50,13 +62,13 @@ public static class Spatial {
         IGeometryContext context) =>
         SpatialCompute.MedialAxis(brep: brep, tolerance: tolerance, context: context);
 
-    /// <summary>Compute directional proximity field: (direction, maxDistance, angleWeight) → (index, distance, angle)[].</summary>
+    /// <summary>Compute directional proximity field via algebraic request.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<(int Index, double Distance, double Angle)[]> ProximityField(
         GeometryBase[] geometry,
-        (Vector3d Direction, double MaxDistance, double AngleWeight) parameters,
+        ProximityFieldRequest request,
         IGeometryContext context) =>
-        SpatialCompute.ProximityField(geometry: geometry, direction: parameters.Direction, maxDist: parameters.MaxDistance, angleWeight: parameters.AngleWeight, context: context);
+        SpatialCompute.ProximityField(geometry: geometry, request: request, context: context);
 
     /// <summary>Compute 3D convex hull → mesh face vertex indices as int[][].</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- convert `Spatial` public API surface to nested algebraic request/query records and route analysis through the core layer
- update `SpatialCore` dispatch metadata to work with the new strongly typed queries and mesh overlap requests
- refactor `SpatialCompute` algorithms to consume the new clustering and proximity request types and add reusable cluster output helpers

## Testing
- dotnet build *(fails: `dotnet` is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c26302474832192c65b3ad2bbc5ba)