### PR TITLE
Refactor morphology API to algebraic records

### DIFF
--- a/libs/rhino/morphology/MorphologyConfig.cs
+++ b/libs/rhino/morphology/MorphologyConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Arsenal.Core.Validation;
 using Rhino;
@@ -8,58 +9,48 @@ namespace Arsenal.Rhino.Morphology;
 
 /// <summary>Morphology operation configuration constants and dispatch tables.</summary>
 internal static class MorphologyConfig {
+    internal readonly record struct OperationMetadata(V Validation, string Name);
+
     /// <summary>Operation metadata: validation, name, parameter type.</summary>
-    internal static readonly FrozenDictionary<(byte Op, Type Type), (V Validation, string Name)> Operations =
-        new Dictionary<(byte, Type), (V, string)> {
-            [(1, typeof(Mesh))] = (V.Standard | V.Topology, "CageDeform"),
-            [(1, typeof(Brep))] = (V.Standard | V.Topology, "CageDeform"),
-            [(2, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "SubdivideCatmullClark"),
-            [(3, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "SubdivideLoop"),
-            [(4, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "SubdivideButterfly"),
-            [(10, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "SmoothLaplacian"),
-            [(11, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "SmoothTaubin"),
-            [(12, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshOffset"),
-            [(13, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "MeshReduce"),
-            [(14, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshRemesh"),
-            [(15, typeof(Brep))] = (V.Standard | V.BoundingBox, "BrepToMesh"),
-            [(16, typeof(Mesh))] = (V.Standard | V.Topology | V.MeshSpecific, "MeshRepair"),
-            [(17, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshThicken"),
-            [(18, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshUnwrap"),
-            [(19, typeof(Mesh))] = (V.Standard | V.Topology, "MeshSeparate"),
-            [(20, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "EvolveMeanCurvature"),
-            [(21, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshWeld"),
+    internal static readonly FrozenDictionary<(Type RequestType, Type GeometryType), OperationMetadata> Operations =
+        new Dictionary<(Type, Type), OperationMetadata> {
+            [(typeof(Morphology.CageDeformRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.Topology, "CageDeform"),
+            [(typeof(Morphology.CageDeformRequest), typeof(Brep))] = new OperationMetadata(V.Standard | V.Topology, "CageDeform"),
+            [(typeof(Morphology.CatmullClarkSubdivisionRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific | V.Topology, "SubdivideCatmullClark"),
+            [(typeof(Morphology.LoopSubdivisionRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific | V.Topology, "SubdivideLoop"),
+            [(typeof(Morphology.ButterflySubdivisionRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific | V.Topology, "SubdivideButterfly"),
+            [(typeof(Morphology.LaplacianSmoothingRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "SmoothLaplacian"),
+            [(typeof(Morphology.TaubinSmoothingRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "SmoothTaubin"),
+            [(typeof(Morphology.MeanCurvatureFlowRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "EvolveMeanCurvature"),
+            [(typeof(Morphology.MeshOffsetRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "MeshOffset"),
+            [(typeof(Morphology.MeshReductionRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "MeshReduce"),
+            [(typeof(Morphology.RemeshRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "MeshRemesh"),
+            [(typeof(Morphology.BrepToMeshRequest), typeof(Brep))] = new OperationMetadata(V.Standard | V.BoundingBox, "BrepToMesh"),
+            [(typeof(Morphology.MeshRepairRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.Topology | V.MeshSpecific, "MeshRepair"),
+            [(typeof(Morphology.MeshThickenRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "MeshThicken"),
+            [(typeof(Morphology.MeshUnwrapRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "MeshUnwrap"),
+            [(typeof(Morphology.MeshSeparationRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.Topology, "MeshSeparate"),
+            [(typeof(Morphology.MeshWeldRequest), typeof(Mesh))] = new OperationMetadata(V.Standard | V.MeshSpecific, "MeshWeld"),
         }.ToFrozenDictionary();
 
-    /// <summary>Operation names by ID for O(1) lookup, derived from Operations.</summary>
-    private static readonly FrozenDictionary<byte, string> OperationNames =
+    /// <summary>Operation names by request type for O(1) lookup, derived from Operations.</summary>
+    private static readonly FrozenDictionary<Type, string> OperationNames =
         Operations
-            .GroupBy(static kv => kv.Key.Op)
+            .GroupBy(static kv => kv.Key.Item1)
             .ToDictionary(static g => g.Key, static g => g.First().Value.Name)
             .ToFrozenDictionary();
 
-    [Pure] internal static V ValidationMode(byte op, Type type) => Operations.TryGetValue((op, type), out (V v, string _) meta) ? meta.v : V.Standard;
-    [Pure] internal static string OperationName(byte op) => OperationNames.TryGetValue(op, out string? name) ? name : $"Op{op}";
+    [Pure] internal static V ValidationMode(Type requestType, Type geometryType) => Operations.TryGetValue((requestType, geometryType), out OperationMetadata metadata) ? metadata.Validation : V.Standard;
+    [Pure] internal static string OperationName(Type requestType) => OperationNames.TryGetValue(requestType, out string? name) ? name : requestType.Name;
 
-    /// <summary>Operation ID constants.</summary>
-    internal const byte OpCageDeform = 1;
-    internal const byte OpSubdivideCatmullClark = 2;
-    internal const byte OpSubdivideLoop = 3;
-    internal const byte OpSubdivideButterfly = 4;
-    internal const byte OpSmoothLaplacian = 10;
-    internal const byte OpSmoothTaubin = 11;
-    internal const byte OpOffset = 12;
-    internal const byte OpReduce = 13;
-    internal const byte OpRemesh = 14;
-    internal const byte OpBrepToMesh = 15;
-    internal const byte OpMeshRepair = 16;
-    internal const byte OpMeshThicken = 17;
-    internal const byte OpMeshUnwrap = 18;
-    internal const byte OpMeshSeparate = 19;
-    internal const byte OpEvolveMeanCurvature = 20;
-    internal const byte OpMeshWeld = 21;
+    internal enum SubdivisionAlgorithm {
+        CatmullClark,
+        Loop,
+        Butterfly,
+    }
 
     /// <summary>Subdivision algorithms requiring triangulated meshes.</summary>
-    internal static readonly FrozenSet<byte> TriangulatedSubdivisionOps = new HashSet<byte> { OpSubdivideLoop, OpSubdivideButterfly, }.ToFrozenSet();
+    internal static readonly FrozenSet<SubdivisionAlgorithm> TriangulatedSubdivisionAlgorithms = new HashSet<SubdivisionAlgorithm> { SubdivisionAlgorithm.Loop, SubdivisionAlgorithm.Butterfly, }.ToFrozenSet();
 
     /// <summary>Cage deformation configuration.</summary>
     internal const int MinCageControlPoints = 8;
@@ -124,22 +115,17 @@ internal static class MorphologyConfig {
     internal const double MinThickenDistance = 0.0001;
     internal const double MaxThickenDistance = 10000.0;
 
-    /// <summary>Mesh repair operation flags for bitwise composition.</summary>
-    internal const byte RepairNone = 0;
-    internal const byte RepairFillHoles = 1;
-    internal const byte RepairUnifyNormals = 2;
-    internal const byte RepairCullDegenerateFaces = 4;
-    internal const byte RepairCompact = 8;
-    internal const byte RepairWeld = 16;
-    internal const byte RepairAll = RepairFillHoles | RepairUnifyNormals | RepairCullDegenerateFaces | RepairCompact | RepairWeld;
-
-    /// <summary>Mesh repair operation dispatch: flag → (operation name, mesh action).</summary>
-    internal static readonly FrozenDictionary<byte, (string Name, Func<Mesh, double, bool> Action)> RepairOperations =
-        new Dictionary<byte, (string, Func<Mesh, double, bool>)> {
-            [RepairFillHoles] = ("FillHoles", static (m, _) => m.FillHoles()),
-            [RepairUnifyNormals] = ("UnifyNormals", static (m, _) => m.UnifyNormals() >= 0),
-            [RepairCullDegenerateFaces] = ("CullDegenerateFaces", static (m, _) => m.Faces.CullDegenerateFaces() >= 0),
-            [RepairCompact] = ("Compact", static (m, _) => m.Compact()),
-            [RepairWeld] = ("Weld", static (m, _) => m.Vertices.CombineIdentical(ignoreNormals: true, ignoreAdditional: true)),
+    /// <summary>Mesh repair operation dispatch: operation type → (operation name, mesh action).</summary>
+    internal static readonly FrozenDictionary<Type, (string Name, Func<Mesh, double, bool> Action)> RepairOperations =
+        new Dictionary<Type, (string, Func<Mesh, double, bool>)> {
+            [typeof(Morphology.FillHolesRepairOperation)] = ("FillHoles", static (m, _) => m.FillHoles()),
+            [typeof(Morphology.UnifyNormalsRepairOperation)] = ("UnifyNormals", static (m, _) => m.UnifyNormals() >= 0),
+            [typeof(Morphology.CullDegenerateFacesRepairOperation)] = ("CullDegenerateFaces", static (m, _) => m.Faces.CullDegenerateFaces() >= 0),
+            [typeof(Morphology.CompactRepairOperation)] = ("Compact", static (m, _) => m.Compact()),
+            [typeof(Morphology.WeldVerticesRepairOperation)] = ("Weld", static (m, _) => m.Vertices.CombineIdentical(ignoreNormals: true, ignoreAdditional: true)),
         }.ToFrozenDictionary();
+
+    [Pure] internal static string RepairOperationName(Type operationType) => RepairOperations.TryGetValue(operationType, out (string Name, Func<Mesh, double, bool> _) operation)
+        ? operation.Name
+        : operationType.Name;
 }


### PR DESCRIPTION
## Summary
- replace the byte/object morphology spec with nested algebraic request records and repair operation types
- update MorphologyConfig/Core/Compute dispatch to use request/geometry type metadata and strongly typed parameters
- refresh compute implementations to consume the new request types, including mesh repair, brep meshing, and unwrap routines

## Testing
- dotnet build *(fails: `dotnet` not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2feac1a883218119072e9ae0b226)