### PR TITLE
Refactor Fields APIs to algebraic domain types

### DIFF
--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -261,12 +261,12 @@ internal static class FieldsCompute {
         Point3d[] grid,
         int resolution,
         BoundingBox bounds,
-        byte interpolationMethod,
+        Fields.InterpolationMode interpolation,
         Func<T, T, double, T> lerp) where T : struct =>
-        interpolationMethod switch {
-            FieldsConfig.InterpolationNearest => InterpolateNearest(query, field, grid),
-            FieldsConfig.InterpolationTrilinear => InterpolateTrilinear(query: query, field: field, resolution: resolution, bounds: bounds, lerp: lerp),
-            _ => ResultFactory.Create<T>(error: E.Geometry.InvalidFieldInterpolation.WithContext($"Unsupported interpolation method: {interpolationMethod.ToString(System.Globalization.CultureInfo.InvariantCulture)}")),
+        interpolation switch {
+            Fields.NearestInterpolationMode => InterpolateNearest(query, field, grid),
+            Fields.TrilinearInterpolationMode => InterpolateTrilinear(query: query, field: field, resolution: resolution, bounds: bounds, lerp: lerp),
+            _ => ResultFactory.Create<T>(error: E.Geometry.InvalidFieldInterpolation.WithContext($"Unsupported interpolation mode: {interpolation.GetType().Name}")),
         };
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -276,8 +276,8 @@ internal static class FieldsCompute {
         Point3d[] grid,
         int resolution,
         BoundingBox bounds,
-        byte interpolationMethod) =>
-        InterpolateField(query: query, field: scalarField, grid: grid, resolution: resolution, bounds: bounds, interpolationMethod: interpolationMethod, lerp: (a, b, t) => a + (t * (b - a)));
+        Fields.InterpolationMode interpolation) =>
+        InterpolateField(query: query, field: scalarField, grid: grid, resolution: resolution, bounds: bounds, interpolation: interpolation, lerp: (a, b, t) => a + (t * (b - a)));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<Vector3d> InterpolateVector(
@@ -286,8 +286,8 @@ internal static class FieldsCompute {
         Point3d[] grid,
         int resolution,
         BoundingBox bounds,
-        byte interpolationMethod) =>
-        InterpolateField(query: query, field: vectorField, grid: grid, resolution: resolution, bounds: bounds, interpolationMethod: interpolationMethod, lerp: (a, b, t) => a + (t * (b - a)));
+        Fields.InterpolationMode interpolation) =>
+        InterpolateField(query: query, field: vectorField, grid: grid, resolution: resolution, bounds: bounds, interpolation: interpolation, lerp: (a, b, t) => a + (t * (b - a)));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<T> InterpolateNearest<T>(Point3d query, T[] field, Point3d[] grid) {
@@ -356,7 +356,7 @@ internal static class FieldsCompute {
         Point3d[] gridPoints,
         Point3d[] seeds,
         double stepSize,
-        byte integrationMethod,
+        Fields.StreamlineIntegration integration,
         int resolution,
         BoundingBox bounds,
         IGeometryContext context) =>
@@ -371,10 +371,10 @@ internal static class FieldsCompute {
                     for (int step = 0; step < FieldsConfig.MaxStreamlineSteps - 1; step++) {
                         Vector3d k1 = InterpolateVectorFieldInternal(vectorField: vectorField, gridPoints: gridPoints, query: current, resolution: resolution, bounds: bounds);
                         Vector3d Interpolate(double coeff, Vector3d k) => InterpolateVectorFieldInternal(vectorField: vectorField, gridPoints: gridPoints, query: current + (stepSize * coeff * k), resolution: resolution, bounds: bounds);
-                        Vector3d delta = integrationMethod switch {
-                            0 => stepSize * k1,
-                            1 => stepSize * Interpolate(FieldsConfig.RK2HalfStep, k1),
-                            2 or 3 => ((Func<Vector3d>)(() => {
+                        Vector3d delta = integration switch {
+                            Fields.ExplicitEulerIntegration => stepSize * k1,
+                            Fields.RungeKutta2Integration => stepSize * Interpolate(FieldsConfig.RK2HalfStep, k1),
+                            Fields.RungeKutta4Integration => ((Func<Vector3d>)(() => {
                                 Vector3d k2 = Interpolate(FieldsConfig.RK4HalfSteps[0], k1);
                                 Vector3d k3 = Interpolate(FieldsConfig.RK4HalfSteps[1], k2);
                                 Vector3d k4 = Interpolate(FieldsConfig.RK4HalfSteps[2], k3);
@@ -645,22 +645,19 @@ internal static class FieldsCompute {
         double[] scalarField,
         Vector3d[] vectorField,
         Point3d[] grid,
-        int component) =>
-        (component is >= 0 and <= 2) switch {
-            false => ResultFactory.Create<(Point3d[], double[])>(error: E.Geometry.InvalidFieldComposition.WithContext("Component must be 0 (X), 1 (Y), or 2 (Z)")),
-            true => ApplyBinaryFieldOperation(
-                inputField1: scalarField,
-                inputField2: vectorField,
-                grid: grid,
-                operation: (scalar, vector, _) => component switch {
-                    0 => scalar * vector.X,
-                    1 => scalar * vector.Y,
-                    2 => scalar * vector.Z,
-                    _ => 0.0,
-                },
-                error1: E.Geometry.InvalidFieldComposition.WithContext("Scalar field length must match grid points"),
-                error2: E.Geometry.InvalidFieldComposition.WithContext("Vector field length must match grid points")),
-        };
+        Fields.VectorComponent component) =>
+        ApplyBinaryFieldOperation(
+            inputField1: scalarField,
+            inputField2: vectorField,
+            grid: grid,
+            operation: (scalar, vector, _) => component switch {
+                Fields.XComponent => scalar * vector.X,
+                Fields.YComponent => scalar * vector.Y,
+                Fields.ZComponent => scalar * vector.Z,
+                _ => 0.0,
+            },
+            error1: E.Geometry.InvalidFieldComposition.WithContext("Scalar field length must match grid points"),
+            error2: E.Geometry.InvalidFieldComposition.WithContext("Vector field length must match grid points"));
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<(Point3d[] Grid, double[] DotProduct)> VectorDotProduct(
@@ -707,15 +704,15 @@ internal static class FieldsCompute {
                                 (double[] eigenvalues, Vector3d[] eigenvectors) = ComputeEigendecomposition3x3(localHessian);
                                 int positiveCount = eigenvalues.Count(ev => ev > FieldsConfig.EigenvalueThreshold);
                                 int negativeCount = eigenvalues.Count(ev => ev < -FieldsConfig.EigenvalueThreshold);
-                                byte criticalType = (positiveCount, negativeCount) switch {
-                                    (3, 0) => FieldsConfig.CriticalPointMinimum,
-                                    (0, 3) => FieldsConfig.CriticalPointMaximum,
-                                    _ => FieldsConfig.CriticalPointSaddle,
+                                Fields.CriticalPointKind criticalType = (positiveCount, negativeCount) switch {
+                                    (3, 0) => new Fields.MinimumCriticalPoint(),
+                                    (0, 3) => new Fields.MaximumCriticalPoint(),
+                                    _ => new Fields.SaddleCriticalPoint(),
                                 };
 
                                 criticalPoints.Add(new Fields.CriticalPoint(
                                     Location: grid[idx],
-                                    Type: criticalType,
+                                    Kind: criticalType,
                                     Value: scalarField[idx],
                                     Eigenvectors: eigenvectors,
                                     Eigenvalues: eigenvalues));

--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -646,18 +646,20 @@ internal static class FieldsCompute {
         Vector3d[] vectorField,
         Point3d[] grid,
         Fields.VectorComponent component) =>
-        ApplyBinaryFieldOperation(
-            inputField1: scalarField,
-            inputField2: vectorField,
-            grid: grid,
-            operation: (scalar, vector, _) => component switch {
-                Fields.XComponent => scalar * vector.X,
-                Fields.YComponent => scalar * vector.Y,
-                Fields.ZComponent => scalar * vector.Z,
-                _ => 0.0,
-            },
-            error1: E.Geometry.InvalidFieldComposition.WithContext("Scalar field length must match grid points"),
-            error2: E.Geometry.InvalidFieldComposition.WithContext("Vector field length must match grid points"));
+        (component == Fields.XComponent || component == Fields.YComponent || component == Fields.ZComponent)
+            ? ApplyBinaryFieldOperation(
+                inputField1: scalarField,
+                inputField2: vectorField,
+                grid: grid,
+                operation: (scalar, vector, _) => component switch {
+                    Fields.XComponent => scalar * vector.X,
+                    Fields.YComponent => scalar * vector.Y,
+                    Fields.ZComponent => scalar * vector.Z,
+                },
+                error1: E.Geometry.InvalidFieldComposition.WithContext("Scalar field length must match grid points"),
+                error2: E.Geometry.InvalidFieldComposition.WithContext("Vector field length must match grid points"))
+            : ResultFactory.Create<(Point3d[], double[])>(
+                error: E.Geometry.InvalidFieldComponent.WithContext("Invalid vector component for scalar-vector product")),
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<(Point3d[] Grid, double[] DotProduct)> VectorDotProduct(

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -6,10 +6,9 @@ namespace Arsenal.Rhino.Fields;
 /// <summary>Configuration constants, byte operation codes, and unified dispatch registry for fields operations.</summary>
 [Pure]
 internal static class FieldsConfig {
-    internal const byte OperationDistance = 0;
-    internal const byte IntegrationRK4 = 2;
-    internal const byte InterpolationNearest = 0;
-    internal const byte InterpolationTrilinear = 1;
+    internal static class OperationNames {
+        internal const string DistanceField = "fields.distance-field";
+    }
 
     internal const int DefaultResolution = 32;
     internal const int MinResolution = 8;
@@ -31,9 +30,10 @@ internal static class FieldsConfig {
 
     internal const int FieldRTreeThreshold = 100;
 
-    internal const byte CriticalPointMinimum = 0;
-    internal const byte CriticalPointMaximum = 1;
-    internal const byte CriticalPointSaddle = 2;
+    internal const int DistanceFieldMeshBuffer = 4096;
+    internal const int DistanceFieldBrepBuffer = 8192;
+    internal const int DistanceFieldCurveBuffer = 2048;
+    internal const int DistanceFieldSurfaceBuffer = 4096;
 
     internal static readonly (int V1, int V2)[] EdgeVertexPairs = [
         (0, 1),


### PR DESCRIPTION
## Summary
- introduce algebraic request, interpolation, integration, component, and critical-point record hierarchies inside `Fields` and update every public API to consume strongly typed `FieldSampling` specifications
- rework the core dispatch table to use typed `FrozenDictionary` metadata with `UnifiedOperation`, and update `FieldsCompute` to interpret the new algebraic types for interpolation, streamline integration, scalar-vector products, and critical point classification
- extend `FieldsConfig` with named operation metadata and buffer constants supporting the algebraic model

## Testing
- dotnet build *(fails: `dotnet` not found in container)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbdef6590832191e134038b0462e6)