### PR TITLE
Refactor fields API to algebraic domain types

### DIFF
--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -6,14 +6,21 @@ namespace Arsenal.Rhino.Fields;
 /// <summary>Configuration constants, byte operation codes, and unified dispatch registry for fields operations.</summary>
 [Pure]
 internal static class FieldsConfig {
-    internal const byte OperationDistance = 0;
-    internal const byte IntegrationRK4 = 2;
-    internal const byte InterpolationNearest = 0;
-    internal const byte InterpolationTrilinear = 1;
+    internal static class OperationNames {
+        internal const string MeshDistance = "Fields.Mesh.Distance";
+        internal const string BrepDistance = "Fields.Brep.Distance";
+        internal const string CurveDistance = "Fields.Curve.Distance";
+        internal const string SurfaceDistance = "Fields.Surface.Distance";
+    }
 
     internal const int DefaultResolution = 32;
     internal const int MinResolution = 8;
     internal const int MaxResolution = 256;
+
+    internal const int MeshDistanceBuffer = 4096;
+    internal const int BrepDistanceBuffer = 8192;
+    internal const int CurveDistanceBuffer = 2048;
+    internal const int SurfaceDistanceBuffer = 4096;
 
     internal const double DefaultStepSize = 0.01;
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1802:Use literals where appropriate", Justification = "Value depends on RhinoMath constant")]
@@ -30,10 +37,6 @@ internal static class FieldsConfig {
     internal const double RK2HalfStep = 0.5;
 
     internal const int FieldRTreeThreshold = 100;
-
-    internal const byte CriticalPointMinimum = 0;
-    internal const byte CriticalPointMaximum = 1;
-    internal const byte CriticalPointSaddle = 2;
 
     internal static readonly (int V1, int V2)[] EdgeVertexPairs = [
         (0, 1),

--- a/libs/rhino/fields/FieldsCore.cs
+++ b/libs/rhino/fields/FieldsCore.cs
@@ -43,7 +43,7 @@ internal static class FieldsCore {
                 ValidationMode: V.Standard | V.BoundingBox,
                 OperationName: FieldsConfig.OperationNames.SurfaceDistance,
                 BufferSize: FieldsConfig.SurfaceDistanceBuffer),
-        }.ToFrozenDictionary();
+        ,}.ToFrozenDictionary();
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<(Point3d[] Grid, double[] Distances)> DistanceField(

--- a/libs/rhino/fields/FieldsCore.cs
+++ b/libs/rhino/fields/FieldsCore.cs
@@ -1,43 +1,99 @@
 using System.Buffers;
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
+using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
 using Arsenal.Core.Validation;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Fields;
 
-/// <summary>Fields dispatch registry with unified FrozenDictionary following SpatialCore pattern.</summary>
+/// <summary>Fields dispatch registry wired through UnifiedOperation.</summary>
 [Pure]
 internal static class FieldsCore {
-    /// <summary>Unified operation dispatch table: (operation, geometry type) → (execute function, validation mode, buffer size, integration method).</summary>
-    internal static readonly FrozenDictionary<(byte Operation, Type GeometryType), (Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, V ValidationMode, int BufferSize, byte IntegrationMethod)> OperationRegistry =
-        new Dictionary<(byte, Type), (Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>>, V, int, byte)> {
-            [(FieldsConfig.OperationDistance, typeof(Mesh))] = (ExecuteDistanceField<Mesh>, V.Standard | V.MeshSpecific, 4096, FieldsConfig.IntegrationRK4),
-            [(FieldsConfig.OperationDistance, typeof(Brep))] = (ExecuteDistanceField<Brep>, V.Standard | V.Topology, 8192, FieldsConfig.IntegrationRK4),
-            [(FieldsConfig.OperationDistance, typeof(Curve))] = (ExecuteDistanceField<Curve>, V.Standard | V.Degeneracy, 2048, FieldsConfig.IntegrationRK4),
-            [(FieldsConfig.OperationDistance, typeof(Surface))] = (ExecuteDistanceField<Surface>, V.Standard | V.BoundingBox, 4096, FieldsConfig.IntegrationRK4),
+    private sealed record DistanceOperationMetadata(
+        Func<GeometryBase, Fields.FieldSampling, int, IGeometryContext, Result<(Point3d[], double[])>> Executor,
+        V ValidationMode,
+        string OperationName,
+        int BufferSize);
+
+    private static readonly FrozenDictionary<Type, DistanceOperationMetadata> DistanceDispatch =
+        new Dictionary<Type, DistanceOperationMetadata> {
+            [typeof(Mesh)] = new DistanceOperationMetadata(
+                Executor: static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Mesh>(geometry, sampling, bufferSize, context),
+                ValidationMode: V.Standard | V.MeshSpecific,
+                OperationName: FieldsConfig.OperationNames.MeshDistance,
+                BufferSize: FieldsConfig.MeshDistanceBuffer),
+            [typeof(Brep)] = new DistanceOperationMetadata(
+                Executor: static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Brep>(geometry, sampling, bufferSize, context),
+                ValidationMode: V.Standard | V.Topology,
+                OperationName: FieldsConfig.OperationNames.BrepDistance,
+                BufferSize: FieldsConfig.BrepDistanceBuffer),
+            [typeof(Curve)] = new DistanceOperationMetadata(
+                Executor: static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Curve>(geometry, sampling, bufferSize, context),
+                ValidationMode: V.Standard | V.Degeneracy,
+                OperationName: FieldsConfig.OperationNames.CurveDistance,
+                BufferSize: FieldsConfig.CurveDistanceBuffer),
+            [typeof(Surface)] = new DistanceOperationMetadata(
+                Executor: static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Surface>(geometry, sampling, bufferSize, context),
+                ValidationMode: V.Standard | V.BoundingBox,
+                OperationName: FieldsConfig.OperationNames.SurfaceDistance,
+                BufferSize: FieldsConfig.SurfaceDistanceBuffer),
         }.ToFrozenDictionary();
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(Point3d[] Grid, double[] Distances)> DistanceField(
+        Fields.DistanceFieldRequest request,
+        IGeometryContext context) =>
+        request switch {
+            null => ResultFactory.Create<(Point3d[], double[])>(
+                error: E.Geometry.UnsupportedAnalysis.WithContext("Request cannot be null")),
+            { Geometry: null } => ResultFactory.Create<(Point3d[], double[])>(
+                error: E.Geometry.UnsupportedAnalysis.WithContext("Geometry cannot be null")),
+            { Sampling: null } => ResultFactory.Create<(Point3d[], double[])>(
+                error: E.Geometry.UnsupportedAnalysis.WithContext("Sampling specification cannot be null")),
+            _ => DispatchDistance(request: request, context: context),
+        };
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<(Point3d[] Grid, double[] Distances)> DispatchDistance(
+        Fields.DistanceFieldRequest request,
+        IGeometryContext context) {
+        GeometryBase geometry = request.Geometry;
+        return DistanceDispatch.TryGetValue(geometry.GetType(), out DistanceOperationMetadata metadata)
+            ? UnifiedOperation.Apply(
+                input: geometry,
+                operation: (Func<GeometryBase, Result<(Point3d[], double[])>>)(item => metadata.Executor(item, request.Sampling, metadata.BufferSize, context)),
+                config: new OperationConfig<GeometryBase, (Point3d[], double[])> {
+                    Context = context,
+                    ValidationMode = metadata.ValidationMode,
+                    OperationName = metadata.OperationName,
+                    EnableDiagnostics = false,
+                }).Map(results => results[0])
+            : ResultFactory.Create<(Point3d[], double[])>(
+                error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {geometry.GetType().Name}"));
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Result<(Point3d[], double[])> ExecuteDistanceField<T>(
-        object geometry,
-        Fields.FieldSpec spec,
+        GeometryBase geometry,
+        Fields.FieldSampling sampling,
+        int preferredBuffer,
         IGeometryContext context) where T : GeometryBase =>
         ((Func<Result<(Point3d[], double[])>>)(() => {
             T typed = (T)geometry;
-            BoundingBox bounds = spec.Bounds ?? typed.GetBoundingBox(accurate: true);
+            BoundingBox bounds = sampling.Bounds ?? typed.GetBoundingBox(accurate: true);
             if (!bounds.IsValid) {
                 return ResultFactory.Create<(Point3d[], double[])>(error: E.Geometry.InvalidFieldBounds);
             }
-            int resolution = spec.Resolution;
+
+            int resolution = sampling.Resolution;
             int totalSamples = resolution * resolution * resolution;
-            int bufferSize = OperationRegistry.TryGetValue((FieldsConfig.OperationDistance, typeof(T)), out (Func<object, Fields.FieldSpec, IGeometryContext, Result<(Point3d[], double[])>> Execute, V ValidationMode, int BufferSize, byte IntegrationMethod) config)
-                ? Math.Max(totalSamples, config.BufferSize)
-                : totalSamples;
+            int bufferSize = Math.Max(totalSamples, preferredBuffer);
             Point3d[] grid = ArrayPool<Point3d>.Shared.Rent(bufferSize);
             double[] distances = ArrayPool<double>.Shared.Rent(bufferSize);
             try {
@@ -46,16 +102,20 @@ internal static class FieldsCore {
                 for (int i = 0; i < resolution; i++) {
                     for (int j = 0; j < resolution; j++) {
                         for (int k = 0; k < resolution; k++) {
-                            grid[gridIndex++] = new Point3d(bounds.Min.X + (i * delta.X), bounds.Min.Y + (j * delta.Y), bounds.Min.Z + (k * delta.Z));
+                            grid[gridIndex++] = new Point3d(
+                                bounds.Min.X + (i * delta.X),
+                                bounds.Min.Y + (j * delta.Y),
+                                bounds.Min.Z + (k * delta.Z));
                         }
                     }
                 }
+
                 for (int i = 0; i < totalSamples; i++) {
                     Point3d closest = typed switch {
-                        Mesh m => m.ClosestPoint(grid[i]),
-                        Brep b => b.ClosestPoint(grid[i]),
-                        Curve c => c.ClosestPoint(grid[i], out double t) ? c.PointAt(t) : grid[i],
-                        Surface s => s.ClosestPoint(grid[i], out double u, out double v) ? s.PointAt(u, v) : grid[i],
+                        Mesh mesh => mesh.ClosestPoint(grid[i]),
+                        Brep brep => brep.ClosestPoint(grid[i]),
+                        Curve curve => curve.ClosestPoint(grid[i], out double t) ? curve.PointAt(t) : grid[i],
+                        Surface surface => surface.ClosestPoint(grid[i], out double u, out double v) ? surface.PointAt(u, v) : grid[i],
                         _ => grid[i],
                     };
                     double unsignedDist = grid[i].DistanceTo(closest);
@@ -66,6 +126,7 @@ internal static class FieldsCore {
                     };
                     distances[i] = inside ? -unsignedDist : unsignedDist;
                 }
+
                 Point3d[] finalGrid = [.. grid[..totalSamples]];
                 double[] finalDistances = [.. distances[..totalSamples]];
                 return ResultFactory.Create(value: (Grid: finalGrid, Distances: finalDistances));


### PR DESCRIPTION
## Summary
- replace the Fields API surface with algebraic record hierarchies for sampling, interpolation, integration, component selection, and distance field requests
- rebuild the FieldsCore dispatch layer around UnifiedOperation with frozen metadata instead of byte opcodes
- update compute routines to consume the new domain types for interpolation, streamline integration, scalar/vector products, and critical point classification

## Testing
- `dotnet build` *(fails: `dotnet` command is unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbdef6590832191e134038b0462e6)