### PR TITLE
Refactor Morphology requests to algebraic records

### DIFF
--- a/libs/rhino/morphology/MorphologyConfig.cs
+++ b/libs/rhino/morphology/MorphologyConfig.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Arsenal.Core.Validation;
 using Rhino;
@@ -8,37 +10,32 @@ namespace Arsenal.Rhino.Morphology;
 
 /// <summary>Morphology operation configuration constants and dispatch tables.</summary>
 internal static class MorphologyConfig {
-    /// <summary>Operation metadata: validation, name, parameter type.</summary>
-    internal static readonly FrozenDictionary<(byte Op, Type Type), (V Validation, string Name)> Operations =
-        new Dictionary<(byte, Type), (V, string)> {
-            [(1, typeof(Mesh))] = (V.Standard | V.Topology, "CageDeform"),
-            [(1, typeof(Brep))] = (V.Standard | V.Topology, "CageDeform"),
-            [(2, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "SubdivideCatmullClark"),
-            [(3, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "SubdivideLoop"),
-            [(4, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "SubdivideButterfly"),
-            [(10, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "SmoothLaplacian"),
-            [(11, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "SmoothTaubin"),
-            [(12, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshOffset"),
-            [(13, typeof(Mesh))] = (V.Standard | V.MeshSpecific | V.Topology, "MeshReduce"),
-            [(14, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshRemesh"),
-            [(15, typeof(Brep))] = (V.Standard | V.BoundingBox, "BrepToMesh"),
-            [(16, typeof(Mesh))] = (V.Standard | V.Topology | V.MeshSpecific, "MeshRepair"),
-            [(17, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshThicken"),
-            [(18, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshUnwrap"),
-            [(19, typeof(Mesh))] = (V.Standard | V.Topology, "MeshSeparate"),
-            [(20, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "EvolveMeanCurvature"),
-            [(21, typeof(Mesh))] = (V.Standard | V.MeshSpecific, "MeshWeld"),
+    internal readonly record struct OperationMetadata(V Validation, string Name);
+
+    internal static readonly FrozenDictionary<(Type RequestType, Type GeometryType), OperationMetadata> OperationTable =
+        new Dictionary<(Type, Type), OperationMetadata> {
+            [(typeof(Morphology.CageDeformRequest), typeof(Mesh))] = new(V.Standard | V.Topology, "CageDeform"),
+            [(typeof(Morphology.CageDeformRequest), typeof(Brep))] = new(V.Standard | V.Topology, "CageDeform"),
+            [(typeof(Morphology.CatmullClarkSubdivisionRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific | V.Topology, "SubdivideCatmullClark"),
+            [(typeof(Morphology.LoopSubdivisionRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific | V.Topology, "SubdivideLoop"),
+            [(typeof(Morphology.ButterflySubdivisionRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific | V.Topology, "SubdivideButterfly"),
+            [(typeof(Morphology.LaplacianSmoothingRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "SmoothLaplacian"),
+            [(typeof(Morphology.TaubinSmoothingRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "SmoothTaubin"),
+            [(typeof(Morphology.MeanCurvatureFlowRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "EvolveMeanCurvature"),
+            [(typeof(Morphology.MeshOffsetRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "MeshOffset"),
+            [(typeof(Morphology.MeshReductionRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific | V.Topology, "MeshReduce"),
+            [(typeof(Morphology.RemeshRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "MeshRemesh"),
+            [(typeof(Morphology.BrepToMeshRequest), typeof(Brep))] = new(V.Standard | V.BoundingBox, "BrepToMesh"),
+            [(typeof(Morphology.MeshRepairRequest), typeof(Mesh))] = new(V.Standard | V.Topology | V.MeshSpecific, "MeshRepair"),
+            [(typeof(Morphology.MeshThickenRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "MeshThicken"),
+            [(typeof(Morphology.MeshUnwrapRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "MeshUnwrap"),
+            [(typeof(Morphology.MeshSeparationRequest), typeof(Mesh))] = new(V.Standard | V.Topology, "MeshSeparate"),
+            [(typeof(Morphology.MeshWeldRequest), typeof(Mesh))] = new(V.Standard | V.MeshSpecific, "MeshWeld"),
         }.ToFrozenDictionary();
 
-    /// <summary>Operation names by ID for O(1) lookup, derived from Operations.</summary>
-    private static readonly FrozenDictionary<byte, string> OperationNames =
-        Operations
-            .GroupBy(static kv => kv.Key.Op)
-            .ToDictionary(static g => g.Key, static g => g.First().Value.Name)
-            .ToFrozenDictionary();
-
-    [Pure] internal static V ValidationMode(byte op, Type type) => Operations.TryGetValue((op, type), out (V v, string _) meta) ? meta.v : V.Standard;
-    [Pure] internal static string OperationName(byte op) => OperationNames.TryGetValue(op, out string? name) ? name : $"Op{op}";
+    [Pure]
+    internal static bool TryGetOperationMetadata(Type requestType, Type geometryType, out OperationMetadata metadata) =>
+        OperationTable.TryGetValue((requestType, geometryType), out metadata);
 
     /// <summary>Operation ID constants.</summary>
     internal const byte OpCageDeform = 1;
@@ -124,22 +121,13 @@ internal static class MorphologyConfig {
     internal const double MinThickenDistance = 0.0001;
     internal const double MaxThickenDistance = 10000.0;
 
-    /// <summary>Mesh repair operation flags for bitwise composition.</summary>
-    internal const byte RepairNone = 0;
-    internal const byte RepairFillHoles = 1;
-    internal const byte RepairUnifyNormals = 2;
-    internal const byte RepairCullDegenerateFaces = 4;
-    internal const byte RepairCompact = 8;
-    internal const byte RepairWeld = 16;
-    internal const byte RepairAll = RepairFillHoles | RepairUnifyNormals | RepairCullDegenerateFaces | RepairCompact | RepairWeld;
-
-    /// <summary>Mesh repair operation dispatch: flag → (operation name, mesh action).</summary>
-    internal static readonly FrozenDictionary<byte, (string Name, Func<Mesh, double, bool> Action)> RepairOperations =
-        new Dictionary<byte, (string, Func<Mesh, double, bool>)> {
-            [RepairFillHoles] = ("FillHoles", static (m, _) => m.FillHoles()),
-            [RepairUnifyNormals] = ("UnifyNormals", static (m, _) => m.UnifyNormals() >= 0),
-            [RepairCullDegenerateFaces] = ("CullDegenerateFaces", static (m, _) => m.Faces.CullDegenerateFaces() >= 0),
-            [RepairCompact] = ("Compact", static (m, _) => m.Compact()),
-            [RepairWeld] = ("Weld", static (m, _) => m.Vertices.CombineIdentical(ignoreNormals: true, ignoreAdditional: true)),
+    /// <summary>Mesh repair operation dispatch: operation type → mesh action.</summary>
+    internal static readonly FrozenDictionary<Type, Func<Mesh, double, bool>> RepairOperationHandlers =
+        new Dictionary<Type, Func<Mesh, double, bool>> {
+            [typeof(Morphology.FillHolesRepairOperation)] = static (m, _) => m.FillHoles(),
+            [typeof(Morphology.UnifyNormalsRepairOperation)] = static (m, _) => m.UnifyNormals() >= 0,
+            [typeof(Morphology.CullDegenerateFacesRepairOperation)] = static (m, _) => m.Faces.CullDegenerateFaces() >= 0,
+            [typeof(Morphology.CompactRepairOperation)] = static (m, _) => m.Compact(),
+            [typeof(Morphology.WeldRepairOperation)] = static (m, _) => m.Vertices.CombineIdentical(ignoreNormals: true, ignoreAdditional: true),
         }.ToFrozenDictionary();
 }

--- a/libs/rhino/morphology/MorphologyCore.cs
+++ b/libs/rhino/morphology/MorphologyCore.cs
@@ -1,8 +1,11 @@
-using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
+using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
 using Rhino;
 using Rhino.Geometry;
@@ -11,147 +14,156 @@ namespace Arsenal.Rhino.Morphology;
 
 /// <summary>Morphology operation dispatch and executor implementations.</summary>
 internal static class MorphologyCore {
-    /// <summary>Operation dispatch: (operation ID, type) → executor function.</summary>
-    internal static readonly FrozenDictionary<(byte Operation, Type InputType), Func<object, object, IGeometryContext, Result<IReadOnlyList<Morphology.IMorphologyResult>>>> OperationDispatch =
-        new Dictionary<(byte, Type), Func<object, object, IGeometryContext, Result<IReadOnlyList<Morphology.IMorphologyResult>>>> {
-            [(MorphologyConfig.OpCageDeform, typeof(Mesh))] = ExecuteCageDeform,
-            [(MorphologyConfig.OpCageDeform, typeof(Brep))] = ExecuteCageDeform,
-            [(MorphologyConfig.OpSubdivideCatmullClark, typeof(Mesh))] = ExecuteSubdivideCatmullClark,
-            [(MorphologyConfig.OpSubdivideLoop, typeof(Mesh))] = ExecuteSubdivideLoop,
-            [(MorphologyConfig.OpSubdivideButterfly, typeof(Mesh))] = ExecuteSubdivideButterfly,
-            [(MorphologyConfig.OpSmoothLaplacian, typeof(Mesh))] = ExecuteSmoothLaplacian,
-            [(MorphologyConfig.OpSmoothTaubin, typeof(Mesh))] = ExecuteSmoothTaubin,
-            [(MorphologyConfig.OpEvolveMeanCurvature, typeof(Mesh))] = ExecuteEvolveMeanCurvature,
-            [(MorphologyConfig.OpOffset, typeof(Mesh))] = ExecuteOffset,
-            [(MorphologyConfig.OpReduce, typeof(Mesh))] = ExecuteReduce,
-            [(MorphologyConfig.OpRemesh, typeof(Mesh))] = ExecuteRemesh,
-            [(MorphologyConfig.OpBrepToMesh, typeof(Brep))] = ExecuteBrepToMesh,
-            [(MorphologyConfig.OpMeshRepair, typeof(Mesh))] = ExecuteMeshRepair,
-            [(MorphologyConfig.OpMeshThicken, typeof(Mesh))] = ExecuteMeshThicken,
-            [(MorphologyConfig.OpMeshUnwrap, typeof(Mesh))] = ExecuteMeshUnwrap,
-            [(MorphologyConfig.OpMeshSeparate, typeof(Mesh))] = ExecuteMeshSeparate,
-            [(MorphologyConfig.OpMeshWeld, typeof(Mesh))] = ExecuteMeshWeld,
-        }.ToFrozenDictionary();
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<Morphology.IMorphologyResult>> Apply<T>(
+        T input,
+        Morphology.MorphologyRequest request,
+        IGeometryContext context) where T : GeometryBase =>
+        request is null
+            ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.UnsupportedConfiguration.WithContext("Request cannot be null"))
+            : MorphologyConfig.TryGetOperationMetadata(request.GetType(), typeof(T), out MorphologyConfig.OperationMetadata metadata)
+                ? UnifiedOperation.Apply(
+                    input: input,
+                    operation: (Func<T, Result<IReadOnlyList<Morphology.IMorphologyResult>>>)(geometry => Dispatch(geometry, request, context)),
+                    config: new OperationConfig<T, Morphology.IMorphologyResult> {
+                        Context = context,
+                        ValidationMode = metadata.Validation,
+                        OperationName = string.Create(CultureInfo.InvariantCulture, $"Morphology.{metadata.Name}"),
+                        EnableDiagnostics = false,
+                    })
+                : ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
+                    error: E.Geometry.Morphology.UnsupportedConfiguration.WithContext(
+                        string.Create(CultureInfo.InvariantCulture, $"Request: {request.GetType().Name}, Type: {typeof(T).Name}")));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> Execute<TGeom, TParam>(
-        object input,
-        object parameters,
-        IGeometryContext context,
-        Func<TGeom, TParam, IGeometryContext, Result<IReadOnlyList<Morphology.IMorphologyResult>>> compute,
-        Func<object, bool>? geomCheck = null) where TGeom : GeometryBase =>
-        input is not TGeom geom || (geomCheck is not null && !geomCheck(input))
-            ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.InvalidGeometryType.WithContext($"Expected: {typeof(TGeom).Name}"))
-            : parameters is not TParam param
-                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.InsufficientParameters.WithContext($"Expected: {typeof(TParam).Name}"))
-                : compute(geom, param, context);
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> Dispatch(
+        GeometryBase geometry,
+        Morphology.MorphologyRequest request,
+        IGeometryContext context) =>
+        (geometry, request) switch {
+            (Mesh mesh, Morphology.CageDeformRequest cage) => ExecuteCageDeform(mesh, cage, context),
+            (Brep brep, Morphology.CageDeformRequest cage) => ExecuteCageDeform(brep, cage, context),
+            (Mesh mesh, Morphology.CatmullClarkSubdivisionRequest subdiv) => ExecuteSubdivision(mesh, subdiv, MorphologyConfig.OpSubdivideCatmullClark, context),
+            (Mesh mesh, Morphology.LoopSubdivisionRequest subdiv) => ExecuteSubdivision(mesh, subdiv, MorphologyConfig.OpSubdivideLoop, context),
+            (Mesh mesh, Morphology.ButterflySubdivisionRequest subdiv) => ExecuteSubdivision(mesh, subdiv, MorphologyConfig.OpSubdivideButterfly, context),
+            (Mesh mesh, Morphology.LaplacianSmoothingRequest smoothing) => ExecuteLaplacianSmoothing(mesh, smoothing, context),
+            (Mesh mesh, Morphology.TaubinSmoothingRequest smoothing) => ExecuteTaubinSmoothing(mesh, smoothing, context),
+            (Mesh mesh, Morphology.MeanCurvatureFlowRequest smoothing) => ExecuteMeanCurvatureFlow(mesh, smoothing, context),
+            (Mesh mesh, Morphology.MeshOffsetRequest offset) => ExecuteOffset(mesh, offset, context),
+            (Mesh mesh, Morphology.MeshReductionRequest reduction) => ExecuteReduce(mesh, reduction, context),
+            (Mesh mesh, Morphology.RemeshRequest remesh) => ExecuteRemesh(mesh, remesh, context),
+            (Brep brep, Morphology.BrepToMeshRequest brepRequest) => ExecuteBrepToMesh(brep, brepRequest, context),
+            (Mesh mesh, Morphology.MeshRepairRequest repair) => ExecuteMeshRepair(mesh, repair, context),
+            (Mesh mesh, Morphology.MeshThickenRequest thicken) => ExecuteMeshThicken(mesh, thicken, context),
+            (Mesh mesh, Morphology.MeshUnwrapRequest unwrap) => ExecuteMeshUnwrap(mesh, unwrap, context),
+            (Mesh mesh, Morphology.MeshSeparationRequest) => ExecuteMeshSeparate(mesh, context),
+            (Mesh mesh, Morphology.MeshWeldRequest weld) => ExecuteMeshWeld(mesh, weld, context),
+            _ => ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.UnsupportedConfiguration.WithContext(
+                string.Create(CultureInfo.InvariantCulture, $"Geometry: {geometry.GetType().Name}, Request: {request.GetType().Name}"))),
+        };
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteCageDeform(object input, object parameters, IGeometryContext context) =>
-        Execute<GeometryBase, (GeometryBase, Point3d[], Point3d[])>(
-            input,
-            parameters,
-            context,
-            (geom, p, ctx) => {
-                (GeometryBase cage, Point3d[] originalPts, Point3d[] deformedPts) = p;
-                return MorphologyCompute.CageDeform(geom, cage, originalPts, deformedPts, ctx).Bind(deformed => {
-                    BoundingBox originalBounds = geom.GetBoundingBox(accurate: false);
-                    BoundingBox deformedBounds = deformed.GetBoundingBox(accurate: false);
-                    double[] displacements = [.. originalPts.Zip(deformedPts, static (o, d) => o.DistanceTo(d)),];
-                    return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
-                        value: [new Morphology.CageDeformResult(
-                            deformed,
-                            displacements.Length > 0 ? displacements.Max() : 0.0,
-                            displacements.Length > 0 ? displacements.Average() : 0.0,
-                            originalBounds,
-                            deformedBounds,
-                            RhinoMath.IsValidDouble(originalBounds.Volume) && originalBounds.Volume > RhinoMath.ZeroTolerance
-                                ? deformedBounds.Volume / originalBounds.Volume
-                                : 1.0),
-                        ]);
-                });
-            },
-            geomCheck: g => g is Mesh or Brep);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivideCatmullClark(object input, object parameters, IGeometryContext context) =>
-        ExecuteSubdivision(input, parameters, context, MorphologyConfig.OpSubdivideCatmullClark);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivideLoop(object input, object parameters, IGeometryContext context) =>
-        ExecuteSubdivision(input, parameters, context, MorphologyConfig.OpSubdivideLoop);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivideButterfly(object input, object parameters, IGeometryContext context) =>
-        ExecuteSubdivision(input, parameters, context, MorphologyConfig.OpSubdivideButterfly);
-
-    /// <summary>Unified subdivision executor for CatmullClark, Loop, and Butterfly algorithms. Validates triangulated mesh requirement for Loop/Butterfly (MorphologyConfig.OpSubdivideLoop/OpSubdivideButterfly).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivision(object input, object parameters, IGeometryContext context, byte algorithm) =>
-        Execute<Mesh, int>(input, parameters, context, (mesh, levels, ctx) =>
-            MorphologyConfig.TriangulatedSubdivisionOps.Contains(algorithm) && mesh.Faces.TriangleCount != mesh.Faces.Count
-                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
-                    error: (algorithm == MorphologyConfig.OpSubdivideLoop ? E.Geometry.Morphology.LoopRequiresTriangles : E.Geometry.Morphology.ButterflyRequiresTriangles)
-                        .WithContext(string.Create(System.Globalization.CultureInfo.InvariantCulture, $"TriangleCount: {mesh.Faces.TriangleCount}, FaceCount: {mesh.Faces.Count}")))
-                : MorphologyCompute.SubdivideIterative(mesh, algorithm, levels, ctx).Bind(subdivided => ComputeSubdivisionMetrics(mesh, subdivided, ctx)));
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSmoothLaplacian(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (int, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (int iters, bool lockBound) = p;
-            return MorphologyCompute.SmoothWithConvergence(mesh, iters, lockBound, (m, pos, _) => LaplacianUpdate(m, pos, useCotangent: true), ctx)
-                .Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, iters, ctx));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteCageDeform(
+        GeometryBase geometry,
+        Morphology.CageDeformRequest request,
+        IGeometryContext context) {
+        Point3d[] originalPoints = request.OriginalControlPoints is Point3d[] directOriginal
+            ? directOriginal
+            : request.OriginalControlPoints.ToArray();
+        Point3d[] deformedPoints = request.DeformedControlPoints is Point3d[] directDeformed
+            ? directDeformed
+            : request.DeformedControlPoints.ToArray();
+        return MorphologyCompute.CageDeform(geometry, request.Cage, originalPoints, deformedPoints, context).Bind(deformed => {
+            BoundingBox originalBounds = geometry.GetBoundingBox(accurate: false);
+            BoundingBox deformedBounds = deformed.GetBoundingBox(accurate: false);
+            double[] displacements = [.. originalPoints.Zip(deformedPoints, static (o, d) => o.DistanceTo(d)),];
+            return ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
+                value: [new Morphology.CageDeformResult(
+                    deformed,
+                    displacements.Length > 0 ? displacements.Max() : 0.0,
+                    displacements.Length > 0 ? displacements.Average() : 0.0,
+                    originalBounds,
+                    deformedBounds,
+                    RhinoMath.IsValidDouble(originalBounds.Volume) && originalBounds.Volume > RhinoMath.ZeroTolerance
+                        ? deformedBounds.Volume / originalBounds.Volume
+                        : 1.0),
+                ]);
         });
+    }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSmoothTaubin(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (int, double, double)>(input, parameters, context, (mesh, p, ctx) =>
-            p.Item3 >= -p.Item2
-                ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.TaubinParametersInvalid.WithContext(
-                    string.Create(System.Globalization.CultureInfo.InvariantCulture, $"μ ({p.Item3:F4}) must be < -λ ({(-p.Item2):F4})")))
-                : MorphologyCompute.SmoothWithConvergence(mesh, p.Item1, lockBoundary: false, (m, pos, _) => {
-                    Point3d[] step1 = LaplacianUpdate(m, pos, useCotangent: false);
-                    Point3d[] blended1 = new Point3d[pos.Length];
-                    for (int i = 0; i < pos.Length; i++) {
-                        blended1[i] = pos[i] + (p.Item2 * (step1[i] - pos[i]));
-                    }
-                    Point3d[] step2 = LaplacianUpdate(m, blended1, useCotangent: false);
-                    Point3d[] result = new Point3d[pos.Length];
-                    for (int i = 0; i < pos.Length; i++) {
-                        result[i] = blended1[i] + (p.Item3 * (step2[i] - blended1[i]));
-                    }
-                    return result;
-                }, ctx).Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, p.Item1, ctx)));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteSubdivision(
+        Mesh mesh,
+        Morphology.SubdivisionRequest request,
+        byte algorithm,
+        IGeometryContext context) =>
+        MorphologyConfig.TriangulatedSubdivisionOps.Contains(algorithm) && mesh.Faces.TriangleCount != mesh.Faces.Count
+            ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(
+                error: (algorithm == MorphologyConfig.OpSubdivideLoop ? E.Geometry.Morphology.LoopRequiresTriangles : E.Geometry.Morphology.ButterflyRequiresTriangles)
+                    .WithContext(string.Create(CultureInfo.InvariantCulture, $"TriangleCount: {mesh.Faces.TriangleCount}, FaceCount: {mesh.Faces.Count}")))
+            : MorphologyCompute.SubdivideIterative(mesh, algorithm, request.Levels, context).Bind(subdivided => ComputeSubdivisionMetrics(mesh, subdivided, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteEvolveMeanCurvature(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, int)>(input, parameters, context, (mesh, p, ctx) => {
-            (double timeStep, int iters) = p;
-            return MorphologyCompute.SmoothWithConvergence(mesh, iters, lockBoundary: false, (m, pos, _) => MeanCurvatureFlowUpdate(m, pos, timeStep), ctx)
-                .Bind(evolved => ComputeSmoothingMetrics(mesh, evolved, iters, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteLaplacianSmoothing(
+        Mesh mesh,
+        Morphology.LaplacianSmoothingRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.SmoothWithConvergence(mesh, request.Iterations, request.LockBoundary, (m, pos, _) => LaplacianUpdate(m, pos, useCotangent: true), context)
+            .Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, request.Iterations, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteOffset(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (double distance, bool bothSides) = p;
-            return MorphologyCompute.OffsetMesh(mesh, distance, bothSides, ctx).Bind(offset => ComputeOffsetMetrics(mesh, offset, distance, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteTaubinSmoothing(
+        Mesh mesh,
+        Morphology.TaubinSmoothingRequest request,
+        IGeometryContext context) =>
+        request.Mu >= -request.Lambda
+            ? ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.Morphology.TaubinParametersInvalid.WithContext(
+                string.Create(CultureInfo.InvariantCulture, $"μ ({request.Mu:F4}) must be < -λ ({(-request.Lambda):F4})")))
+            : MorphologyCompute.SmoothWithConvergence(mesh, request.Iterations, lockBoundary: false, (m, pos, _) => {
+                Point3d[] step1 = LaplacianUpdate(m, pos, useCotangent: false);
+                Point3d[] blended1 = new Point3d[pos.Length];
+                for (int i = 0; i < pos.Length; i++) {
+                    blended1[i] = pos[i] + (request.Lambda * (step1[i] - pos[i]));
+                }
+                Point3d[] step2 = LaplacianUpdate(m, blended1, useCotangent: false);
+                Point3d[] result = new Point3d[pos.Length];
+                for (int i = 0; i < pos.Length; i++) {
+                    result[i] = blended1[i] + (request.Mu * (step2[i] - blended1[i]));
+                }
+                return result;
+            }, context).Bind(smoothed => ComputeSmoothingMetrics(mesh, smoothed, request.Iterations, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteReduce(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (int, bool, double)>(input, parameters, context, (mesh, p, ctx) => {
-            (int targetFaces, bool preserveBoundary, double accuracy) = p;
-            return MorphologyCompute.ReduceMesh(mesh, targetFaces, preserveBoundary, accuracy, ctx).Bind(reduced => ComputeReductionMetrics(mesh, reduced, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeanCurvatureFlow(
+        Mesh mesh,
+        Morphology.MeanCurvatureFlowRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.SmoothWithConvergence(mesh, request.Iterations, lockBoundary: false, (m, pos, _) => MeanCurvatureFlowUpdate(m, pos, request.TimeStep), context)
+            .Bind(evolved => ComputeSmoothingMetrics(mesh, evolved, request.Iterations, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteRemesh(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, int, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (double targetEdge, int maxIters, bool preserveFeats) = p;
-            return MorphologyCompute.RemeshIsotropic(mesh, targetEdge, maxIters, preserveFeats, ctx)
-                .Bind(remeshData => ComputeRemeshMetrics(mesh, remeshData.Remeshed, targetEdge, remeshData.IterationsPerformed, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteOffset(
+        Mesh mesh,
+        Morphology.MeshOffsetRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.OffsetMesh(mesh, request.Distance, request.OffsetBothSides, context)
+            .Bind(offset => ComputeOffsetMetrics(mesh, offset, request.Distance, context));
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteReduce(
+        Mesh mesh,
+        Morphology.MeshReductionRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.ReduceMesh(mesh, request.TargetFaceCount, request.PreserveBoundary, request.Accuracy, context)
+            .Bind(reduced => ComputeReductionMetrics(mesh, reduced, context));
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteRemesh(
+        Mesh mesh,
+        Morphology.RemeshRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.RemeshIsotropic(mesh, request.TargetEdgeLength, request.MaxIterations, request.PreserveFeatures, context)
+            .Bind(remeshData => ComputeRemeshMetrics(mesh, remeshData.Remeshed, request.TargetEdgeLength, remeshData.IterationsPerformed, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Point3d[] LaplacianUpdate(Mesh mesh, Point3d[] positions, bool useCotangent) =>
@@ -168,8 +180,8 @@ internal static class MorphologyCore {
                             ? MorphologyConfig.UniformLaplacianWeight / Math.Max(positions[i].DistanceTo(neighborPos), RhinoMath.ZeroTolerance)
                             : MorphologyConfig.UniformLaplacianWeight;
                         return (acc.weightedSum + (weight * (Vector3d)neighborPos), acc.weightSum + weight);
-                    }) is var (wSum, wTotal) && wTotal > RhinoMath.ZeroTolerance
-                        ? (Point3d)(wSum / wTotal)
+                    }) is (Vector3d WeightedSum, double WeightTotal) data && data.WeightTotal > RhinoMath.ZeroTolerance
+                        ? (Point3d)(data.WeightedSum / data.WeightTotal)
                         : positions[i];
         }),
         ];
@@ -325,29 +337,34 @@ internal static class MorphologyCore {
     }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshRepair(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (byte, double)>(input, parameters, context, (mesh, p, ctx) => {
-            (byte flags, double weldTol) = p;
-            return MorphologyCompute.RepairMesh(mesh, flags, weldTol, ctx).Bind(repaired => ComputeRepairMetrics(mesh, repaired, flags, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshRepair(
+        Mesh mesh,
+        Morphology.MeshRepairRequest request,
+        IGeometryContext context) {
+        IReadOnlyList<Morphology.MeshRepairOperation> operations = request.Operations ?? System.Array.Empty<Morphology.MeshRepairOperation>();
+        return MorphologyCompute.RepairMesh(mesh, operations, request.WeldTolerance, context)
+            .Bind(repaired => ComputeRepairMetrics(mesh, repaired, operations, context));
+    }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshSeparate(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, ValueTuple>(input, parameters, context, (mesh, _, ctx) =>
-            MorphologyCompute.SeparateMeshComponents(mesh, ctx).Bind(components => ComputeSeparationMetrics(components, ctx)));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshSeparate(
+        Mesh mesh,
+        IGeometryContext context) =>
+        MorphologyCompute.SeparateMeshComponents(mesh, context).Bind(components => ComputeSeparationMetrics(components, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshWeld(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, bool)>(input, parameters, context, (mesh, p, ctx) => {
-            (double tolerance, bool weldNormals) = p;
-            return MorphologyCompute.WeldMeshVertices(mesh, tolerance, weldNormals, ctx).Bind(welded => ComputeWeldMetrics(mesh, welded, tolerance, weldNormals, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshWeld(
+        Mesh mesh,
+        Morphology.MeshWeldRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.WeldMeshVertices(mesh, request.Tolerance, request.RecomputeNormals, context)
+            .Bind(welded => ComputeWeldMetrics(mesh, welded, request.Tolerance, request.RecomputeNormals, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeRepairMetrics(
         Mesh original,
         Mesh repaired,
-        byte operations,
+        IReadOnlyList<Morphology.MeshRepairOperation> operations,
         IGeometryContext context) =>
         ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(value: [
             new Morphology.MeshRepairResult(
@@ -356,7 +373,7 @@ internal static class MorphologyCore {
                 repaired.Vertices.Count,
                 original.Faces.Count,
                 repaired.Faces.Count,
-                operations,
+                [.. operations,],
                 MorphologyCompute.ValidateMeshQuality(repaired, context).IsSuccess ? 1.0 : 0.0,
                 original.DisjointMeshCount > 1,
                 original.Normals.Count != original.Vertices.Count || original.Normals.Any(n => n.IsZero)),
@@ -409,11 +426,12 @@ internal static class MorphologyCore {
             : ResultFactory.Create<IReadOnlyList<Morphology.IMorphologyResult>>(error: E.Geometry.InvalidCount);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteBrepToMesh(object input, object parameters, IGeometryContext context) =>
-        Execute<Brep, (MeshingParameters?, bool)>(input, parameters, context, (brep, p, ctx) => {
-            (MeshingParameters? meshParams, bool joinMeshes) = p;
-            return MorphologyCompute.BrepToMesh(brep, meshParams, joinMeshes, ctx).Bind(mesh => ComputeBrepToMeshMetrics(brep, mesh, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteBrepToMesh(
+        Brep brep,
+        Morphology.BrepToMeshRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.BrepToMesh(brep, request.Parameters, request.JoinMeshes, context)
+            .Bind(mesh => ComputeBrepToMeshMetrics(brep, mesh, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeBrepToMeshMetrics(
@@ -456,11 +474,12 @@ internal static class MorphologyCore {
     }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshThicken(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, (double, bool, Vector3d)>(input, parameters, context, (mesh, p, ctx) => {
-            (double thickness, bool solidify, Vector3d direction) = p;
-            return MorphologyCompute.ThickenMesh(mesh, thickness, solidify, direction, ctx).Bind(thickened => ComputeThickenMetrics(mesh, thickened, thickness, solidify, direction, ctx));
-        });
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshThicken(
+        Mesh mesh,
+        Morphology.MeshThickenRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.ThickenMesh(mesh, request.Thickness, request.Solidify, request.Direction, context)
+            .Bind(thickened => ComputeThickenMetrics(mesh, thickened, request.Thickness, request.Solidify, request.Direction, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeThickenMetrics(
@@ -490,9 +509,12 @@ internal static class MorphologyCore {
     }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshUnwrap(object input, object parameters, IGeometryContext context) =>
-        Execute<Mesh, byte>(input, parameters, context, (mesh, unwrapMethod, ctx) =>
-            MorphologyCompute.UnwrapMesh(mesh, unwrapMethod, ctx).Bind(unwrapped => ComputeUnwrapMetrics(mesh, unwrapped, ctx)));
+    private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ExecuteMeshUnwrap(
+        Mesh mesh,
+        Morphology.MeshUnwrapRequest request,
+        IGeometryContext context) =>
+        MorphologyCompute.UnwrapMesh(mesh, request.Strategy, context)
+            .Bind(unwrapped => ComputeUnwrapMetrics(mesh, unwrapped, context));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<IReadOnlyList<Morphology.IMorphologyResult>> ComputeUnwrapMetrics(


### PR DESCRIPTION
## Summary
- replace the legacy byte-and-object morphology API with nested algebraic request, strategy, and operation records on `Morphology`
- rework `MorphologyConfig`, `MorphologyCore`, and `MorphologyCompute` to dispatch and execute based on the new strongly typed requests while keeping the existing four-file architecture
- update mesh repair and unwrap implementations to operate on strongly typed operations/strategies and surface richer result data

## Testing
- `dotnet build` *(fails: `dotnet` command is unavailable in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2fec3b5c8321a54d823dd7e81c21)