### PR TITLE
Refactor Morphology API to algebraic requests

### DIFF
--- a/libs/rhino/morphology/MorphologyCompute.cs
+++ b/libs/rhino/morphology/MorphologyCompute.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
@@ -93,9 +94,9 @@ internal static class MorphologyCompute {
                     ResultFactory.Create(value: mesh.DuplicateMesh()),
                     (result, level) => result.Bind(current => {
                         Mesh? next = algorithm switch {
-                            MorphologyConfig.OpSubdivideCatmullClark => current.DuplicateMesh(),
-                            MorphologyConfig.OpSubdivideLoop => SubdivideLoop(current),
-                            MorphologyConfig.OpSubdivideButterfly => SubdivideButterfly(current),
+                            MorphologyConfig.AlgorithmSubdivideCatmullClark => current.DuplicateMesh(),
+                            MorphologyConfig.AlgorithmSubdivideLoop => SubdivideLoop(current),
+                            MorphologyConfig.AlgorithmSubdivideButterfly => SubdivideButterfly(current),
                             _ => null,
                         };
                         bool valid = next?.IsValid is true && ValidateMeshQuality(next, context).IsSuccess;
@@ -489,7 +490,7 @@ internal static class MorphologyCompute {
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Mesh> RepairMesh(
         Mesh mesh,
-        byte flags,
+        IReadOnlyList<Morphology.MeshRepairOperation> operations,
         double weldTolerance,
         IGeometryContext _) =>
         (weldTolerance, mesh.DuplicateMesh()) switch {
@@ -499,11 +500,15 @@ internal static class MorphologyCompute {
             (_, null) or (_, { IsValid: false }) =>
                 ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.MeshRepairFailed.WithContext("Mesh duplication failed")),
             (double tol, Mesh repaired) => ((Func<Result<Mesh>>)(() => {
-                for (int i = 0; i < 5; i++) {
-                    byte flag = (byte)(1 << i);
-                    if ((flag & flags) != 0 && MorphologyConfig.RepairOperations.TryGetValue(flag, out (string discard, Func<Mesh, double, bool> action) entry)) {
-                        bool success = entry.action(repaired, tol);
-                    }
+                foreach (Morphology.MeshRepairOperation operation in operations) {
+                    _ = operation switch {
+                        Morphology.FillHolesRepairOperation => repaired.FillHoles(),
+                        Morphology.UnifyNormalsRepairOperation => repaired.UnifyNormals() >= 0,
+                        Morphology.CullDegenerateFacesRepairOperation => repaired.Faces.CullDegenerateFaces() >= 0,
+                        Morphology.CompactRepairOperation => repaired.Compact(),
+                        Morphology.WeldRepairOperation => repaired.Vertices.CombineIdentical(ignoreNormals: true, ignoreAdditional: true),
+                        _ => true,
+                    };
                 }
                 return repaired.Normals.ComputeNormals()
                     ? ResultFactory.Create(value: repaired)
@@ -597,19 +602,19 @@ internal static class MorphologyCompute {
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Mesh> UnwrapMesh(
         Mesh mesh,
-        byte unwrapMethod,
+        MeshUnwrapMethod method,
         IGeometryContext _) =>
-        unwrapMethod switch {
-            0 or 1 => ((Func<Result<Mesh>>)(() => {
+        method switch {
+            MeshUnwrapMethod.AngleBased or MeshUnwrapMethod.Conformal => ((Func<Result<Mesh>>)(() => {
                 Mesh unwrapped = mesh.DuplicateMesh();
                 using MeshUnwrapper unwrapper = new(unwrapped);
-                bool success = unwrapper.Unwrap(method: (MeshUnwrapMethod)unwrapMethod);
+                bool success = unwrapper.Unwrap(method: method);
                 return success && unwrapped.TextureCoordinates.Count > 0
                     ? ResultFactory.Create(value: unwrapped)
                     : ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.MeshUnwrapFailed.WithContext(
-                        string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Method: {(unwrapMethod == 0 ? "AngleBased" : "ConformalEnergyMinimization")}, Success: {success}, UVCount: {unwrapped.TextureCoordinates.Count}")));
+                        string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Method: {method}, Success: {success}, UVCount: {unwrapped.TextureCoordinates.Count}")));
             }))(),
             _ => ResultFactory.Create<Mesh>(error: E.Geometry.Morphology.MeshUnwrapFailed.WithContext(
-                string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Invalid unwrap method: {unwrapMethod}"))),
+                string.Create(System.Globalization.CultureInfo.InvariantCulture, $"Invalid unwrap method: {method}"))),
         };
 }

--- a/libs/rhino/morphology/MorphologyCore.cs
+++ b/libs/rhino/morphology/MorphologyCore.cs
@@ -1,8 +1,11 @@
-using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
+using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
 using Rhino;
 using Rhino.Geometry;
@@ -11,147 +14,160 @@ namespace Arsenal.Rhino.Morphology;
 
 /// <summary>Morphology operation dispatch and executor implementations.</summary>
 internal static class MorphologyCore {
-    /// <summary>Operation dispatch: (operation ID, type) → executor function.</summary>
-    internal static readonly FrozenDictionary<(byte Operation, Type InputType), Func<object, object, IGeometryContext, Result<IReadOnlyList<Morphology.IMorphologyResult>>>> OperationDispatch =
-        new Dictionary<(byte, Type), Func<object, object, IGeometryContext, Result<IReadOnlyList<Morphology.IMorphologyResult>>>> {
-            [(MorphologyConfig.OpCageDeform, typeof(Mesh))] = ExecuteCageDeform,
-            [(MorphologyConfig.OpCageDeform, typeof(Brep))] = ExecuteCageDeform,
-            [(MorphologyConfig.OpSubdivideCatmullClark, typeof(Mesh))] = ExecuteSubdivideCatmullClark,
-            [(MorphologyConfig.OpSubdivideLoop, typeof(Mesh))] = ExecuteSubdivideLoop,
-            [(MorphologyConfig.OpSubdivideButterfly, typeof(Mesh))] = ExecuteSubdivideButterfly,
-            [(MorphologyConfig.OpSmoothLaplacian, typeof(Mesh))] = ExecuteSmoothLaplacian,
-            [(MorphologyConfig.OpSmoothTaubin, typeof(Mesh))] = ExecuteSmoothTaubin,
-            [(MorphologyConfig.OpEvolveMeanCurvature, typeof(Mesh))] = ExecuteEvolveMeanCurvature,
-            [(MorphologyConfig.OpOffset, typeof(Mesh))] = ExecuteOffset,
-            [(MorphologyConfig.OpReduce, typeof(Mesh))] = ExecuteReduce,
-            [(MorphologyConfig.OpRemesh, typeof(Mesh))] = ExecuteRemesh,
-            [(MorphologyConfig.OpBrepToMesh, typeof(Brep))] = ExecuteBrepToMesh,
-            [(MorphologyConfig.OpMeshRepair, typeof(Mesh))] = ExecuteMeshRepair,
-            [(MorphologyConfig.OpMeshThicken, typeof(Mesh))] = ExecuteMeshThicken,
-            [(MorphologyConfig.OpMeshUnwrap, typeof(Mesh))] = ExecuteMeshUnwrap,
-            [(MorphologyConfig.OpMeshSeparate, typeof(Mesh))] = ExecuteMeshSeparate,
-            [(MorphologyConfig.OpMeshWeld, typeof(Mesh))] = ExecuteMeshWeld,
-        }.ToFrozenDictionary();
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<Morphology.IMorphologyResult>> Apply<T>(
+        T input,
+        Morphology.MorphologyRequest request,
+        IGeometryContext context) where T : GeometryBase =>
+        MorphologyConfig.TryGetMetadata(request.GetType(), typeof(T), out MorphologyConfig.OperationMetadata metadata)
+            ? UnifiedOperation.Apply(
+                input: input,
+                operation: (Func<T, Result<IReadOnlyList<Morphology.IMorphologyResult>>>)(geometry => ExecuteRequest(geometry, request, context)),
+                config: new OperationConfig<T, Morphology.IMorphologyResult> {
+                    Context = context,
+                    ValidationMode = metadata.Validation,
+                    OperationName = string.Create(CultureInfo.InvariantCulture, $"Morphology.{metadata.Name}"),
+                    EnableDiagnostics = false,
+                })
+            : ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.UnsupportedConfiguration.WithContext(
+                string.Create(CultureInfo.InvariantCulture, $"Request: {request.GetType().Name}, Type: {typeof(T).Name}")));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> Execute<TGeom, TParam>(
-        object input,
-        object parameters,
-        IGeometryContext context,
-        Func<TGeom, TParam, IGeometryContext, Result<IReadOnlyList<Morphology.IMorphologyResult>>> compute,
-        Func<object, bool>? geomCheck = null) where TGeom : GeometryBase =>
-        input is not TGeom geom || (geomCheck is not null && !geomCheck(input))
-            ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.InvalidGeometryType.WithContext($"Expected: {typeof(TGeom).Name}"))
-            : parameters is not TParam param
-                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.InsufficientParameters.WithContext($"Expected: {typeof(TParam).Name}"))
-                : compute(geom, param, context);
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteRequest(
+        GeometryBase input,
+        Morphology.MorphologyRequest request,
+        IGeometryContext context) =>
+        (input, request) switch {
+            (Mesh mesh, Morphology.CageDeformRequest cage) => ExecuteCageDeform(mesh, cage, context),
+            (Brep brep, Morphology.CageDeformRequest cage) => ExecuteCageDeform(brep, cage, context),
+            (Mesh mesh, Morphology.CatmullClarkSubdivisionRequest subdiv) => ExecuteSubdivision(mesh, subdiv, MorphologyConfig.AlgorithmSubdivideCatmullClark, context),
+            (Mesh mesh, Morphology.LoopSubdivisionRequest subdiv) => ExecuteSubdivision(mesh, subdiv, MorphologyConfig.AlgorithmSubdivideLoop, context),
+            (Mesh mesh, Morphology.ButterflySubdivisionRequest subdiv) => ExecuteSubdivision(mesh, subdiv, MorphologyConfig.AlgorithmSubdivideButterfly, context),
+            (Mesh mesh, Morphology.LaplacianSmoothingRequest smoothing) => ExecuteSmoothLaplacian(mesh, smoothing, context),
+            (Mesh mesh, Morphology.TaubinSmoothingRequest smoothing) => ExecuteSmoothTaubin(mesh, smoothing, context),
+            (Mesh mesh, Morphology.MeanCurvatureFlowRequest flow) => ExecuteEvolveMeanCurvature(mesh, flow, context),
+            (Mesh mesh, Morphology.MeshOffsetRequest offset) => ExecuteOffset(mesh, offset, context),
+            (Mesh mesh, Morphology.MeshReductionRequest reduction) => ExecuteReduce(mesh, reduction, context),
+            (Mesh mesh, Morphology.RemeshRequest remesh) => ExecuteRemesh(mesh, remesh, context),
+            (Brep brep, Morphology.BrepToMeshRequest brepRequest) => ExecuteBrepToMesh(brep, brepRequest, context),
+            (Mesh mesh, Morphology.MeshRepairRequest repair) => ExecuteMeshRepair(mesh, repair, context),
+            (Mesh mesh, Morphology.MeshThickenRequest thicken) => ExecuteMeshThicken(mesh, thicken, context),
+            (Mesh mesh, Morphology.MeshUnwrapRequest unwrap) => ExecuteMeshUnwrap(mesh, unwrap, context),
+            (Mesh mesh, Morphology.MeshSeparationRequest) => ExecuteMeshSeparate(mesh, context),
+            (Mesh mesh, Morphology.MeshWeldRequest weld) => ExecuteMeshWeld(mesh, weld, context),
+            _ => ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.UnsupportedConfiguration.WithContext(
+                string.Create(CultureInfo.InvariantCulture, $"Request: {request.GetType().Name}, Geometry: {input.GetType().Name}"))),
+        };
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteCageDeform(object input, object parameters, IGeometryContext context) =>
-        Execute<GeometryBase, (GeometryBase, Point3d[], Point3d[])>(
-            input,
-            parameters,
-            context,
-            (geom, p, ctx) => {
-                (GeometryBase cage, Point3d[] originalPts, Point3d[] deformedPts) = p;
-                return MorphologyCompute.CageDeform(geom, cage, originalPts, deformedPts, ctx).Bind(deformed => {
-                    BoundingBox originalBounds = geom.GetBoundingBox(accurate: false);
-                    BoundingBox deformedBounds = deformed.GetBoundingBox(accurate: false);
-                    double[] displacements = [.. originalPts.Zip(deformedPts, static (o, d) => o.DistanceTo(d)),];
-                    return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
-                        value: [new Morphology.CageDeformResult(
-                            deformed,
-                            displacements.Length > 0 ? displacements.Max() : 0.0,
-                            displacements.Length > 0 ? displacements.Average() : 0.0,
-                            originalBounds,
-                            deformedBounds,
-                            RhinoMath.IsValidDouble(originalBounds.Volume) && originalBounds.Volume > RhinoMath.ZeroTolerance
-                                ? deformedBounds.Volume / originalBounds.Volume
-                                : 1.0),
-                        ]);
-                });
-            },
-            geomCheck: g => g is Mesh or Brep);
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteCageDeform(
+        GeometryBase geometry,
+        Morphology.CageDeformRequest request,
+        IGeometryContext context) {
+        Point3d[] originalPoints = request.OriginalControlPoints.ToArray();
+        Point3d[] deformedPoints = request.DeformedControlPoints.ToArray();
+        return MorphologyCompute.CageDeform(geometry, request.Cage, originalPoints, deformedPoints, context).Bind(deformed => {
+            BoundingBox originalBounds = geometry.GetBoundingBox(accurate: false);
+            BoundingBox deformedBounds = deformed.GetBoundingBox(accurate: false);
+            double[] displacements = [.. originalPoints.Zip(deformedPoints, static (o, d) => o.DistanceTo(d)),];
+            return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
+                value: [new Morphology.CageDeformResult(
+                    deformed,
+                    displacements.Length > 0 ? displacements.Max() : 0.0,
+                    displacements.Length > 0 ? displacements.Average() : 0.0,
+                    originalBounds,
+                    deformedBounds,
+                    RhinoMath.IsValidDouble(originalBounds.Volume) && originalBounds.Volume > RhinoMath.ZeroTolerance
+                        ? deformedBounds.Volume / originalBounds.Volume
+                        : 1.0),
+                ]);
+        });
+    }
 
+    /// <summary>Unified subdivision executor for CatmullClark, Loop, and Butterfly algorithms.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivideCatmullClark(object input, object parameters, IGeometryContext context) =>
-        ExecuteSubdivision(input, parameters, context, MorphologyConfig.OpSubdivideCatmullClark);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivideLoop(object input, object parameters, IGeometryContext context) =>
-        ExecuteSubdivision(input, parameters, context, MorphologyConfig.OpSubdivideLoop);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivideButterfly(object input, object parameters, IGeometryContext context) =>
-        ExecuteSubdivision(input, parameters, context, MorphologyConfig.OpSubdivideButterfly);
-
-    /// <summary>Unified subdivision executor for CatmullClark, Loop, and Butterfly algorithms. Validates triangulated mesh requirement for Loop/Butterfly (MorphologyConfig.OpSubdivideLoop/OpSubdivideButterfly).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivision(object input, object parameters, IGeometryContext context, byte algorithm) =>
-        Execute<Mesh, int>(input, parameters, context, (mesh, levels, ctx) =>
-            MorphologyConfig.TriangulatedSubdivisionOps.Contains(algorithm) && mesh.Faces.TriangleCount != mesh.Faces.Count
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivision(
+        Mesh mesh,
+        Morphology.SubdivisionRequest request,
+        byte algorithm,
+        IGeometryContext context) =>
+        request is Morphology.LoopSubdivisionRequest or Morphology.ButterflySubdivisionRequest
+            ? mesh.Faces.TriangleCount != mesh.Faces.Count
                 ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
-                    error: (algorithm == MorphologyConfig.OpSubdivideLoop ? E.Geometry.Morphology.LoopRequiresTriangles : E.Geometry.Morphology.ButterflyRequiresTriangles)
-                        .WithContext(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"TriangleCount: {mesh.Faces.TriangleCount}, FaceCount: {mesh.Faces.Count}")))
-                : MorphologyCompute.SubdivideIterative(mesh, algorithm, levels, ctx).Bind(subdivided => ComputeSubdivisionMetrics(mesh, subdivided, ctx)));
+                    error: (request is Morphology.LoopSubdivisionRequest ? E.Geometry.Morphology.LoopRequiresTriangles : E.Geometry.Morphology.ButterflyRequiresTriangles)
+                        .WithContext(string.Create(CultureInfo.InvariantCulture, $"TriangleCount: {mesh.Faces.TriangleCount}, FaceCount: {mesh.Faces.Count}")))
+                : MorphologyCompute.SubdivideIterative(mesh, algorithm, request.Levels, context).Bind(subdivided => ComputeSubdivisionMetrics(mesh, subdivided, context))
+            : MorphologyCompute.SubdivideIterative(mesh, algorithm, request.Levels, context).Bind(subdivided => ComputeSubdivisionMetrics(mesh, subdivided, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSmoothLaplacian(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (int, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (int iters, bool lockBound) = p;
-            return MorphologyCompute.SmoothWithConvergence(mesh, iters, lockBound, (m, pos, _) => LaplacianUpdate(m, pos, useCotangent: true), ctx)
-                .Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, iters, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSmoothLaplacian(
+        Mesh mesh,
+        Morphology.LaplacianSmoothingRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.SmoothWithConvergence(
+            mesh,
+            request.Iterations,
+            request.LockBoundary,
+            (m, pos, _) => LaplacianUpdate(m, pos, useCotangent: true),
+            context).Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, request.Iterations, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSmoothTaubin(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (int, double, double)>(input, parameters, context, (mesh, p, ctx) =>
-            p.Item3 >= -p.Item2
-                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.TaubinParametersInvalid.WithContext(
-                    string.Create(System.Globalization.CultureInfo.InvariantCulture, $"μ ({p.Item3:F4}) must be < -λ ({(-p.Item2):F4})")))
-                : MorphologyCompute.SmoothWithConvergence(mesh, p.Item1, lockBoundary: false, (m, pos, _) => {
-                    Point3d[] step1 = LaplacianUpdate(m, pos, useCotangent: false);
-                    Point3d[] blended1 = new Point3d[pos.Length];
-                    for (int i = 0; i < pos.Length; i++) {
-                        blended1[i] = pos[i] + (p.Item2 * (step1[i] - pos[i]));
-                    }
-                    Point3d[] step2 = LaplacianUpdate(m, blended1, useCotangent: false);
-                    Point3d[] result = new Point3d[pos.Length];
-                    for (int i = 0; i < pos.Length; i++) {
-                        result[i] = blended1[i] + (p.Item3 * (step2[i] - blended1[i]));
-                    }
-                    return result;
-                }, ctx).Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, p.Item1, ctx)));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSmoothTaubin(
+        Mesh mesh,
+        Morphology.TaubinSmoothingRequest request,
+        IGeometryContext context) =>
+        request.Mu >= -request.Lambda
+            ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.TaubinParametersInvalid.WithContext(
+                string.Create(CultureInfo.InvariantCulture, $"μ ({request.Mu:F4}) must be < -λ ({(-request.Lambda):F4})")))
+            : MorphologyCompute.SmoothWithConvergence(mesh, request.Iterations, lockBoundary: false, (m, pos, _) => {
+                Point3d[] step1 = LaplacianUpdate(m, pos, useCotangent: false);
+                Point3d[] blended1 = new Point3d[pos.Length];
+                for (int i = 0; i < pos.Length; i++) {
+                    blended1[i] = pos[i] + (request.Lambda * (step1[i] - pos[i]));
+                }
+                Point3d[] step2 = LaplacianUpdate(m, blended1, useCotangent: false);
+                Point3d[] result = new Point3d[pos.Length];
+                for (int i = 0; i < pos.Length; i++) {
+                    result[i] = blended1[i] + (request.Mu * (step2[i] - blended1[i]));
+                }
+                return result;
+            }, context).Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, request.Iterations, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteEvolveMeanCurvature(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, int)>(input, parameters, context, (mesh, p, ctx) => {
-            (double timeStep, int iters) = p;
-            return MorphologyCompute.SmoothWithConvergence(mesh, iters, lockBoundary: false, (m, pos, _) => MeanCurvatureFlowUpdate(m, pos, timeStep), ctx)
-                .Bind(evolved => ComputeSmoothingMetrics(mesh, evolved, iters, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteEvolveMeanCurvature(
+        Mesh mesh,
+        Morphology.MeanCurvatureFlowRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.SmoothWithConvergence(
+            mesh,
+            request.Iterations,
+            lockBoundary: false,
+            (m, pos, _) => MeanCurvatureFlowUpdate(m, pos, request.TimeStep),
+            context).Bind(evolved => ComputeSmoothingMetrics(mesh, evolved, request.Iterations, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteOffset(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (double distance, bool bothSides) = p;
-            return MorphologyCompute.OffsetMesh(mesh, distance, bothSides, ctx).Bind(offset => ComputeOffsetMetrics(mesh, offset, distance, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteOffset(
+        Mesh mesh,
+        Morphology.MeshOffsetRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.OffsetMesh(mesh, request.Distance, request.BothSides, context)
+            .Bind(offset => ComputeOffsetMetrics(mesh, offset, request.Distance, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteReduce(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (int, bool, double)>(input, parameters, context, (mesh, p, ctx) => {
-            (int targetFaces, bool preserveBoundary, double accuracy) = p;
-            return MorphologyCompute.ReduceMesh(mesh, targetFaces, preserveBoundary, accuracy, ctx).Bind(reduced => ComputeReductionMetrics(mesh, reduced, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteReduce(
+        Mesh mesh,
+        Morphology.MeshReductionRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.ReduceMesh(mesh, request.TargetFaceCount, request.PreserveBoundary, request.Accuracy, context)
+            .Bind(reduced => ComputeReductionMetrics(mesh, reduced, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteRemesh(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, int, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (double targetEdge, int maxIters, bool preserveFeats) = p;
-            return MorphologyCompute.RemeshIsotropic(mesh, targetEdge, maxIters, preserveFeats, ctx)
-                .Bind(remeshData => ComputeRemeshMetrics(mesh, remeshData.Remeshed, targetEdge, remeshData.IterationsPerformed, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteRemesh(
+        Mesh mesh,
+        Morphology.RemeshRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.RemeshIsotropic(mesh, request.TargetEdgeLength, request.MaxIterations, request.PreserveFeatures, context)
+            .Bind(remeshData => ComputeRemeshMetrics(mesh, remeshData.Remeshed, request.TargetEdgeLength, remeshData.IterationsPerformed, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Point3d[] LaplacianUpdate(Mesh mesh, Point3d[] positions, bool useCotangent) =>
@@ -325,42 +341,49 @@ internal static class MorphologyCore {
     }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshRepair(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (byte, double)>(input, parameters, context, (mesh, p, ctx) => {
-            (byte flags, double weldTol) = p;
-            return MorphologyCompute.RepairMesh(mesh, flags, weldTol, ctx).Bind(repaired => ComputeRepairMetrics(mesh, repaired, flags, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshRepair(
+        Mesh mesh,
+        Morphology.MeshRepairRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.RepairMesh(mesh, request.Operations, request.WeldTolerance, context)
+            .Bind(repaired => ComputeRepairMetrics(mesh, repaired, request.Operations, request.WeldTolerance, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshSeparate(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, ValueTuple>(input, parameters, context, (mesh, _, ctx) =>
-            MorphologyCompute.SeparateMeshComponents(mesh, ctx).Bind(components => ComputeSeparationMetrics(components, ctx)));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshSeparate(
+        Mesh mesh,
+        IGeometryContext context) =>
+        MorphologyCompute.SeparateMeshComponents(mesh, context).Bind(components => ComputeSeparationMetrics(components, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshWeld(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (double tolerance, bool weldNormals) = p;
-            return MorphologyCompute.WeldMeshVertices(mesh, tolerance, weldNormals, ctx).Bind(welded => ComputeWeldMetrics(mesh, welded, tolerance, weldNormals, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshWeld(
+        Mesh mesh,
+        Morphology.MeshWeldRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.WeldMeshVertices(mesh, request.Tolerance, request.RecalculateNormals, context)
+            .Bind(welded => ComputeWeldMetrics(mesh, welded, request.Tolerance, request.RecalculateNormals, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeRepairMetrics(
         Mesh original,
         Mesh repaired,
-        byte operations,
-        IGeometryContext context) =>
-        ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(value: [
+        IReadOnlyList<Morphology.MeshRepairOperation> operations,
+        double weldTolerance,
+        IGeometryContext context) {
+        Morphology.MeshRepairOperation[] performed = operations.ToArray();
+        return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(value: [
             new Morphology.MeshRepairResult(
                 repaired,
                 original.Vertices.Count,
                 repaired.Vertices.Count,
                 original.Faces.Count,
                 repaired.Faces.Count,
-                operations,
+                performed,
+                weldTolerance,
                 MorphologyCompute.ValidateMeshQuality(repaired, context).IsSuccess ? 1.0 : 0.0,
                 original.DisjointMeshCount > 1,
                 original.Normals.Count != original.Vertices.Count || original.Normals.Any(n => n.IsZero)),
         ]);
+    }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeSeparationMetrics(
@@ -409,11 +432,12 @@ internal static class MorphologyCore {
             : ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.InvalidCount);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteBrepToMesh(object input, object parameters, IGeometryContext context) =>
-        Execute<Brep, (MeshingParameters?, bool)>(input, parameters, context, (brep, p, ctx) => {
-            (MeshingParameters? meshParams, bool joinMeshes) = p;
-            return MorphologyCompute.BrepToMesh(brep, meshParams, joinMeshes, ctx).Bind(mesh => ComputeBrepToMeshMetrics(brep, mesh, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteBrepToMesh(
+        Brep brep,
+        Morphology.BrepToMeshRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.BrepToMesh(brep, request.Parameters, request.JoinMeshes, context)
+            .Bind(mesh => ComputeBrepToMeshMetrics(brep, mesh, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeBrepToMeshMetrics(
@@ -456,11 +480,12 @@ internal static class MorphologyCore {
     }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshThicken(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, bool, Vector3d)>(input, parameters, context, (mesh, p, ctx) => {
-            (double thickness, bool solidify, Vector3d direction) = p;
-            return MorphologyCompute.ThickenMesh(mesh, thickness, solidify, direction, ctx).Bind(thickened => ComputeThickenMetrics(mesh, thickened, thickness, solidify, direction, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshThicken(
+        Mesh mesh,
+        Morphology.MeshThickenRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.ThickenMesh(mesh, request.Thickness, request.Solidify, request.Direction, context)
+            .Bind(thickened => ComputeThickenMetrics(mesh, thickened, request.Thickness, request.Solidify, request.Direction, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeThickenMetrics(
@@ -490,9 +515,12 @@ internal static class MorphologyCore {
     }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshUnwrap(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, byte>(input, parameters, context, (mesh, unwrapMethod, ctx) =>
-            MorphologyCompute.UnwrapMesh(mesh, unwrapMethod, ctx).Bind(unwrapped => ComputeUnwrapMetrics(mesh, unwrapped, ctx)));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshUnwrap(
+        Mesh mesh,
+        Morphology.MeshUnwrapRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.UnwrapMesh(mesh, request.Mode.Method, context)
+            .Bind(unwrapped => ComputeUnwrapMetrics(mesh, unwrapped, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeUnwrapMetrics(


### PR DESCRIPTION
## Summary
- replace the Morphology public API surface with algebraic request, mode, and operation records so callers configure behavior via strong types instead of tuple specs
- rework MorphologyConfig and MorphologyCore to key validation metadata by request type and to dispatch through UnifiedOperation by matching the new request records
- update the compute layer to consume the new strongly typed parameters, including list-driven mesh repair operations and explicit mesh unwrap modes

## Testing
- `dotnet build` *(fails: `dotnet` is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2feac1a883218119072e9ae0b226)