### PR TITLE
Refactor intersection metadata and API

### DIFF
--- a/libs/rhino/intersection/Intersect.cs
+++ b/libs/rhino/intersection/Intersect.cs
@@ -1,25 +1,52 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Intersection;
 
-/// <summary>Polymorphic intersection with automatic type-based dispatch.</summary>
+/// <summary>Polymorphic intersection with strongly typed algebraic requests.</summary>
 public static class Intersect {
-    /// <summary>Intersection operation options controlling tolerance, projection, and output formatting.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct IntersectionOptions(
+    /// <summary>Intersection option set controlling tolerance, projection, and sorting behavior.</summary>
+    public sealed record IntersectionSettings(
         double? Tolerance = null,
         Vector3d? ProjectionDirection = null,
         int? MaxHits = null,
-        bool WithIndices = false,
-        bool Sorted = false);
+        bool IncludeIndices = false,
+        bool Sorted = false) {
+        /// <summary>Default settings instance.</summary>
+        public static IntersectionSettings Default { get; } = new();
+    }
 
-    /// <summary>Intersection operation result containing points, curves, parameters, and topology indices.</summary>
+    /// <summary>Base type for all intersection requests.</summary>
+    public abstract record IntersectionRequest;
+
+    /// <summary>Intersection computation request for two arbitrary Rhino geometry operands.</summary>
+    public sealed record GeometryIntersectionRequest(
+        object GeometryA,
+        object GeometryB,
+        IntersectionSettings? Settings = null) : IntersectionRequest;
+
+    /// <summary>Classification request using an existing intersection output.</summary>
+    public sealed record ClassificationRequest(
+        IntersectionOutput Output,
+        GeometryBase GeometryA,
+        GeometryBase GeometryB) : IntersectionRequest;
+
+    /// <summary>Near-miss sampling request between two geometries.</summary>
+    public sealed record NearMissRequest(
+        GeometryBase GeometryA,
+        GeometryBase GeometryB,
+        double SearchRadius) : IntersectionRequest;
+
+    /// <summary>Stability analysis request for an existing intersection solution.</summary>
+    public sealed record StabilityRequest(
+        IntersectionOutput BaseIntersection,
+        GeometryBase GeometryA,
+        GeometryBase GeometryB) : IntersectionRequest;
+
+    /// <summary>Intersection result containing all extracted entities and associated indices.</summary>
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
     public readonly record struct IntersectionOutput(
         IReadOnlyList<Point3d> Points,
@@ -28,70 +55,57 @@ public static class Intersect {
         IReadOnlyList<double> ParametersB,
         IReadOnlyList<int> FaceIndices,
         IReadOnlyList<Polyline> Sections) {
-        /// <summary>Empty result with zero-length collections for non-intersecting geometries.</summary>
+        /// <summary>Empty output singleton.</summary>
         public static readonly IntersectionOutput Empty = new([], [], [], [], [], []);
     }
-    /// <summary>Executes type-detected intersection with automatic validation and collection aggregation.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<IntersectionOutput> Execute<T1, T2>(
-        T1 geometryA,
-        T2 geometryB,
-        IGeometryContext context,
-        IntersectionOptions? options = null) where T1 : notnull where T2 : notnull {
-        IntersectionOptions opts = options ?? new IntersectionOptions();
-        (Type t1, Type t2) = (typeof(T1), typeof(T2));
 
-        return IntersectionCore.NormalizeOptions(opts, context)
-            .Bind(normalized => UnifiedOperation.Apply(
-                geometryA,
-                (Func<object, Result<IReadOnlyList<IntersectionOutput>>>)(item => IntersectionCore.ExecuteWithOptions(
-                        item,
-                        geometryB,
-                        context,
-                        normalized)
-                    .Map(output => (IReadOnlyList<IntersectionOutput>)[output])),
-                new OperationConfig<object, IntersectionOutput> {
-                    Context = context,
-                    ValidationMode = V.None,
-                    AccumulateErrors = true,
-                    OperationName = $"Intersect.{t1.Name}.{t2.Name}",
-                    EnableDiagnostics = false,
-                }))
-        .Map(outputs => outputs.Count == 0
-            ? IntersectionOutput.Empty
-            : new IntersectionOutput(
-                [.. outputs.SelectMany(static output => output.Points)],
-                [.. outputs.SelectMany(static output => output.Curves)],
-                [.. outputs.SelectMany(static output => output.ParametersA)],
-                [.. outputs.SelectMany(static output => output.ParametersB)],
-                [.. outputs.SelectMany(static output => output.FaceIndices)],
-                [.. outputs.SelectMany(static output => output.Sections)]));
-    }
+    /// <summary>Classification data describing intersection tangency and grazing metrics.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    public readonly record struct ClassificationResult(
+        byte Type,
+        double[] ApproachAngles,
+        bool IsGrazing,
+        double BlendScore);
 
-    /// <summary>Classifies intersection type (tangent/transverse/unknown) via approach angle analysis.</summary>
+    /// <summary>Near-miss sampling data with paired locations and distances.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    public readonly record struct NearMissResult(
+        Point3d[] LocationsA,
+        Point3d[] LocationsB,
+        double[] Distances);
+
+    /// <summary>Stability evaluation result including score, sensitivity, and unstable flags.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    public readonly record struct StabilityResult(
+        double StabilityScore,
+        double PerturbationSensitivity,
+        bool[] UnstableFlags);
+
+    /// <summary>Executes polymorphic intersection with automatic metadata-driven dispatch.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(byte Type, double[] ApproachAngles, bool IsGrazing, double BlendScore)> ClassifyIntersection(
-        IntersectionOutput output,
-        GeometryBase geometryA,
-        GeometryBase geometryB,
+    public static Result<IntersectionOutput> Execute(
+        GeometryIntersectionRequest request,
         IGeometryContext context) =>
-        IntersectionCompute.Classify(output: output, geomA: geometryA, geomB: geometryB, context: context);
+        IntersectionCore.Execute(request: request, context: context);
 
-    /// <summary>Finds near-miss locations within tolerance band via closest point sampling.</summary>
+    /// <summary>Classifies the supplied intersection result.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] LocationsA, Point3d[] LocationsB, double[] Distances)> FindNearMisses(
-        GeometryBase geometryA,
-        GeometryBase geometryB,
-        double searchRadius,
+    public static Result<ClassificationResult> ClassifyIntersection(
+        ClassificationRequest request,
         IGeometryContext context) =>
-        IntersectionCompute.FindNearMisses(geomA: geometryA, geomB: geometryB, searchRadius: searchRadius, context: context);
+        IntersectionCore.Classify(request: request, context: context);
 
-    /// <summary>Analyzes intersection stability via spherical perturbation sampling.</summary>
+    /// <summary>Computes near-miss sample pairs for the supplied geometries.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(double StabilityScore, double PerturbationSensitivity, bool[] UnstableFlags)> AnalyzeStability(
-        IntersectionOutput baseIntersection,
-        GeometryBase geometryA,
-        GeometryBase geometryB,
+    public static Result<NearMissResult> FindNearMisses(
+        NearMissRequest request,
         IGeometryContext context) =>
-        IntersectionCompute.AnalyzeStability(geomA: geometryA, geomB: geometryB, baseOutput: baseIntersection, context: context);
+        IntersectionCore.NearMisses(request: request, context: context);
+
+    /// <summary>Evaluates intersection stability under perturbation sampling.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<StabilityResult> AnalyzeStability(
+        StabilityRequest request,
+        IGeometryContext context) =>
+        IntersectionCore.Stability(request: request, context: context);
 }

--- a/libs/rhino/intersection/IntersectionConfig.cs
+++ b/libs/rhino/intersection/IntersectionConfig.cs
@@ -1,82 +1,90 @@
 using System.Collections.Frozen;
+using System.Globalization;
+using System.Linq;
 using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Intersection;
 
-/// <summary>Validation modes and parameters for intersection operations using RhinoDoc tolerances via GeometryContext.FromDocument(doc).</summary>
+/// <summary>Intersection metadata registry containing validation flags and tolerances.</summary>
 internal static class IntersectionConfig {
-    /// <summary>(TypeA, TypeB) tuple to validation mode mapping.</summary>
-    internal static readonly FrozenDictionary<(Type, Type), (V ModeA, V ModeB)> ValidationModes =
-        new (Type TypeA, Type TypeB, V ModeA, V ModeB)[] {
-            (typeof(Curve), typeof(Curve), V.Standard | V.Degeneracy, V.Standard | V.Degeneracy),
-            (typeof(NurbsCurve), typeof(NurbsCurve), V.Standard | V.Degeneracy | V.NurbsGeometry, V.Standard | V.Degeneracy | V.NurbsGeometry),
-            (typeof(PolyCurve), typeof(Curve), V.Standard | V.Degeneracy | V.PolycurveStructure, V.Standard | V.Degeneracy),
-            (typeof(Curve), typeof(Surface), V.Standard | V.Degeneracy, V.Standard | V.UVDomain),
-            (typeof(Curve), typeof(NurbsSurface), V.Standard | V.Degeneracy, V.Standard | V.NurbsGeometry | V.UVDomain),
-            (typeof(Curve), typeof(Brep), V.Standard | V.Degeneracy, V.Standard | V.Topology),
-            (typeof(Curve), typeof(Extrusion), V.Standard | V.Degeneracy, V.Standard | V.ExtrusionGeometry),
-            (typeof(Curve), typeof(BrepFace), V.Standard | V.Degeneracy, V.Standard | V.Topology),
-            (typeof(Curve), typeof(Plane), V.Standard | V.Degeneracy, V.Standard),
-            (typeof(Curve), typeof(Line), V.Standard | V.Degeneracy, V.Standard),
-            (typeof(Brep), typeof(Brep), V.Standard | V.Topology, V.Standard | V.Topology),
-            (typeof(Brep), typeof(Plane), V.Standard | V.Topology, V.Standard),
-            (typeof(Brep), typeof(Surface), V.Standard | V.Topology, V.Standard | V.UVDomain),
-            (typeof(Extrusion), typeof(Extrusion), V.Standard | V.ExtrusionGeometry, V.Standard | V.ExtrusionGeometry),
-            (typeof(Surface), typeof(Surface), V.Standard | V.UVDomain, V.Standard | V.UVDomain),
-            (typeof(NurbsSurface), typeof(NurbsSurface), V.Standard | V.NurbsGeometry | V.UVDomain, V.Standard | V.NurbsGeometry | V.UVDomain),
-            (typeof(Mesh), typeof(Mesh), V.MeshSpecific, V.MeshSpecific),
-            (typeof(Mesh), typeof(Ray3d), V.MeshSpecific, V.None),
-            (typeof(Mesh), typeof(Plane), V.MeshSpecific, V.Standard),
-            (typeof(Mesh), typeof(Line), V.MeshSpecific, V.Standard),
-            (typeof(Mesh), typeof(PolylineCurve), V.MeshSpecific, V.Standard | V.Degeneracy),
-            (typeof(Line), typeof(Line), V.Standard, V.Standard),
-            (typeof(Line), typeof(BoundingBox), V.Standard, V.None),
-            (typeof(Line), typeof(Plane), V.Standard, V.Standard),
-            (typeof(Line), typeof(Sphere), V.Standard, V.Standard),
-            (typeof(Line), typeof(Cylinder), V.Standard, V.Standard),
-            (typeof(Line), typeof(Circle), V.Standard, V.Standard),
-            (typeof(Plane), typeof(Plane), V.Standard, V.Standard),
-            (typeof(ValueTuple<Plane, Plane>), typeof(Plane), V.Standard, V.Standard),
-            (typeof(Plane), typeof(Circle), V.Standard, V.Standard),
-            (typeof(Plane), typeof(Sphere), V.Standard, V.Standard),
-            (typeof(Plane), typeof(BoundingBox), V.Standard, V.None),
-            (typeof(Sphere), typeof(Sphere), V.Standard, V.Standard),
-            (typeof(Circle), typeof(Circle), V.Standard, V.Standard),
-            (typeof(Arc), typeof(Arc), V.Standard, V.Standard),
-            (typeof(Point3d[]), typeof(Brep[]), V.None, V.None),
-            (typeof(Point3d[]), typeof(Mesh[]), V.None, V.None),
-            (typeof(Ray3d), typeof(GeometryBase[]), V.None, V.None),
-        }
-        .SelectMany<(Type TypeA, Type TypeB, V ModeA, V ModeB), KeyValuePair<(Type, Type), (V ModeA, V ModeB)>>(static p => p.TypeA == p.TypeB
-            ? [KeyValuePair.Create((p.TypeA, p.TypeB), (p.ModeA, p.ModeB)),]
-            : [KeyValuePair.Create((p.TypeA, p.TypeB), (p.ModeA, p.ModeB)), KeyValuePair.Create((p.TypeB, p.TypeA), (p.ModeB, p.ModeA)),])
-        .ToFrozenDictionary();
+    internal sealed record PairStrategyMetadata(string OperationName, V ModeA, V ModeB);
 
-    /// <summary>Angle thresholds for intersection classification.</summary>
+    internal sealed record OperationMetadata(string OperationName, V ValidationMode);
+
+    private static readonly (Type TypeA, Type TypeB, V ModeA, V ModeB)[] StrategyDefinitions = [
+        (typeof(Curve), typeof(Curve), V.Standard | V.Degeneracy, V.Standard | V.Degeneracy),
+        (typeof(NurbsCurve), typeof(NurbsCurve), V.Standard | V.Degeneracy | V.NurbsGeometry, V.Standard | V.Degeneracy | V.NurbsGeometry),
+        (typeof(PolyCurve), typeof(Curve), V.Standard | V.Degeneracy | V.PolycurveStructure, V.Standard | V.Degeneracy),
+        (typeof(Curve), typeof(Surface), V.Standard | V.Degeneracy, V.Standard | V.UVDomain),
+        (typeof(Curve), typeof(NurbsSurface), V.Standard | V.Degeneracy, V.Standard | V.NurbsGeometry | V.UVDomain),
+        (typeof(Curve), typeof(Brep), V.Standard | V.Degeneracy, V.Standard | V.Topology),
+        (typeof(Curve), typeof(Extrusion), V.Standard | V.Degeneracy, V.Standard | V.ExtrusionGeometry),
+        (typeof(Curve), typeof(BrepFace), V.Standard | V.Degeneracy, V.Standard | V.Topology),
+        (typeof(Curve), typeof(Plane), V.Standard | V.Degeneracy, V.Standard),
+        (typeof(Curve), typeof(Line), V.Standard | V.Degeneracy, V.Standard),
+        (typeof(Brep), typeof(Brep), V.Standard | V.Topology, V.Standard | V.Topology),
+        (typeof(Brep), typeof(Plane), V.Standard | V.Topology, V.Standard),
+        (typeof(Brep), typeof(Surface), V.Standard | V.Topology, V.Standard | V.UVDomain),
+        (typeof(Extrusion), typeof(Extrusion), V.Standard | V.ExtrusionGeometry, V.Standard | V.ExtrusionGeometry),
+        (typeof(Surface), typeof(Surface), V.Standard | V.UVDomain, V.Standard | V.UVDomain),
+        (typeof(NurbsSurface), typeof(NurbsSurface), V.Standard | V.NurbsGeometry | V.UVDomain, V.Standard | V.NurbsGeometry | V.UVDomain),
+        (typeof(Mesh), typeof(Mesh), V.MeshSpecific, V.MeshSpecific),
+        (typeof(Mesh), typeof(Ray3d), V.MeshSpecific, V.None),
+        (typeof(Mesh), typeof(Plane), V.MeshSpecific, V.Standard),
+        (typeof(Mesh), typeof(Line), V.MeshSpecific, V.Standard),
+        (typeof(Mesh), typeof(PolylineCurve), V.MeshSpecific, V.Standard | V.Degeneracy),
+        (typeof(Line), typeof(Line), V.Standard, V.Standard),
+        (typeof(Line), typeof(BoundingBox), V.Standard, V.None),
+        (typeof(Line), typeof(Plane), V.Standard, V.Standard),
+        (typeof(Line), typeof(Sphere), V.Standard, V.Standard),
+        (typeof(Line), typeof(Cylinder), V.Standard, V.Standard),
+        (typeof(Line), typeof(Circle), V.Standard, V.Standard),
+        (typeof(Plane), typeof(Plane), V.Standard, V.Standard),
+        (typeof(ValueTuple<Plane, Plane>), typeof(Plane), V.Standard, V.Standard),
+        (typeof(Plane), typeof(Circle), V.Standard, V.Standard),
+        (typeof(Plane), typeof(Sphere), V.Standard, V.Standard),
+        (typeof(Plane), typeof(BoundingBox), V.Standard, V.None),
+        (typeof(Sphere), typeof(Sphere), V.Standard, V.Standard),
+        (typeof(Circle), typeof(Circle), V.Standard, V.Standard),
+        (typeof(Arc), typeof(Arc), V.Standard, V.Standard),
+        (typeof(Point3d[]), typeof(Brep[]), V.None, V.None),
+        (typeof(Point3d[]), typeof(Mesh[]), V.None, V.None),
+        (typeof(Ray3d), typeof(GeometryBase[]), V.None, V.None),
+    ];
+
+    internal static readonly FrozenDictionary<(Type, Type), PairStrategyMetadata> PairStrategies =
+        StrategyDefinitions
+            .SelectMany(CreateEntries)
+            .ToFrozenDictionary(entry => entry.Key, entry => entry.Value);
+
+    internal static readonly OperationMetadata IntersectionOperation = new("Intersect.Execute", V.None);
+    internal static readonly OperationMetadata ClassificationOperation = new("Intersect.Classify", V.None);
+    internal static readonly OperationMetadata NearMissOperation = new("Intersect.NearMiss", V.None);
+    internal static readonly OperationMetadata StabilityOperation = new("Intersect.Stability", V.None);
+
     internal static readonly double TangentAngleThreshold = RhinoMath.ToRadians(5.0);
     internal static readonly double GrazingAngleThreshold = RhinoMath.ToRadians(15.0);
-
-    /// <summary>Tolerance multiplier for near-miss detection threshold.</summary>
     internal const double NearMissToleranceMultiplier = 10.0;
-
-    /// <summary>Stability analysis parameters.</summary>
     internal const double StabilityPerturbationFactor = 0.001;
     internal const int StabilitySampleCount = 8;
-
-    /// <summary>Maximum vertex sample count for mesh near-miss detection.</summary>
     internal const int MaxNearMissSamples = 1000;
-
-    /// <summary>Minimum sample count for curve near-miss detection.</summary>
     internal const int MinCurveNearMissSamples = 3;
-
-    /// <summary>Minimum sample count for Brep near-miss detection.</summary>
     internal const int MinBrepNearMissSamples = 8;
-
-    /// <summary>Blend quality scores for intersection types.</summary>
     internal const double TangentBlendScore = 1.0;
     internal const double PerpendicularBlendScore = 0.5;
     internal const double CurveSurfaceTangentBlendScore = 0.8;
     internal const double CurveSurfacePerpendicularBlendScore = 0.4;
+
+    private static IEnumerable<KeyValuePair<(Type, Type), PairStrategyMetadata>> CreateEntries((Type TypeA, Type TypeB, V ModeA, V ModeB) definition) =>
+        definition.TypeA == definition.TypeB
+            ? [KeyValuePair.Create((definition.TypeA, definition.TypeB), new PairStrategyMetadata(CreateOperationName(definition.TypeA, definition.TypeB), definition.ModeA, definition.ModeB)),]
+            : [
+                KeyValuePair.Create((definition.TypeA, definition.TypeB), new PairStrategyMetadata(CreateOperationName(definition.TypeA, definition.TypeB), definition.ModeA, definition.ModeB)),
+                KeyValuePair.Create((definition.TypeB, definition.TypeA), new PairStrategyMetadata(CreateOperationName(definition.TypeB, definition.TypeA), definition.ModeB, definition.ModeA)),
+            ];
+
+    private static string CreateOperationName(Type left, Type right) =>
+        string.Create(CultureInfo.InvariantCulture, $"Intersect.{left.Name}.{right.Name}");
 }


### PR DESCRIPTION
## Summary
- refactor the Rhino intersection API to use algebraic request/response records with a single public entry point per operation
- consolidate validation flags, operation names, and tolerance constants into strongly typed metadata with FrozenDictionary dispatch
- update the core and compute layers to consume the new metadata, return strongly typed results, and route all execution through UnifiedOperation

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d7cea2170832195daf69aa83a5554)