### PR TITLE
Refactor orientation APIs to algebraic architecture

### DIFF
--- a/libs/rhino/orientation/Orient.cs
+++ b/libs/rhino/orientation/Orient.cs
@@ -1,234 +1,148 @@
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
-using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
-using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Orientation;
 
-/// <summary>Polymorphic geometry orientation and canonical alignment.</summary>
+/// <summary>Algebraic public API for geometry orientation, alignment, and diagnostics.</summary>
 public static class Orient {
-    /// <summary>Canonical orientation modes for world plane alignment operations.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly struct Canonical(byte mode) {
-        internal readonly byte Mode = mode;
-        /// <summary>Align bounding box center to world XY plane.</summary>
-        public static readonly Canonical WorldXY = new(1);
-        /// <summary>Align bounding box center to world YZ plane.</summary>
-        public static readonly Canonical WorldYZ = new(2);
-        /// <summary>Align bounding box center to world XZ plane.</summary>
-        public static readonly Canonical WorldXZ = new(3);
-        /// <summary>Translate area centroid to world origin.</summary>
-        public static readonly Canonical AreaCentroid = new(4);
-        /// <summary>Translate volume centroid to world origin.</summary>
-        public static readonly Canonical VolumeCentroid = new(5);
+    /// <summary>Base request for alignment operations.</summary>
+    public abstract record AlignmentRequest;
+
+    public sealed record PlaneAlignment(Plane Target) : AlignmentRequest;
+
+    public sealed record CurveFrameAlignment(Curve Curve, double Parameter) : AlignmentRequest;
+
+    public sealed record SurfaceFrameAlignment(Surface Surface, double U, double V) : AlignmentRequest;
+
+    public sealed record WorldXYAlignment() : AlignmentRequest;
+
+    public sealed record WorldYZAlignment() : AlignmentRequest;
+
+    public sealed record WorldXZAlignment() : AlignmentRequest;
+
+    public sealed record BoundingBoxOriginAlignment() : AlignmentRequest;
+
+    public sealed record VolumeOriginAlignment() : AlignmentRequest;
+
+    public sealed record BoundingBoxPointAlignment(Point3d Target) : AlignmentRequest;
+
+    public sealed record MassPointAlignment(Point3d Target) : AlignmentRequest;
+
+    public sealed record VectorAlignment(Vector3d Source, Vector3d Target, AnchorSpecification Anchor) : AlignmentRequest;
+
+    public sealed record BestFitAlignment() : AlignmentRequest;
+
+    public sealed record MirrorAlignment(Plane Plane) : AlignmentRequest;
+
+    public sealed record FlipDirectionAlignment() : AlignmentRequest;
+
+    /// <summary>Anchor specification for vector alignment operations.</summary>
+    public abstract record AnchorSpecification {
+        private protected AnchorSpecification() { }
+
+        public sealed record BoundingBoxAnchor : AnchorSpecification;
+
+        public sealed record CustomAnchor(Point3d Anchor) : AnchorSpecification;
     }
 
-    /// <summary>Orientation specification for plane, point, vector, or curve/surface frame targets.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct OrientSpec {
-        /// <summary>Target plane for plane-to-plane alignment.</summary>
-        public Plane? TargetPlane { get; init; }
-        /// <summary>Target point for translation operations.</summary>
-        public Point3d? TargetPoint { get; init; }
-        /// <summary>Target vector for rotation alignment.</summary>
-        public Vector3d? TargetVector { get; init; }
-        /// <summary>Target curve for frame-based orientation.</summary>
-        public Curve? TargetCurve { get; init; }
-        /// <summary>Target surface for frame-based orientation.</summary>
-        public Surface? TargetSurface { get; init; }
-        /// <summary>Curve parameter for frame evaluation at specific location.</summary>
-        public double CurveParameter { get; init; }
-        /// <summary>Surface UV coordinates for frame evaluation.</summary>
-        public (double u, double v) SurfaceUV { get; init; }
+    public sealed record OrientationOptimizationRequest(OptimizationCriterion Criterion);
 
-        /// <summary>Create plane-to-plane orientation specification.</summary>
-        public static OrientSpec Plane(Plane p) => new() { TargetPlane = p };
-        /// <summary>Create point-to-point translation specification.</summary>
-        public static OrientSpec Point(Point3d p) => new() { TargetPoint = p };
-        /// <summary>Create vector-to-vector rotation specification.</summary>
-        public static OrientSpec Vector(Vector3d v) => new() { TargetVector = v };
-        /// <summary>Create curve frame orientation at parameter t.</summary>
-        public static OrientSpec Curve(Curve c, double t) => new() { TargetCurve = c, CurveParameter = t };
-        /// <summary>Create surface frame orientation at UV coordinates.</summary>
-        public static OrientSpec Surface(Surface s, double u, double v) => new() { TargetSurface = s, SurfaceUV = (u, v) };
+    public abstract record OptimizationCriterion {
+        private protected OptimizationCriterion() { }
+
+        internal abstract byte Code { get; }
     }
 
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> ToPlane<T>(T geometry, Plane target, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                (OrientCore.PlaneExtractors.TryGetValue(item.GetType(), out Func<object, Result<Plane>>? extractor) ? extractor(item)
-                    : OrientCore.PlaneExtractors.FirstOrDefault(kv => kv.Key.IsInstanceOfType(item)).Value?.Invoke(item)
-                    ?? ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(item.GetType().Name)))
-                .Bind(src => !target.IsValid
-                    ? ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationPlane)
-                    : OrientCore.ApplyTransform(item, Transform.PlaneToPlane(src, target)))),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = OrientConfig.ValidationModes.GetValueOrDefault(typeof(T), V.Standard),
-            }).Map(r => r[0]);
+    public sealed record CompactnessCriterion() : OptimizationCriterion {
+        internal override byte Code => 1;
+    }
+
+    public sealed record CentroidCriterion() : OptimizationCriterion {
+        internal override byte Code => 2;
+    }
+
+    public sealed record FlatnessCriterion() : OptimizationCriterion {
+        internal override byte Code => 3;
+    }
+
+    public sealed record CanonicalCriterion() : OptimizationCriterion {
+        internal override byte Code => 4;
+    }
+
+    public sealed record OrientationOptimizationResult(
+        Transform OptimalTransform,
+        double Score,
+        IReadOnlyList<OptimizationCriterion> CriteriaMet);
+
+    public sealed record RelativeOrientationRequest(GeometryBase Primary, GeometryBase Secondary);
+
+    public abstract record SymmetryClassification {
+        private protected SymmetryClassification() { }
+
+        public sealed record None : SymmetryClassification;
+
+        public sealed record Mirror : SymmetryClassification;
+
+        public sealed record Rotational : SymmetryClassification;
+    }
+
+    public abstract record OrientationRelationship {
+        private protected OrientationRelationship() { }
+
+        public sealed record Aligned : OrientationRelationship;
+
+        public sealed record Orthogonal : OrientationRelationship;
+
+        public sealed record Skew : OrientationRelationship;
+    }
+
+    public sealed record RelativeOrientationResult(
+        Transform RelativeTransform,
+        double Twist,
+        double Tilt,
+        SymmetryClassification Symmetry,
+        OrientationRelationship Relationship);
+
+    public sealed record PatternDetectionRequest(GeometryBase[] Geometries);
+
+    public abstract record PatternClassification {
+        private protected PatternClassification() { }
+
+        public sealed record Linear : PatternClassification;
+
+        public sealed record Radial : PatternClassification;
+    }
+
+    public sealed record PatternDetectionResult(
+        PatternClassification Classification,
+        Transform[] IdealTransforms,
+        int[] Anomalies,
+        double Deviation);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> ToCanonical<T>(T geometry, Canonical mode, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                ((mode.Mode, item.GetBoundingBox(accurate: true)) switch {
-                    (_, BoundingBox box) when !box.IsValid && mode.Mode != 5 => ResultFactory.Create<Transform>(error: E.Validation.BoundingBoxInvalid),
-                    (1, BoundingBox box) => ResultFactory.Create(value: Transform.PlaneToPlane(new Plane(box.Center, Vector3d.XAxis, Vector3d.YAxis), Plane.WorldXY)),
-                    (2, BoundingBox box) => ResultFactory.Create(value: Transform.PlaneToPlane(new Plane(box.Center, Vector3d.YAxis, Vector3d.ZAxis), Plane.WorldYZ)),
-                    (3, BoundingBox box) => ResultFactory.Create(value: Transform.PlaneToPlane(new Plane(box.Center, Vector3d.XAxis, Vector3d.ZAxis), new Plane(Point3d.Origin, Vector3d.XAxis, Vector3d.ZAxis))),
-                    (4, BoundingBox box) => ResultFactory.Create(value: Transform.Translation(Point3d.Origin - box.Center)),
-                    (5, _) => OrientCore.ExtractCentroid(item, useMassProperties: true).Map(c => Transform.Translation(Point3d.Origin - c)),
-                    _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationMode),
-                }).Bind(xform => OrientCore.ApplyTransform(item, xform))),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = mode.Mode is (>= 1 and <= 4) ? V.Standard | V.BoundingBox : mode.Mode is 5 ? V.Standard | V.MassProperties : V.Standard,
-            }).Map(r => r[0]);
+    public static Result<T> Apply<T>(T geometry, AlignmentRequest request, IGeometryContext context) where T : GeometryBase =>
+        OrientCore.Align(geometry, request, context);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> ToPoint<T>(T geometry, Point3d target, bool useMass, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                OrientCore.ExtractCentroid(item, useMassProperties: useMass)
-                    .Map(c => Transform.Translation(target - c))
-                    .Bind(x => OrientCore.ApplyTransform(item, x))),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = useMass ? V.Standard | V.MassProperties : V.Standard | V.BoundingBox,
-            }).Map(r => r[0]);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> ToVector<T>(T geometry, Vector3d target, Vector3d? source, Point3d? anchor, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                ((item.GetBoundingBox(accurate: true), source ?? Vector3d.ZAxis, target) switch {
-                    (BoundingBox box, Vector3d s, Vector3d t) when box.IsValid && s.Length > RhinoMath.ZeroTolerance && t.Length > RhinoMath.ZeroTolerance =>
-                        ((Func<Result<Transform>>)(() => {
-                            Vector3d su = new(s);
-                            Vector3d tu = new(t);
-                            // The outer 'when' clause guarantees Unitize will succeed.
-                            _ = su.Unitize();
-                            _ = tu.Unitize();
-                            Point3d pt = anchor ?? box.Center;
-
-                            return Vector3d.CrossProduct(su, tu).Length < RhinoMath.SqrtEpsilon
-                                ? Math.Abs((su * tu) - 1.0) < RhinoMath.SqrtEpsilon
-                                    ? ResultFactory.Create(value: Transform.Identity)
-                                    : Math.Abs((su * tu) + 1.0) < RhinoMath.SqrtEpsilon
-                                        ? ((Func<Result<Transform>>)(() => {
-                                            Vector3d axisCandidate = Math.Abs(su * Vector3d.XAxis) < 0.95 ? Vector3d.CrossProduct(su, Vector3d.XAxis) : Vector3d.CrossProduct(su, Vector3d.YAxis);
-                                            bool normalized = axisCandidate.Unitize();
-                                            return normalized
-                                                ? ResultFactory.Create(value: Transform.Rotation(Math.PI, axisCandidate, pt))
-                                                : ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors);
-                                        }))()
-                                        : ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors)
-                                : ResultFactory.Create(value: Transform.Rotation(su, tu, pt));
-                        }))(),
-                    _ => ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors),
-                }).Bind(xform => OrientCore.ApplyTransform(item, xform))),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = V.Standard,
-            }).Map(r => r[0]);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> ToBestFit<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                OrientCore.ExtractBestFitPlane(item)
-                    .Bind(plane => OrientCore.ApplyTransform(item, Transform.PlaneToPlane(plane, Plane.WorldXY)))),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = V.Standard,
-            }).Map(r => r[0]);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Mirror<T>(T geometry, Plane plane, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                plane.IsValid
-                    ? OrientCore.ApplyTransform(item, Transform.Mirror(plane))
-                    : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationPlane)),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = OrientConfig.ValidationModes.GetValueOrDefault(typeof(T), V.Standard),
-            }).Map(r => r[0]);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> FlipDirection<T>(T geometry, IGeometryContext context) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            input: geometry,
-            operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                item.Duplicate() switch {
-                    Curve c when c.Reverse() => ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)c,]),
-                    Brep b => ((Func<Result<IReadOnlyList<T>>>)(() => { b.Flip(); return ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)b,]); }))(),
-                    Extrusion e => e.ToBrep() switch {
-                        Brep br => ((Func<Result<IReadOnlyList<T>>>)(() => { br.Flip(); return ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)br,]); }))(),
-                        _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed),
-                    },
-                    Mesh m => ((Func<Result<IReadOnlyList<T>>>)(() => { m.Flip(vertexNormals: true, faceNormals: true, faceOrientation: true); return ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)m,]); }))(),
-                    null => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed),
-                    _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.UnsupportedOrientationType.WithContext(item.GetType().Name)),
-                }),
-            config: new OperationConfig<T, T> {
-                Context = context,
-                ValidationMode = OrientConfig.ValidationModes.GetValueOrDefault(typeof(T), V.Standard),
-            }).Map(r => r[0]);
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Apply<T>(T geometry, OrientSpec spec, IGeometryContext context) where T : GeometryBase =>
-        (spec.TargetPlane, spec.TargetPoint, spec.TargetVector, spec.TargetCurve, spec.TargetSurface) switch {
-            (null, null, null, null, null) => ResultFactory.Create<T>(error: E.Geometry.InvalidOrientationMode),
-            (Plane p, null, null, null, null) when p != default => ToPlane(geometry, p, context),
-            (null, Point3d pt, null, null, null) when pt != default => ToPoint(geometry, pt, useMass: false, context),
-            (null, null, Vector3d v, null, null) when v != default => ToVector(geometry, v, source: null, anchor: null, context),
-            (null, null, null, Curve c, null) => c.FrameAt(spec.CurveParameter, out Plane f) && f.IsValid
-                ? ToPlane(geometry, f, context)
-                : ResultFactory.Create<T>(error: E.Geometry.InvalidCurveParameter),
-            (null, null, null, null, Surface s) => s.FrameAt(spec.SurfaceUV.u, spec.SurfaceUV.v, out Plane f) && f.IsValid
-                ? ToPlane(geometry, f, context)
-                : ResultFactory.Create<T>(error: E.Geometry.InvalidSurfaceUV),
-            _ => ResultFactory.Create<T>(error: E.Geometry.InvalidOrientationMode),
-        };
-
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Transform OptimalTransform, double Score, byte[] CriteriaMet)> OptimizeOrientation(
+    public static Result<OrientationOptimizationResult> Optimize(
         Brep brep,
-        byte criteria,
+        OrientationOptimizationRequest request,
         IGeometryContext context) =>
-        UnifiedOperation.Apply(
-            input: brep,
-            operation: (Func<Brep, Result<IReadOnlyList<(Transform, double, byte[])>>>)(item =>
-                OrientCompute.OptimizeOrientation(item, criteria, context.AbsoluteTolerance, context)
-                    .Map(r => (IReadOnlyList<(Transform, double, byte[])>)[r,])),
-            config: new OperationConfig<Brep, (Transform, double, byte[])> {
-                Context = context,
-                ValidationMode = V.Standard | V.Topology,
-            }).Map(r => r[0]);
+        OrientCore.Optimize(brep, request, context);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Transform RelativeTransform, double Twist, double Tilt, byte SymmetryType, byte Relationship)> ComputeRelativeOrientation(
-        GeometryBase geometryA,
-        GeometryBase geometryB,
+    public static Result<RelativeOrientationResult> Relative(
+        RelativeOrientationRequest request,
         IGeometryContext context) =>
-        OrientCompute.ComputeRelative(geometryA, geometryB, context);
+        OrientCore.Relative(request, context);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(byte PatternType, Transform[] IdealTransforms, int[] Anomalies, double Deviation)> DetectAndAlign(
-        GeometryBase[] geometries,
+    public static Result<PatternDetectionResult> Detect(
+        PatternDetectionRequest request,
         IGeometryContext context) =>
-        OrientCompute.DetectPattern(geometries, context);
+        OrientCore.Detect(request, context);
 }

--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -197,13 +197,12 @@ internal static class OrientCompute {
             return metadata.Extractor(geometry);
         }
 
-        foreach (KeyValuePair<Type, OrientConfig.PlaneExtractorMetadata> entry in OrientConfig.PlaneExtractors) {
-            if (entry.Key.IsAssignableFrom(runtimeType)) {
-                return entry.Value.Extractor(geometry);
-            }
-        }
+        Result<Plane>? result = OrientConfig.PlaneExtractors
+            .Where(entry => entry.Key.IsAssignableFrom(runtimeType))
+            .Select(entry => entry.Value.Extractor(geometry))
+            .FirstOrDefault();
 
-        return ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name));
+        return result ?? ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/libs/rhino/orientation/OrientCompute.cs
+++ b/libs/rhino/orientation/OrientCompute.cs
@@ -1,8 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 
@@ -11,172 +14,469 @@ namespace Arsenal.Rhino.Orientation;
 /// <summary>Optimization, relative orientation, and pattern alignment algorithms.</summary>
 [Pure]
 internal static class OrientCompute {
-    /// <summary>Optimize orientation via criteria: 1=compact, 2=centroid, 3=flatness, 4=canonical.</summary>
-    internal static Result<(Transform OptimalTransform, double Score, byte[] CriteriaMet)> OptimizeOrientation(
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignToPlane<T>(T geometry, Plane target) where T : GeometryBase =>
+        !target.IsValid
+            ? ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationPlane)
+            : ExtractPlane(geometry)
+                .Map(source => Transform.PlaneToPlane(source, target))
+                .Bind(xform => ApplyTransform(geometry, xform));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignToCurveFrame<T>(T geometry, Curve curve, double parameter) where T : GeometryBase =>
+        curve is null
+            ? ResultFactory.Create<IReadOnlyList<T>>(error: E.Validation.GeometryInvalid.WithContext("Curve cannot be null"))
+            : curve.FrameAt(parameter, out Plane frame) && frame.IsValid
+                ? AlignToPlane(geometry, frame)
+                : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidCurveParameter);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignToSurfaceFrame<T>(T geometry, Surface surface, double u, double v) where T : GeometryBase =>
+        surface is null
+            ? ResultFactory.Create<IReadOnlyList<T>>(error: E.Validation.GeometryInvalid.WithContext("Surface cannot be null"))
+            : surface.FrameAt(u, v, out Plane frame) && frame.IsValid
+                ? AlignToPlane(geometry, frame)
+                : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidSurfaceUV);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignToWorldPlane<T>(T geometry, Plane targetPlane, Vector3d sourceXAxis, Vector3d sourceYAxis) where T : GeometryBase =>
+        geometry.GetBoundingBox(accurate: true) is BoundingBox box && box.IsValid
+            ? ApplyTransform(geometry, Transform.PlaneToPlane(new Plane(box.Center, sourceXAxis, sourceYAxis), targetPlane))
+            : ResultFactory.Create<IReadOnlyList<T>>(error: E.Validation.BoundingBoxInvalid);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignBoundingBoxToOrigin<T>(T geometry) where T : GeometryBase =>
+        geometry.GetBoundingBox(accurate: true) is BoundingBox box && box.IsValid
+            ? ApplyTransform(geometry, Transform.Translation(Point3d.Origin - box.Center))
+            : ResultFactory.Create<IReadOnlyList<T>>(error: E.Validation.BoundingBoxInvalid);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignCentroidToOrigin<T>(T geometry) where T : GeometryBase =>
+        ExtractCentroid(geometry, useMassProperties: true)
+            .Map(center => Transform.Translation(Point3d.Origin - center))
+            .Bind(xform => ApplyTransform(geometry, xform));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignBoundingBoxToPoint<T>(T geometry, Point3d target) where T : GeometryBase =>
+        ExtractCentroid(geometry, useMassProperties: false)
+            .Map(center => Transform.Translation(target - center))
+            .Bind(xform => ApplyTransform(geometry, xform));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignCentroidToPoint<T>(T geometry, Point3d target) where T : GeometryBase =>
+        ExtractCentroid(geometry, useMassProperties: true)
+            .Map(center => Transform.Translation(target - center))
+            .Bind(xform => ApplyTransform(geometry, xform));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignVector<T>(T geometry, Vector3d source, Vector3d target, Orient.AnchorSpecification anchor) where T : GeometryBase =>
+        (source.Length > RhinoMath.ZeroTolerance, target.Length > RhinoMath.ZeroTolerance) switch {
+            (true, true) => ResolveAnchor(geometry, anchor)
+                .Bind(anchorPoint => BuildVectorRotation(source, target, anchorPoint))
+                .Bind(xform => ApplyTransform(geometry, xform)),
+            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationVectors),
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> AlignBestFit<T>(T geometry) where T : GeometryBase =>
+        ExtractBestFitPlane(geometry)
+            .Bind(plane => ApplyTransform(geometry, Transform.PlaneToPlane(plane, Plane.WorldXY)));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> MirrorGeometry<T>(T geometry, Plane plane) where T : GeometryBase =>
+        plane.IsValid
+            ? ApplyTransform(geometry, Transform.Mirror(plane))
+            : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.InvalidOrientationPlane);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<IReadOnlyList<T>> FlipGeometry<T>(T geometry) where T : GeometryBase =>
+        geometry.Duplicate() switch {
+            Curve c when c.Reverse() => ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)c,]),
+            Brep b => ((Func<Result<IReadOnlyList<T>>>)(() => { b.Flip(); return ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)b,]); }))(),
+            Extrusion e => e.ToBrep() is Brep br
+                ? ((Func<Result<IReadOnlyList<T>>>)(() => { br.Flip(); return ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)br,]); }))()
+                : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed),
+            Mesh m => ((Func<Result<IReadOnlyList<T>>>)(() => { m.Flip(vertexNormals: true, faceNormals: true, faceOrientation: true); return ResultFactory.Create(value: (IReadOnlyList<T>)[(T)(GeometryBase)m,]); }))(),
+            null => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed),
+            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
+        };
+
+    internal static Result<Orient.OrientationOptimizationResult> OptimizeOrientation(
         Brep brep,
-        byte criteria,
-        double tolerance,
+        Orient.OptimizationCriterion criterion,
         IGeometryContext context) =>
         ResultFactory.Create(value: brep)
             .Validate(args: [context, V.Standard | V.Topology | V.BoundingBox | V.MassProperties,])
-            .Bind(validBrep => criteria is < 1 or > 4
-                ? ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.InvalidOrientationMode.WithContext($"Criteria must be 1-4, got {criteria}"))
-                : tolerance <= 0.0
-                    ? ResultFactory.Create<(Transform, double, byte[])>(error: E.Validation.ToleranceAbsoluteInvalid)
+            .Bind(validBrep => criterion.Code is < 1 or > 4
+                ? ResultFactory.Create<Orient.OrientationOptimizationResult>(error: E.Geometry.InvalidOrientationMode.WithContext($"Criterion code {criterion.Code} is unsupported"))
+                : context.AbsoluteTolerance <= 0.0
+                    ? ResultFactory.Create<Orient.OrientationOptimizationResult>(error: E.Validation.ToleranceAbsoluteInvalid)
                     : validBrep.GetBoundingBox(accurate: true) is BoundingBox box && box.IsValid
-                        ? ((Func<Result<(Transform, double, byte[])>>)(() => {
-                            Result<Point3d> centroidResult = OrientCore.ExtractCentroid(validBrep, useMassProperties: true);
-                            return (criteria, centroidResult.IsSuccess) switch {
-                                (2, false) => ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.CentroidExtractionFailed),
-                                _ => ((Func<Result<(Transform, double, byte[])>>)(() => {
-                                    Vector3d diag1 = new(1, 1, 0);
-                                    Vector3d diag2 = new(1, 0, 1);
-                                    Vector3d diag3 = new(0, 1, 1);
-                                    _ = diag1.Unitize();
-                                    _ = diag2.Unitize();
-                                    _ = diag3.Unitize();
-                                    Plane[] testPlanes = [
-                                        new Plane(box.Center, Vector3d.XAxis, Vector3d.YAxis),
-                                        new Plane(box.Center, Vector3d.YAxis, Vector3d.ZAxis),
-                                        new Plane(box.Center, Vector3d.XAxis, Vector3d.ZAxis),
-                                        new Plane(box.Center, diag1, Vector3d.ZAxis),
-                                        new Plane(box.Center, diag2, Vector3d.YAxis),
-                                        new Plane(box.Center, diag3, Vector3d.XAxis),
-                                    ];
+                        ? EvaluateOrientationCriteria(validBrep, criterion, box, context)
+                        : ResultFactory.Create<Orient.OrientationOptimizationResult>(error: E.Geometry.TransformFailed.WithContext("Invalid bounding box")));
 
-                                    (Transform, double, byte[])[] results = [.. testPlanes.Select(plane => {
-                                        Transform xf = Transform.PlaneToPlane(plane, Plane.WorldXY);
-                                        using Brep test = (Brep)validBrep.Duplicate();
-                                        return !test.Transform(xf) ? (Transform.Identity, 0.0, Array.Empty<byte>())
-                                            : test.GetBoundingBox(accurate: true) is BoundingBox testBox && testBox.IsValid
-                                                ? (xf, criteria switch {
-                                                    1 => testBox.Diagonal.Length > tolerance ? 1.0 / testBox.Diagonal.Length : 0.0,
-                                                    2 => centroidResult.IsSuccess && testBox.Diagonal.Length > tolerance
-                                                        ? ((Func<double>)(() => {
-                                                            Point3d centroid = centroidResult.Value;
-                                                            centroid.Transform(xf);
-                                                            return Math.Max(0.0, 1.0 - (Math.Abs(centroid.Z) / testBox.Diagonal.Length));
-                                                        }))()
-                                                        : 0.0,
-                                                    3 => ((Math.Abs(testBox.Max.X - testBox.Min.X) <= tolerance ? 1 : 0)
-                                                        + (Math.Abs(testBox.Max.Y - testBox.Min.Y) <= tolerance ? 1 : 0)
-                                                        + (Math.Abs(testBox.Max.Z - testBox.Min.Z) <= tolerance ? 1 : 0)) switch {
-                                                            0 => 0.0,
-                                                            int degeneracy and >= 1 and <= 3 => degeneracy / (double)OrientConfig.MaxDegeneracyDimensions,
-                                                            _ => 0.0,
-                                                        },
-                                                    4 => (testBox.Min.Z >= -tolerance ? OrientConfig.OrientationScoreWeight1 : 0.0) + (Math.Abs(testBox.Center.X) < tolerance && Math.Abs(testBox.Center.Y) < tolerance ? OrientConfig.OrientationScoreWeight2 : 0.0) + ((testBox.Max.Z - testBox.Min.Z) < (testBox.Diagonal.Length * OrientConfig.LowProfileAspectRatio) ? OrientConfig.OrientationScoreWeight3 : 0.0),
-                                                    _ => 0.0,
-                                                }, criteria is >= 1 and <= 4 ? [criteria,] : Array.Empty<byte>())
-                                                : (Transform.Identity, 0.0, Array.Empty<byte>());
-                                    }),
-                                    ];
-
-                                    return results.MaxBy(r => r.Item2) is (Transform best, double bestScore, byte[] met) && bestScore > 0
-                                        ? ResultFactory.Create(value: (best, bestScore, met))
-                                        : ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.TransformFailed.WithContext("No valid orientation found"));
-                                }))(),
-                            };
-                        }))()
-                        : ResultFactory.Create<(Transform, double, byte[])>(error: E.Geometry.TransformFailed.WithContext("Invalid bounding box")));
-
-    /// <summary>Compute relative orientation with symmetry and relationship classification.</summary>
-    internal static Result<(Transform RelativeTransform, double Twist, double Tilt, byte SymmetryType, byte Relationship)> ComputeRelative(
+    internal static Result<Orient.RelativeOrientationResult> ComputeRelative(
         GeometryBase geometryA,
         GeometryBase geometryB,
         IGeometryContext context) {
-        double symmetryTolerance = context.AbsoluteTolerance;
-        double angleTolerance = context.AngleToleranceRadians;
+        Result<Plane> planeA = ExtractPlane(geometryA);
+        if (!planeA.IsSuccess) {
+            return ResultFactory.Create<Orient.RelativeOrientationResult>(error: planeA.Errors.Length > 0 ? planeA.Errors[0] : E.Geometry.OrientationFailed);
+        }
 
-        return (OrientCore.PlaneExtractors.TryGetValue(geometryA.GetType(), out Func<object, Result<Plane>>? extA),
-            OrientCore.PlaneExtractors.TryGetValue(geometryB.GetType(), out Func<object, Result<Plane>>? extB))
-                switch {
-                    (true, true) when extA!(geometryA) is Result<Plane> ra && extB!(geometryB) is Result<Plane> rb => (ra, rb) switch {
-                        (Result<Plane> { IsSuccess: true }, Result<Plane> { IsSuccess: true }) => (ra.Value, rb.Value) is (Plane pa, Plane pb)
-                            ? Transform.PlaneToPlane(pa, pb) is Transform xform && Vector3d.VectorAngle(pa.XAxis, pb.XAxis) is double twist && Vector3d.VectorAngle(pa.ZAxis, pb.ZAxis) is double tilt
-                                ? ((geometryA, geometryB) switch {
-                                    (Brep ba, Brep bb) when ba.Vertices.Count == bb.Vertices.Count => (pb.Origin - pa.Origin).Length > RhinoMath.ZeroTolerance
-                                        ? new Plane(pa.Origin + ((pb.Origin - pa.Origin) * 0.5), pb.Origin - pa.Origin) is Plane mirror && mirror.IsValid
-                                            && ba.Vertices.Select(va => {
-                                                Point3d reflected = va.Location;
-                                                reflected.Transform(Transform.Mirror(mirrorPlane: mirror));
-                                                return reflected;
-                                            }).ToArray() is Point3d[] reflectedA
-                                            && reflectedA.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < symmetryTolerance))
-                                            && bb.Vertices.All(vb => reflectedA.Any(ra => ra.DistanceTo(vb.Location) < symmetryTolerance))
-                                                ? (byte)1 : (byte)0
-                                        : new Plane(pa.Origin, pa.ZAxis) is Plane mirror2 && mirror2.IsValid
-                                            && ba.Vertices.Select(va => {
-                                                Point3d reflected = va.Location;
-                                                reflected.Transform(Transform.Mirror(mirrorPlane: mirror2));
-                                                return reflected;
-                                            }).ToArray() is Point3d[] reflectedA2
-                                            && reflectedA2.All(ra => bb.Vertices.Any(vb => ra.DistanceTo(vb.Location) < symmetryTolerance))
-                                            && bb.Vertices.All(vb => reflectedA2.Any(ra => ra.DistanceTo(vb.Location) < symmetryTolerance))
-                                                ? (byte)1 : (byte)0,
-                                    (Curve ca, Curve cb) when ca.SpanCount == cb.SpanCount && pa.ZAxis.IsValid && pa.ZAxis.Length > symmetryTolerance => ((Func<byte>)(() => {
-                                        Point3d[] samplesA = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => ca.PointAt(ca.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
-                                        Point3d[] samplesB = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => cb.PointAt(cb.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
-                                        int[] testIndices = [0, samplesA.Length / 2, samplesA.Length - 1,];
-                                        double[] candidateAngles = [.. testIndices.Select(idx => {
-                                            Vector3d vecA = samplesA[idx] - pa.Origin;
-                                            Vector3d vecB = samplesB[idx] - pa.Origin;
-                                            Vector3d projA = vecA - ((vecA * pa.ZAxis) * pa.ZAxis);
-                                            Vector3d projB = vecB - ((vecB * pa.ZAxis) * pa.ZAxis);
-                                            return projA.Length < symmetryTolerance || projB.Length < symmetryTolerance
-                                                ? double.NaN
-                                                : Vector3d.CrossProduct(projA, projB) * pa.ZAxis < 0
-                                                    ? -Vector3d.VectorAngle(projA, projB)
-                                                    : Vector3d.VectorAngle(projA, projB);
-                                        }).Where(a => !double.IsNaN(a)),
-                                        ];
-                                        return candidateAngles.Length == 0
-                                            ? (byte)0
-                                            : candidateAngles.All(a => Math.Abs(a - candidateAngles[0]) < context.AngleToleranceRadians)
-                                                && Transform.Rotation(candidateAngles[0], pa.ZAxis, pa.Origin) is Transform rotation
-                                                && samplesA.Zip(samplesB, (ptA, ptB) => {
-                                                    Point3d rotated = ptA;
-                                                    rotated.Transform(rotation);
-                                                    return rotated.DistanceTo(ptB);
-                                                }).All(dist => dist < symmetryTolerance)
-                                                    ? (byte)2 : (byte)0;
-                                    }))(),
-                                    _ => (byte)0,
-                                }, Math.Abs(Vector3d.Multiply(pa.ZAxis, pb.ZAxis)) switch {
-                                    double dot when Math.Abs(dot - 1.0) < 1.0 - Math.Cos(angleTolerance) => (byte)1,
-                                    double dot when Math.Abs(dot) < Math.Sin(angleTolerance) => (byte)2,
-                                    _ => (byte)3,
-                                }) is (byte symmetry, byte relationship)
-                                    ? ResultFactory.Create(value: (xform, twist, tilt, symmetry, relationship))
-                                    : ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed)
-                                : ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed)
-                            : ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed),
-                        _ => ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.OrientationFailed),
-                    },
-                    _ => ResultFactory.Create<(Transform, double, double, byte, byte)>(error: E.Geometry.UnsupportedOrientationType),
-                };
+        Result<Plane> planeB = ExtractPlane(geometryB);
+        if (!planeB.IsSuccess) {
+            return ResultFactory.Create<Orient.RelativeOrientationResult>(error: planeB.Errors.Length > 0 ? planeB.Errors[0] : E.Geometry.OrientationFailed);
+        }
+
+        Plane pa = planeA.Value;
+        Plane pb = planeB.Value;
+        Transform xform = Transform.PlaneToPlane(pa, pb);
+        double twist = Vector3d.VectorAngle(pa.XAxis, pb.XAxis);
+        double tilt = Vector3d.VectorAngle(pa.ZAxis, pb.ZAxis);
+        byte symmetry = ClassifySymmetry(geometryA, geometryB, pa, pb, context.AbsoluteTolerance, context);
+        byte relationship = ClassifyRelationship(pa, pb, context.AngleToleranceRadians);
+
+        return double.IsNaN(twist) || double.IsNaN(tilt)
+            ? ResultFactory.Create<Orient.RelativeOrientationResult>(error: E.Geometry.OrientationFailed)
+            : ResultFactory.Create(value: new Orient.RelativeOrientationResult(
+                RelativeTransform: xform,
+                Twist: twist,
+                Tilt: tilt,
+                Symmetry: CreateSymmetry(symmetry),
+                Relationship: CreateRelationship(relationship)));
     }
 
-    /// <summary>Detect linear or radial patterns with anomaly identification.</summary>
-    internal static Result<(byte PatternType, Transform[] IdealTransforms, int[] Anomalies, double Deviation)> DetectPattern(
+    internal static Result<Orient.PatternDetectionResult> DetectPattern(
         GeometryBase[] geometries,
         IGeometryContext context) =>
         ResultFactory.Create(value: geometries)
             .Ensure(g => g.All(item => item?.IsValid == true), error: E.Validation.GeometryInvalid)
-                .Bind(validGeometries => validGeometries.Length >= OrientConfig.PatternMinInstances
-                    ? ((Func<Result<(byte, Transform[], int[], double)>>)(() => {
-                        Result<Point3d>[] centroidResults = [.. validGeometries.Select(g => OrientCore.ExtractCentroid(g, useMassProperties: false)),];
-                        return centroidResults.All(r => r.IsSuccess)
-                            ? centroidResults.Select(r => r.Value).ToArray() is Point3d[] centroids && centroids.Length >= 3 && centroids.Skip(1).Zip(centroids, (c2, c1) => c2 - c1).ToArray() is Vector3d[] deltas && deltas.Average(v => v.Length) is double avgLen && avgLen > context.AbsoluteTolerance
-                                ? (deltas[0].Length >= context.AbsoluteTolerance
-                                    && deltas.Skip(1).All(v => Math.Abs(v.Length - avgLen) / avgLen < context.AbsoluteTolerance
-                                        && Vector3d.VectorAngle(deltas[0], v) <= context.AngleToleranceRadians))
-                                    ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (0, [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Translation(deltas[0] * i)),], [.. deltas.Select((v, i) => (v, i)).Where(pair => Math.Abs(pair.v.Length - avgLen) / avgLen >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.i),], deltas.Sum(v => Math.Abs(v.Length - avgLen)) / centroids.Length))
-                                    : new Point3d(centroids.Average(p => p.X), centroids.Average(p => p.Y), centroids.Average(p => p.Z)) is Point3d center && centroids.Select(p => p.DistanceTo(center)).ToArray() is double[] radii && radii.Average() is double avgRadius && avgRadius > context.AbsoluteTolerance && radii.All(r => Math.Abs(r - avgRadius) / avgRadius < context.AbsoluteTolerance)
-                                        ? ResultFactory.Create<(byte, Transform[], int[], double)>(value: (1, [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Rotation(RhinoMath.TwoPI * i / centroids.Length, Vector3d.ZAxis, center)),], [.. radii.Select((r, i) => (r, i)).Where(pair => Math.Abs(pair.r - avgRadius) / avgRadius >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.i),], radii.Sum(r => Math.Abs(r - avgRadius)) / centroids.Length))
-                                        : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern too irregular"))
-                                : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext("Insufficient valid centroids"))
-                            : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.PatternDetectionFailed.WithContext($"Centroid extraction failed for {centroidResults.Count(r => !r.IsSuccess)} geometries"));
-                    }))()
-                    : ResultFactory.Create<(byte, Transform[], int[], double)>(error: E.Geometry.InsufficientParameters.WithContext($"Pattern detection requires at least {OrientConfig.PatternMinInstances} geometries, got {validGeometries.Length}")));
+            .Bind(validGeometries => validGeometries.Length >= OrientConfig.PatternMinInstances
+                ? IdentifyPattern(validGeometries, context)
+                : ResultFactory.Create<Orient.PatternDetectionResult>(error: E.Geometry.InsufficientParameters.WithContext($"Pattern detection requires at least {OrientConfig.PatternMinInstances} geometries, got {validGeometries.Length}")));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<IReadOnlyList<T>> ApplyTransform<T>(T geometry, Transform transform) where T : GeometryBase =>
+        (T)geometry.Duplicate() switch {
+            T dup when dup.Transform(transform) => ResultFactory.Create(value: (IReadOnlyList<T>)[dup,]),
+            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.TransformFailed),
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Point3d> ExtractCentroid(GeometryBase geometry, bool useMassProperties) =>
+        (geometry, useMassProperties) switch {
+            (Brep brep, true) when brep.IsSolid => ((Func<Result<Point3d>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(brep); return vmp is not null ? ResultFactory.Create(value: vmp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (Brep brep, true) when brep.SolidOrientation != BrepSolidOrientation.None => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(brep); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (Extrusion ext, true) when ext.IsSolid => ((Func<Result<Point3d>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(ext); return vmp is not null ? ResultFactory.Create(value: vmp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (Extrusion ext, true) when ext.IsClosed(0) && ext.IsClosed(1) => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(ext); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (Mesh mesh, true) when mesh.IsClosed => ((Func<Result<Point3d>>)(() => { using VolumeMassProperties? vmp = VolumeMassProperties.Compute(mesh); return vmp is not null ? ResultFactory.Create(value: vmp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (Mesh mesh, true) => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(mesh); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (Curve curve, true) => ((Func<Result<Point3d>>)(() => { using AreaMassProperties? amp = AreaMassProperties.Compute(curve); return amp is not null ? ResultFactory.Create(value: amp.Centroid) : ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed); }))(),
+            (GeometryBase g, false) => g.GetBoundingBox(accurate: true) switch {
+                BoundingBox b when b.IsValid => ResultFactory.Create(value: b.Center),
+                _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+            },
+            _ => ResultFactory.Create<Point3d>(error: E.Geometry.CentroidExtractionFailed),
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Point3d> ResolveAnchor(GeometryBase geometry, Orient.AnchorSpecification anchor) =>
+        anchor switch {
+            Orient.AnchorSpecification.CustomAnchor custom => ResultFactory.Create(value: custom.Anchor),
+            Orient.AnchorSpecification.BoundingBoxAnchor => geometry.GetBoundingBox(accurate: true) is BoundingBox box && box.IsValid
+                ? ResultFactory.Create(value: box.Center)
+                : ResultFactory.Create<Point3d>(error: E.Validation.BoundingBoxInvalid),
+            _ => ResultFactory.Create<Point3d>(error: E.Geometry.InvalidOrientationMode.WithContext("Unsupported anchor specification")),
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Plane> ExtractPlane(GeometryBase geometry) {
+        Type runtimeType = geometry.GetType();
+        if (OrientConfig.PlaneExtractors.TryGetValue(runtimeType, out OrientConfig.PlaneExtractorMetadata? metadata)) {
+            return metadata.Extractor(geometry);
+        }
+
+        foreach (KeyValuePair<Type, OrientConfig.PlaneExtractorMetadata> entry in OrientConfig.PlaneExtractors) {
+            if (entry.Key.IsAssignableFrom(runtimeType)) {
+                return entry.Value.Extractor(geometry);
+            }
+        }
+
+        return ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(runtimeType.Name));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Plane> ExtractBestFitPlane(GeometryBase geometry) =>
+        geometry switch {
+            PointCloud pc when pc.Count >= OrientConfig.BestFitMinPoints => FitPlane(pc.GetPoints()),
+            PointCloud pc => ResultFactory.Create<Plane>(error: E.Geometry.InsufficientParameters.WithContext($"Best-fit plane requires {OrientConfig.BestFitMinPoints} points, got {pc.Count}")),
+            Mesh mesh when mesh.Vertices.Count >= OrientConfig.BestFitMinPoints => FitPlane(mesh.Vertices.ToPoint3dArray()),
+            Mesh mesh => ResultFactory.Create<Plane>(error: E.Geometry.InsufficientParameters.WithContext($"Best-fit plane requires {OrientConfig.BestFitMinPoints} points, got {mesh.Vertices.Count}")),
+            _ => ResultFactory.Create<Plane>(error: E.Geometry.UnsupportedOrientationType.WithContext(geometry.GetType().Name)),
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Plane> FitPlane(Point3d[] points) =>
+        Plane.FitPlaneToPoints(points, out Plane plane) == PlaneFitResult.Success && ComputeRms(points, plane) <= OrientConfig.BestFitResidualThreshold
+            ? ResultFactory.Create(value: plane)
+            : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double ComputeRms(Point3d[] points, Plane plane) {
+        double sum = 0.0;
+        for (int i = 0; i < points.Length; i++) {
+            double distance = plane.DistanceTo(points[i]);
+            sum += distance * distance;
+        }
+        return Math.Sqrt(sum / points.Length);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Transform> BuildVectorRotation(Vector3d source, Vector3d target, Point3d anchor) {
+        Vector3d su = new(source);
+        Vector3d tu = new(target);
+        _ = su.Unitize();
+        _ = tu.Unitize();
+        double dot = su * tu;
+        double crossLength = Vector3d.CrossProduct(su, tu).Length;
+
+        return crossLength < RhinoMath.SqrtEpsilon
+            ? Math.Abs(dot - 1.0) < RhinoMath.SqrtEpsilon
+                ? ResultFactory.Create(value: Transform.Identity)
+                : Math.Abs(dot + 1.0) < RhinoMath.SqrtEpsilon
+                    ? BuildHalfTurn(su, anchor)
+                    : ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors)
+            : ResultFactory.Create(value: Transform.Rotation(su, tu, anchor));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Transform> BuildHalfTurn(Vector3d source, Point3d anchor) {
+        Vector3d axisCandidate = Math.Abs(source * Vector3d.XAxis) < 0.95
+            ? Vector3d.CrossProduct(source, Vector3d.XAxis)
+            : Vector3d.CrossProduct(source, Vector3d.YAxis);
+        return axisCandidate.Unitize()
+            ? ResultFactory.Create(value: Transform.Rotation(Math.PI, axisCandidate, anchor))
+            : ResultFactory.Create<Transform>(error: E.Geometry.InvalidOrientationVectors);
+    }
+
+    private static Result<Orient.OrientationOptimizationResult> EvaluateOrientationCriteria(
+        Brep brep,
+        Orient.OptimizationCriterion criterion,
+        BoundingBox box,
+        IGeometryContext context) {
+        Result<Point3d> centroidResult = ExtractCentroid(brep, useMassProperties: true);
+        if (criterion.Code == 2 && !centroidResult.IsSuccess) {
+            return ResultFactory.Create<Orient.OrientationOptimizationResult>(error: E.Geometry.CentroidExtractionFailed);
+        }
+
+        Vector3d diag1 = new Vector3d(1, 1, 0);
+        Vector3d diag2 = new Vector3d(1, 0, 1);
+        Vector3d diag3 = new Vector3d(0, 1, 1);
+        _ = diag1.Unitize();
+        _ = diag2.Unitize();
+        _ = diag3.Unitize();
+        Plane[] testPlanes = [
+            new Plane(box.Center, Vector3d.XAxis, Vector3d.YAxis),
+            new Plane(box.Center, Vector3d.YAxis, Vector3d.ZAxis),
+            new Plane(box.Center, Vector3d.XAxis, Vector3d.ZAxis),
+            new Plane(box.Center, diag1, Vector3d.ZAxis),
+            new Plane(box.Center, diag2, Vector3d.YAxis),
+            new Plane(box.Center, diag3, Vector3d.XAxis),
+        ];
+
+        (Transform Transform, double Score, Orient.OptimizationCriterion[] Criteria)[] results = [
+            .. testPlanes.Select(plane => EvaluatePlaneCandidate(brep, plane, criterion, centroidResult, context)),
+        ];
+
+        (Transform Transform, double Score, Orient.OptimizationCriterion[] Criteria)? best = results.MaxBy(result => result.Score);
+        return best is { Score: > 0.0 } winner
+            ? ResultFactory.Create(value: new Orient.OrientationOptimizationResult(winner.Transform, winner.Score, winner.Criteria))
+            : ResultFactory.Create<Orient.OrientationOptimizationResult>(error: E.Geometry.TransformFailed.WithContext("No valid orientation found"));
+    }
+
+    private static (Transform Transform, double Score, Orient.OptimizationCriterion[] Criteria) EvaluatePlaneCandidate(
+        Brep brep,
+        Plane plane,
+        Orient.OptimizationCriterion criterion,
+        Result<Point3d> centroid,
+        IGeometryContext context) {
+        Transform xf = Transform.PlaneToPlane(plane, Plane.WorldXY);
+        using Brep test = (Brep)brep.Duplicate();
+        if (!test.Transform(xf)) {
+            return (Transform.Identity, 0.0, Array.Empty<Orient.OptimizationCriterion>());
+        }
+
+        BoundingBox testBox = test.GetBoundingBox(accurate: true);
+        if (!testBox.IsValid) {
+            return (Transform.Identity, 0.0, Array.Empty<Orient.OptimizationCriterion>());
+        }
+
+        double score = criterion.Code switch {
+            1 => testBox.Diagonal.Length > context.AbsoluteTolerance ? 1.0 / testBox.Diagonal.Length : 0.0,
+            2 => centroid.IsSuccess && testBox.Diagonal.Length > context.AbsoluteTolerance
+                ? ((Func<double>)(() => {
+                    Point3d c = centroid.Value;
+                    c.Transform(xf);
+                    return Math.Max(0.0, 1.0 - (Math.Abs(c.Z) / testBox.Diagonal.Length));
+                }))()
+                : 0.0,
+            3 => CountDegeneracy(testBox, context.AbsoluteTolerance),
+            4 => ((testBox.Min.Z >= -context.AbsoluteTolerance ? OrientConfig.OrientationScoreWeight1 : 0.0)
+                + (Math.Abs(testBox.Center.X) < context.AbsoluteTolerance && Math.Abs(testBox.Center.Y) < context.AbsoluteTolerance ? OrientConfig.OrientationScoreWeight2 : 0.0)
+                + ((testBox.Max.Z - testBox.Min.Z) < (testBox.Diagonal.Length * OrientConfig.LowProfileAspectRatio) ? OrientConfig.OrientationScoreWeight3 : 0.0)),
+            _ => 0.0,
+        };
+
+        return (xf, score, score > 0.0 ? [criterion,] : Array.Empty<Orient.OptimizationCriterion>());
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double CountDegeneracy(BoundingBox box, double tolerance) {
+        double degeneracy = 0.0;
+        degeneracy += Math.Abs(box.Max.X - box.Min.X) <= tolerance ? 1.0 : 0.0;
+        degeneracy += Math.Abs(box.Max.Y - box.Min.Y) <= tolerance ? 1.0 : 0.0;
+        degeneracy += Math.Abs(box.Max.Z - box.Min.Z) <= tolerance ? 1.0 : 0.0;
+        return degeneracy switch {
+            0.0 => 0.0,
+            _ => degeneracy / OrientConfig.MaxDegeneracyDimensions,
+        };
+    }
+
+    private static byte ClassifySymmetry(
+        GeometryBase geometryA,
+        GeometryBase geometryB,
+        Plane planeA,
+        Plane planeB,
+        double tolerance,
+        IGeometryContext context) {
+        return (geometryA, geometryB) switch {
+            (Brep brepA, Brep brepB) when brepA.Vertices.Count == brepB.Vertices.Count =>
+                EvaluateMirrorSymmetry(brepA, brepB, planeA, planeB, tolerance),
+            (Curve curveA, Curve curveB) when curveA.SpanCount == curveB.SpanCount =>
+                EvaluateRotationalSymmetry(curveA, curveB, planeA, tolerance, context),
+            _ => 0,
+        };
+    }
+
+    private static byte EvaluateMirrorSymmetry(Brep first, Brep second, Plane planeA, Plane planeB, double tolerance) {
+        if ((planeB.Origin - planeA.Origin).Length > RhinoMath.ZeroTolerance) {
+            Plane mirror = new Plane(planeA.Origin + ((planeB.Origin - planeA.Origin) * 0.5), planeB.Origin - planeA.Origin);
+            return mirror.IsValid && CheckMirror(first, second, mirror, tolerance) ? (byte)1 : (byte)0;
+        }
+
+        Plane mirrorFallback = new Plane(planeA.Origin, planeA.ZAxis);
+        return mirrorFallback.IsValid && CheckMirror(first, second, mirrorFallback, tolerance) ? (byte)1 : (byte)0;
+    }
+
+    private static bool CheckMirror(Brep first, Brep second, Plane mirror, double tolerance) {
+        Point3d[] reflected = first.Vertices.Select(vertex => {
+            Point3d pt = vertex.Location;
+            pt.Transform(Transform.Mirror(mirror));
+            return pt;
+        }).ToArray();
+        return reflected.All(pt => second.Vertices.Any(other => pt.DistanceTo(other.Location) < tolerance))
+            && second.Vertices.All(pt => reflected.Any(other => other.DistanceTo(pt.Location) < tolerance));
+    }
+
+    private static byte EvaluateRotationalSymmetry(
+        Curve curveA,
+        Curve curveB,
+        Plane planeA,
+        double tolerance,
+        IGeometryContext context) {
+        Point3d[] samplesA = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => curveA.PointAt(curveA.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
+        Point3d[] samplesB = [.. Enumerable.Range(0, OrientConfig.RotationSymmetrySampleCount).Select(i => curveB.PointAt(curveB.Domain.ParameterAt(i / (double)(OrientConfig.RotationSymmetrySampleCount - 1))))];
+        int[] testIndices = [0, samplesA.Length / 2, samplesA.Length - 1,];
+        double[] candidateAngles = [.. testIndices.Select(idx => {
+            Vector3d vecA = samplesA[idx] - planeA.Origin;
+            Vector3d vecB = samplesB[idx] - planeA.Origin;
+            Vector3d projA = vecA - ((vecA * planeA.ZAxis) * planeA.ZAxis);
+            Vector3d projB = vecB - ((vecB * planeA.ZAxis) * planeA.ZAxis);
+            return projA.Length < tolerance || projB.Length < tolerance
+                ? double.NaN
+                : Vector3d.CrossProduct(projA, projB) * planeA.ZAxis < 0
+                    ? -Vector3d.VectorAngle(projA, projB)
+                    : Vector3d.VectorAngle(projA, projB);
+        }).Where(angle => !double.IsNaN(angle)),];
+
+        if (candidateAngles.Length == 0) {
+            return 0;
+        }
+
+        double reference = candidateAngles[0];
+        if (!candidateAngles.All(angle => Math.Abs(angle - reference) < context.AngleToleranceRadians)) {
+            return 0;
+        }
+
+        Transform rotation = Transform.Rotation(reference, planeA.ZAxis, planeA.Origin);
+        return samplesA.Zip(samplesB, (ptA, ptB) => {
+            Point3d rotated = ptA;
+            rotated.Transform(rotation);
+            return rotated.DistanceTo(ptB);
+        }).All(dist => dist < tolerance) ? (byte)2 : (byte)0;
+    }
+
+    private static byte ClassifyRelationship(Plane planeA, Plane planeB, double angleTolerance) {
+        double dot = Math.Abs(Vector3d.Multiply(planeA.ZAxis, planeB.ZAxis));
+        return dot switch {
+            _ when Math.Abs(dot - 1.0) < 1.0 - Math.Cos(angleTolerance) => (byte)1,
+            _ when Math.Abs(dot) < Math.Sin(angleTolerance) => (byte)2,
+            _ => (byte)3,
+        };
+    }
+
+    private static Result<Orient.PatternDetectionResult> IdentifyPattern(GeometryBase[] geometries, IGeometryContext context) {
+        Result<Point3d>[] centroidResults = [.. geometries.Select(g => ExtractCentroid(g, useMassProperties: false)),];
+        if (centroidResults.Any(result => !result.IsSuccess)) {
+            int failed = centroidResults.Count(result => !result.IsSuccess);
+            return ResultFactory.Create<Orient.PatternDetectionResult>(error: E.Geometry.PatternDetectionFailed.WithContext($"Centroid extraction failed for {failed} geometries"));
+        }
+
+        Point3d[] centroids = centroidResults.Select(result => result.Value).ToArray();
+        if (centroids.Length < OrientConfig.PatternMinInstances) {
+            return ResultFactory.Create<Orient.PatternDetectionResult>(error: E.Geometry.PatternDetectionFailed.WithContext("Insufficient valid centroids"));
+        }
+
+        Vector3d[] deltas = centroids.Skip(1).Zip(centroids, (second, first) => second - first).ToArray();
+        double avgLen = deltas.Average(vector => vector.Length);
+        if (avgLen <= context.AbsoluteTolerance) {
+            return ResultFactory.Create<Orient.PatternDetectionResult>(error: E.Geometry.PatternDetectionFailed.WithContext("Degenerate centroid spacing"));
+        }
+
+        bool linear = deltas[0].Length >= context.AbsoluteTolerance
+            && deltas.Skip(1).All(v => Math.Abs(v.Length - avgLen) / avgLen < context.AbsoluteTolerance && Vector3d.VectorAngle(deltas[0], v) <= context.AngleToleranceRadians);
+        if (linear) {
+            Transform[] transforms = [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Translation(deltas[0] * i)),];
+            int[] anomalies = [.. deltas.Select((v, i) => (Vector: v, Index: i)).Where(pair => Math.Abs(pair.Vector.Length - avgLen) / avgLen >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.Index),];
+            double deviation = deltas.Sum(v => Math.Abs(v.Length - avgLen)) / centroids.Length;
+            return ResultFactory.Create(value: new Orient.PatternDetectionResult(new Orient.PatternClassification.Linear(), transforms, anomalies, deviation));
+        }
+
+        Point3d center = new Point3d(centroids.Average(p => p.X), centroids.Average(p => p.Y), centroids.Average(p => p.Z));
+        double[] radii = centroids.Select(p => p.DistanceTo(center)).ToArray();
+        double avgRadius = radii.Average();
+        if (avgRadius <= context.AbsoluteTolerance || radii.Any(r => Math.Abs(r - avgRadius) / avgRadius >= context.AbsoluteTolerance)) {
+            return ResultFactory.Create<Orient.PatternDetectionResult>(error: E.Geometry.PatternDetectionFailed.WithContext("Pattern too irregular"));
+        }
+
+        Transform[] radialTransforms = [.. Enumerable.Range(0, centroids.Length).Select(i => Transform.Rotation(RhinoMath.TwoPI * i / centroids.Length, Vector3d.ZAxis, center)),];
+        int[] radialAnomalies = [.. radii.Select((radius, index) => (radius, index)).Where(pair => Math.Abs(pair.radius - avgRadius) / avgRadius >= (context.AbsoluteTolerance * OrientConfig.PatternAnomalyThreshold)).Select(pair => pair.index),];
+        double radialDeviation = radii.Sum(r => Math.Abs(r - avgRadius)) / centroids.Length;
+        return ResultFactory.Create(value: new Orient.PatternDetectionResult(new Orient.PatternClassification.Radial(), radialTransforms, radialAnomalies, radialDeviation));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Orient.SymmetryClassification CreateSymmetry(byte code) => code switch {
+        1 => new Orient.SymmetryClassification.Mirror(),
+        2 => new Orient.SymmetryClassification.Rotational(),
+        _ => new Orient.SymmetryClassification.None(),
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Orient.OrientationRelationship CreateRelationship(byte code) => code switch {
+        1 => new Orient.OrientationRelationship.Aligned(),
+        2 => new Orient.OrientationRelationship.Orthogonal(),
+        _ => new Orient.OrientationRelationship.Skew(),
+    };
 }

--- a/libs/rhino/orientation/OrientConfig.cs
+++ b/libs/rhino/orientation/OrientConfig.cs
@@ -1,5 +1,8 @@
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using Arsenal.Core.Errors;
+using Arsenal.Core.Results;
 using Arsenal.Core.Validation;
 using Rhino.Geometry;
 
@@ -8,8 +11,173 @@ namespace Arsenal.Rhino.Orientation;
 /// <summary>Validation modes, thresholds, and configuration for orientation operations.</summary>
 [Pure]
 internal static class OrientConfig {
+    internal enum AlignmentOperationKind {
+        Plane,
+        CurveFrame,
+        SurfaceFrame,
+        WorldXY,
+        WorldYZ,
+        WorldXZ,
+        BoundingBoxOrigin,
+        VolumeOrigin,
+        BoundingBoxPoint,
+        MassPoint,
+        Vector,
+        BestFit,
+        Mirror,
+        Flip,
+    }
+
+    internal sealed record AlignmentOperationMetadata(
+        AlignmentOperationKind Kind,
+        string OperationName,
+        V ValidationMode);
+
+    internal sealed record OrientationAnalysisMetadata(
+        string OperationName,
+        V ValidationMode);
+
+    internal sealed record PlaneExtractorMetadata(Func<object, Result<Plane>> Extractor);
+
+    internal static readonly FrozenDictionary<Type, AlignmentOperationMetadata> AlignmentOperations =
+        new Dictionary<Type, AlignmentOperationMetadata> {
+            [typeof(Orient.PlaneAlignment)] = new(
+                Kind: AlignmentOperationKind.Plane,
+                OperationName: "Orient.Align.Plane",
+                ValidationMode: V.Standard),
+            [typeof(Orient.CurveFrameAlignment)] = new(
+                Kind: AlignmentOperationKind.CurveFrame,
+                OperationName: "Orient.Align.CurveFrame",
+                ValidationMode: V.Standard),
+            [typeof(Orient.SurfaceFrameAlignment)] = new(
+                Kind: AlignmentOperationKind.SurfaceFrame,
+                OperationName: "Orient.Align.SurfaceFrame",
+                ValidationMode: V.Standard | V.UVDomain),
+            [typeof(Orient.WorldXYAlignment)] = new(
+                Kind: AlignmentOperationKind.WorldXY,
+                OperationName: "Orient.Align.WorldXY",
+                ValidationMode: V.BoundingBox),
+            [typeof(Orient.WorldYZAlignment)] = new(
+                Kind: AlignmentOperationKind.WorldYZ,
+                OperationName: "Orient.Align.WorldYZ",
+                ValidationMode: V.BoundingBox),
+            [typeof(Orient.WorldXZAlignment)] = new(
+                Kind: AlignmentOperationKind.WorldXZ,
+                OperationName: "Orient.Align.WorldXZ",
+                ValidationMode: V.BoundingBox),
+            [typeof(Orient.BoundingBoxOriginAlignment)] = new(
+                Kind: AlignmentOperationKind.BoundingBoxOrigin,
+                OperationName: "Orient.Align.BoundingOrigin",
+                ValidationMode: V.BoundingBox),
+            [typeof(Orient.VolumeOriginAlignment)] = new(
+                Kind: AlignmentOperationKind.VolumeOrigin,
+                OperationName: "Orient.Align.VolumeOrigin",
+                ValidationMode: V.MassProperties),
+            [typeof(Orient.BoundingBoxPointAlignment)] = new(
+                Kind: AlignmentOperationKind.BoundingBoxPoint,
+                OperationName: "Orient.Align.BoundingPoint",
+                ValidationMode: V.BoundingBox),
+            [typeof(Orient.MassPointAlignment)] = new(
+                Kind: AlignmentOperationKind.MassPoint,
+                OperationName: "Orient.Align.MassPoint",
+                ValidationMode: V.MassProperties),
+            [typeof(Orient.VectorAlignment)] = new(
+                Kind: AlignmentOperationKind.Vector,
+                OperationName: "Orient.Align.Vector",
+                ValidationMode: V.BoundingBox),
+            [typeof(Orient.BestFitAlignment)] = new(
+                Kind: AlignmentOperationKind.BestFit,
+                OperationName: "Orient.Align.BestFit",
+                ValidationMode: V.Standard),
+            [typeof(Orient.MirrorAlignment)] = new(
+                Kind: AlignmentOperationKind.Mirror,
+                OperationName: "Orient.Align.Mirror",
+                ValidationMode: V.Standard),
+            [typeof(Orient.FlipDirectionAlignment)] = new(
+                Kind: AlignmentOperationKind.Flip,
+                OperationName: "Orient.Align.Flip",
+                ValidationMode: V.Standard),
+        }.ToFrozenDictionary();
+
+    internal static readonly OrientationAnalysisMetadata OptimizationMetadata = new(
+        OperationName: "Orient.Optimize",
+        ValidationMode: V.Standard | V.Topology | V.BoundingBox | V.MassProperties);
+
+    internal static readonly OrientationAnalysisMetadata RelativeMetadata = new(
+        OperationName: "Orient.Relative",
+        ValidationMode: V.Standard | V.Topology);
+
+    internal static readonly OrientationAnalysisMetadata PatternMetadata = new(
+        OperationName: "Orient.Pattern",
+        ValidationMode: V.None);
+
+    internal static readonly FrozenDictionary<Type, PlaneExtractorMetadata> PlaneExtractors =
+        new Dictionary<Type, PlaneExtractorMetadata> {
+            [typeof(Curve)] = new(g => ((Curve)g).FrameAt(((Curve)g).Domain.Mid, out Plane f) && f.IsValid
+                ? ResultFactory.Create(value: f)
+                : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed)),
+            [typeof(Surface)] = new(g => ((Surface)g) switch {
+                Surface s when s.FrameAt(s.Domain(0).Mid, s.Domain(1).Mid, out Plane f) && f.IsValid => ResultFactory.Create(value: f),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            }),
+            [typeof(Brep)] = new(g => ((Brep)g) switch {
+                Brep b when b.IsSolid => ((Func<Result<Plane>>)(() => {
+                    using VolumeMassProperties? vmp = VolumeMassProperties.Compute(b);
+                    return vmp is not null
+                        ? ResultFactory.Create(value: new Plane(vmp.Centroid, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis))
+                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                }))(),
+                Brep b when b.SolidOrientation != BrepSolidOrientation.None => ((Func<Result<Plane>>)(() => {
+                    using AreaMassProperties? amp = AreaMassProperties.Compute(b);
+                    return amp is not null
+                        ? ResultFactory.Create(value: new Plane(amp.Centroid, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis))
+                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                }))(),
+                Brep b => ResultFactory.Create(value: new Plane(b.GetBoundingBox(accurate: false).Center, b.Faces.Count > 0 ? b.Faces[0].NormalAt(0.5, 0.5) : Vector3d.ZAxis)),
+            }),
+            [typeof(Extrusion)] = new(g => ((Extrusion)g) switch {
+                Extrusion e when e.IsSolid => ((Func<Result<Plane>>)(() => {
+                    using VolumeMassProperties? vmp = VolumeMassProperties.Compute(e);
+                    using LineCurve path = e.PathLineCurve();
+                    return vmp is not null
+                        ? ResultFactory.Create(value: new Plane(vmp.Centroid, path.TangentAtStart))
+                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                }))(),
+                Extrusion e when e.IsClosed(0) && e.IsClosed(1) => ((Func<Result<Plane>>)(() => {
+                    using AreaMassProperties? amp = AreaMassProperties.Compute(e);
+                    using LineCurve path = e.PathLineCurve();
+                    return amp is not null
+                        ? ResultFactory.Create(value: new Plane(amp.Centroid, path.TangentAtStart))
+                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                }))(),
+                Extrusion e => ((Func<Result<Plane>>)(() => {
+                    using LineCurve path = e.PathLineCurve();
+                    return ResultFactory.Create(value: new Plane(e.GetBoundingBox(accurate: false).Center, path.TangentAtStart));
+                }))(),
+            }),
+            [typeof(Mesh)] = new(g => ((Mesh)g) switch {
+                Mesh m when m.IsClosed => ((Func<Result<Plane>>)(() => {
+                    using VolumeMassProperties? vmp = VolumeMassProperties.Compute(m);
+                    return vmp is not null
+                        ? ResultFactory.Create(value: new Plane(vmp.Centroid, m.Normals.Count > 0 ? m.Normals[0] : Vector3d.ZAxis))
+                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                }))(),
+                Mesh m => ((Func<Result<Plane>>)(() => {
+                    using AreaMassProperties? amp = AreaMassProperties.Compute(m);
+                    return amp is not null
+                        ? ResultFactory.Create(value: new Plane(amp.Centroid, m.Normals.Count > 0 ? m.Normals[0] : Vector3d.ZAxis))
+                        : ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed);
+                }))(),
+            }),
+            [typeof(Point3d)] = new(g => ResultFactory.Create(value: new Plane((Point3d)g, Vector3d.ZAxis))),
+            [typeof(PointCloud)] = new(g => (PointCloud)g switch {
+                PointCloud pc when pc.Count > 0 => ResultFactory.Create(value: new Plane(pc[0].Location, Vector3d.ZAxis)),
+                _ => ResultFactory.Create<Plane>(error: E.Geometry.FrameExtractionFailed),
+            }),
+        }.ToFrozenDictionary();
+
     /// <summary>Type-specific validation mode dispatch for orientation operations.</summary>
-    internal static readonly FrozenDictionary<Type, V> ValidationModes =
+    internal static readonly FrozenDictionary<Type, V> GeometryValidation =
         new Dictionary<Type, V> {
             [typeof(Curve)] = V.Standard | V.Degeneracy,
             [typeof(NurbsCurve)] = V.Standard | V.Degeneracy | V.NurbsGeometry,


### PR DESCRIPTION
## Summary
- replace the legacy Orient entrypoints with algebraic request/response records and a single Apply/Optimize/Relative/Detect surface
- centralize validation flags, operation names, and plane-extraction delegates into OrientConfig metadata tables that feed UnifiedOperation dispatch in OrientCore
- rewrite OrientCompute with strongly-typed algorithms for every request plus new optimization, relative, and pattern diagnostics that emit the new record results

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d3c1a4cb88321aeaf4fb82bd8ffbe)