### PR TITLE
Refactor Spatial API to algebraic requests

### DIFF
--- a/libs/rhino/spatial/SpatialConfig.cs
+++ b/libs/rhino/spatial/SpatialConfig.cs
@@ -19,14 +19,6 @@ internal static class SpatialConfig {
             [("RTreeFactory", typeof(Point3d[]))] = static s => RTree.CreateFromPointArray((Point3d[])s) ?? new RTree(),
             [("RTreeFactory", typeof(PointCloud))] = static s => RTree.CreatePointCloudTree((PointCloud)s) ?? new RTree(),
             [("RTreeFactory", typeof(Mesh))] = static s => RTree.CreateMeshFaceTree((Mesh)s) ?? new RTree(),
-            [("ClusterAssign", typeof(void))] = static input => input is (byte alg, Point3d[] pts, int k, double eps, IGeometryContext ctx)
-                ? alg switch {
-                    0 => SpatialCompute.KMeansAssign(pts, k, ctx.AbsoluteTolerance, KMeansMaxIterations),
-                    1 => SpatialCompute.DBSCANAssign(pts, eps, DBSCANMinPoints),
-                    2 => SpatialCompute.HierarchicalAssign(pts, k),
-                    _ => [],
-                }
-                : [],
         }.ToFrozenDictionary();
 
     /// <summary>Buffer sizes for RTree spatial query operations.</summary>


### PR DESCRIPTION
## Summary
- replace tuple- and type-based Spatial queries with nested algebraic record types and route Analyze through SpatialCore
- rework the SpatialCore operation registry to dispatch on the new query records and add strongly typed proximity dispatch helpers
- update SpatialCompute clustering logic to understand the new ClusterRequest records and preserve all result semantics

## Testing
- `dotnet build` *(fails: `dotnet` command not found in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c26302474832192c65b3ad2bbc5ba)