### PR TITLE
Refactor Fields operations to algebraic configuration model

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -32,10 +32,11 @@ public static class Fields {
         public double StepSize { get; }
 
         private static int NormalizeResolution(int resolution) =>
-            resolution switch {
-                < FieldsConfig.MinResolution => FieldsConfig.DefaultResolution,
-                _ => resolution,
-            };
+        resolution switch {
+            < FieldsConfig.MinResolution => FieldsConfig.MinResolution,
+            > FieldsConfig.MaxResolution => FieldsConfig.MaxResolution,
+            _ => resolution,
+        };
 
         private static double NormalizeStepSize(double? stepSize) =>
             stepSize switch {

--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -14,8 +14,10 @@ public static class Fields {
     /// <summary>Field specification for grid resolution, bounds, and integration step size.</summary>
     public sealed record FieldSpec {
         public FieldSpec(int? resolution = null, BoundingBox? bounds = null, double? stepSize = null) {
-            int normalized = NormalizeResolution(resolution ?? FieldsConfig.DefaultResolution);
-            this.Resolution = RhinoMath.Clamp(normalized, FieldsConfig.MinResolution, FieldsConfig.MaxResolution);
+            this.Resolution = RhinoMath.Clamp(
+                resolution ?? FieldsConfig.DefaultResolution, 
+                FieldsConfig.MinResolution, 
+                FieldsConfig.MaxResolution);
             this.Bounds = bounds;
             this.StepSize = NormalizeStepSize(stepSize);
         }

--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -264,8 +264,8 @@ internal static class FieldsCompute {
         Fields.InterpolationMode interpolationMode,
         Func<T, T, double, T> lerp) where T : struct =>
         interpolationMode switch {
-            Fields.InterpolationMode.NearestInterpolationMode => InterpolateNearest(query, field, grid),
-            Fields.InterpolationMode.TrilinearInterpolationMode => InterpolateTrilinear(query: query, field: field, resolution: resolution, bounds: bounds, lerp: lerp),
+            Fields.InterpolationMode.NearestInterpolationMode _ => InterpolateNearest(query, field, grid),
+            Fields.InterpolationMode.TrilinearInterpolationMode _ => InterpolateTrilinear(query: query, field: field, resolution: resolution, bounds: bounds, lerp: lerp),
             _ => ResultFactory.Create<T>(error: E.Geometry.InvalidFieldInterpolation.WithContext($"Unsupported interpolation mode: {interpolationMode.GetType().Name}")),
         };
 

--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -377,9 +377,9 @@ internal static class FieldsCompute {
                         Vector3d k1 = InterpolateVectorFieldInternal(vectorField: vectorField, gridPoints: gridPoints, query: current, resolution: resolution, bounds: bounds);
                         Vector3d Interpolate(double coeff, Vector3d k) => InterpolateVectorFieldInternal(vectorField: vectorField, gridPoints: gridPoints, query: current + (stepSize * coeff * k), resolution: resolution, bounds: bounds);
                         Vector3d delta = integrationScheme switch {
-                            Fields.IntegrationScheme.EulerIntegrationScheme => stepSize * k1,
-                            Fields.IntegrationScheme.MidpointIntegrationScheme => stepSize * Interpolate(FieldsConfig.RK2HalfStep, k1),
-                            Fields.IntegrationScheme.RungeKuttaFourthOrderIntegrationScheme => ((Func<Vector3d>)(() => {
+                            Fields.IntegrationScheme.EulerIntegrationScheme _ => stepSize * k1,
+                            Fields.IntegrationScheme.MidpointIntegrationScheme _ => stepSize * Interpolate(FieldsConfig.RK2HalfStep, k1),
+                            Fields.IntegrationScheme.RungeKuttaFourthOrderIntegrationScheme _ => ((Func<Vector3d>)(() => {
                                 Vector3d k2 = Interpolate(FieldsConfig.RK4HalfSteps[0], k1);
                                 Vector3d k3 = Interpolate(FieldsConfig.RK4HalfSteps[1], k2);
                                 Vector3d k4 = Interpolate(FieldsConfig.RK4HalfSteps[2], k3);

--- a/libs/rhino/fields/FieldsCompute.cs
+++ b/libs/rhino/fields/FieldsCompute.cs
@@ -654,9 +654,9 @@ internal static class FieldsCompute {
         Point3d[] grid,
         Fields.VectorComponent component) {
         Func<Vector3d, double>? selector = component switch {
-            Fields.VectorComponent.XComponent => v => v.X,
-            Fields.VectorComponent.YComponent => v => v.Y,
-            Fields.VectorComponent.ZComponent => v => v.Z,
+            Fields.VectorComponent.XComponent _ => v => v.X,
+            Fields.VectorComponent.YComponent _ => v => v.Y,
+            Fields.VectorComponent.ZComponent _ => v => v.Z,
             _ => null,
         };
         return selector is null

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -3,7 +3,7 @@ using Rhino;
 
 namespace Arsenal.Rhino.Fields;
 
-/// <summary>Configuration constants, byte operation codes, and unified dispatch registry for fields operations.</summary>
+/// <summary>Configuration constants for fields operations.</summary>
 [Pure]
 internal static class FieldsConfig {
     internal const string DistanceOperationName = "Fields.DistanceField";

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -6,10 +6,7 @@ namespace Arsenal.Rhino.Fields;
 /// <summary>Configuration constants, byte operation codes, and unified dispatch registry for fields operations.</summary>
 [Pure]
 internal static class FieldsConfig {
-    internal const byte OperationDistance = 0;
-    internal const byte IntegrationRK4 = 2;
-    internal const byte InterpolationNearest = 0;
-    internal const byte InterpolationTrilinear = 1;
+    internal const string DistanceOperationName = "Fields.DistanceField";
 
     internal const int DefaultResolution = 32;
     internal const int MinResolution = 8;
@@ -30,10 +27,6 @@ internal static class FieldsConfig {
     internal const double RK2HalfStep = 0.5;
 
     internal const int FieldRTreeThreshold = 100;
-
-    internal const byte CriticalPointMinimum = 0;
-    internal const byte CriticalPointMaximum = 1;
-    internal const byte CriticalPointSaddle = 2;
 
     internal static readonly (int V1, int V2)[] EdgeVertexPairs = [
         (0, 1),


### PR DESCRIPTION
## Summary
- replace the old FieldSpec struct with a sealed record and add nested algebraic types for interpolation, integration, vector components, and critical point kinds so the public API is strongly typed
- rework FieldsConfig/Core to drop byte dispatch, add a UnifiedOperation-based distance field path, and keep all metadata internal while exposing only the new records
- update the compute layer to consume the new algebraic types for interpolation, streamline integration, scalar-vector composition, and critical-point classification

## Testing
- `dotnet build` *(fails: dotnet is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbdef6590832191e134038b0462e6)