### PR TITLE
Refactor fields API around algebraic operations

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
 using Rhino;
 using Rhino.Geometry;
@@ -25,49 +24,76 @@ public static class Fields {
                 FieldsConfig.MinStepSize,
                 FieldsConfig.MaxStepSize);
         }
+
         /// <summary>Default sampling instance (resolution: 32, step size: 0.01).</summary>
         public static FieldSampling Default { get; } = new();
+
         /// <summary>Grid resolution (cube root of sample count), clamped to [8, 256].</summary>
         public int Resolution { get; }
+
         /// <summary>Sample region bounding box (null uses geometry bounds).</summary>
         public BoundingBox? Bounds { get; }
+
         /// <summary>Integration/sampling step size, clamped to [√ε, 1.0].</summary>
         public double StepSize { get; }
     }
 
     /// <summary>Base type for field interpolation strategies.</summary>
     public abstract record InterpolationMode;
+
     /// <summary>Nearest-neighbor interpolation.</summary>
     public sealed record NearestInterpolationMode : InterpolationMode;
+
     /// <summary>Trilinear interpolation.</summary>
     public sealed record TrilinearInterpolationMode : InterpolationMode;
 
     /// <summary>Base type for streamline integration methods.</summary>
     public abstract record IntegrationScheme;
+
     /// <summary>Explicit Euler integration.</summary>
     public sealed record EulerIntegrationScheme : IntegrationScheme;
+
     /// <summary>Midpoint (RK2) integration.</summary>
     public sealed record MidpointIntegrationScheme : IntegrationScheme;
+
     /// <summary>Classical RK4 integration.</summary>
     public sealed record RungeKutta4IntegrationScheme : IntegrationScheme;
 
     /// <summary>Vector component selector for field composition.</summary>
     public abstract record VectorComponent;
+
     /// <summary>X-component selector.</summary>
     public sealed record XComponent : VectorComponent;
+
     /// <summary>Y-component selector.</summary>
     public sealed record YComponent : VectorComponent;
+
     /// <summary>Z-component selector.</summary>
     public sealed record ZComponent : VectorComponent;
 
     /// <summary>Critical point classification.</summary>
     public abstract record CriticalPointKind;
+
     /// <summary>Local minimum point.</summary>
     public sealed record MinimumCriticalPoint : CriticalPointKind;
+
     /// <summary>Local maximum point.</summary>
     public sealed record MaximumCriticalPoint : CriticalPointKind;
+
     /// <summary>Saddle point.</summary>
     public sealed record SaddleCriticalPoint : CriticalPointKind;
+
+    /// <summary>Result structure for scalar field samples.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    public readonly record struct ScalarFieldSamples(Point3d[] Grid, double[] Values);
+
+    /// <summary>Result structure for vector field samples.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    public readonly record struct VectorFieldSamples(Point3d[] Grid, Vector3d[] Vectors);
+
+    /// <summary>Result structure for Hessian tensor samples.</summary>
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+    public readonly record struct HessianFieldSamples(Point3d[] Grid, double[,][] Hessian);
 
     /// <summary>Critical point with location, classification (min/max/saddle), scalar value, and eigendecomposition.</summary>
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
@@ -77,252 +103,163 @@ public static class Fields {
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
     public readonly record struct FieldStatistics(double Min, double Max, double Mean, double StdDev, Point3d MinLocation, Point3d MaxLocation);
 
-    /// <summary>Compute signed distance field: geometry → (grid points[], distances[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Distances)> DistanceField<T>(
-        T geometry,
-        FieldSampling? sampling,
-        IGeometryContext context) where T : GeometryBase =>
-        FieldsCore.DistanceField(
-            geometry: geometry,
-            sampling: sampling ?? FieldSampling.Default,
-            context: context);
+    /// <summary>Base type for all field operations.</summary>
+    public abstract record FieldOperation;
 
-    /// <summary>Compute gradient field: geometry → (grid points[], gradient vectors[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Gradients)> GradientField<T>(
-        T geometry,
-        FieldSampling? sampling,
-        IGeometryContext context) where T : GeometryBase =>
-        DistanceField(geometry: geometry, sampling: sampling, context: context).Bind(distanceField => {
-            FieldSampling samplingValue = sampling ?? FieldSampling.Default;
-            BoundingBox bounds = samplingValue.Bounds ?? geometry.GetBoundingBox(accurate: true);
-            Vector3d gridDelta = (bounds.Max - bounds.Min) / (samplingValue.Resolution - 1);
-            return FieldsCompute.ComputeGradient(
-                distances: distanceField.Distances,
-                grid: distanceField.Grid,
-                resolution: samplingValue.Resolution,
-                gridDelta: gridDelta);
-        });
+    public sealed record DistanceFieldRequest(GeometryBase Geometry, FieldSampling Sampling) : FieldOperation {
+        public DistanceFieldRequest(GeometryBase Geometry) : this(Geometry, FieldSampling.Default) { }
+    }
 
-    /// <summary>Compute curl field: vector field → (grid points[], curl vectors[]) where curl = ∇×F with row-major grid order.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Curl)> CurlField(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidCurlComputation.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeCurl(vectorField: vectorField, grid: gridPoints, resolution: sampling.Resolution, gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    public sealed record GradientFieldRequest(GeometryBase Geometry, FieldSampling Sampling) : FieldOperation {
+        public GradientFieldRequest(GeometryBase Geometry) : this(Geometry, FieldSampling.Default) { }
+    }
 
-    /// <summary>Compute divergence field: vector field → (grid points[], divergence scalars[]) where divergence = ∇·F with row-major grid order.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Divergence)> DivergenceField(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidDivergenceComputation.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeDivergence(vectorField: vectorField, grid: gridPoints, resolution: sampling.Resolution, gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    public sealed record CurlFieldRequest(Vector3d[] VectorField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds) : FieldOperation;
 
-    /// <summary>Compute Laplacian field: scalar field → (grid points[], Laplacian scalars[]) where Laplacian = ∇²f with row-major grid order.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Laplacian)> LaplacianField(
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (scalarField, gridPoints))
-            .Ensure(v => v.scalarField.Length == v.gridPoints.Length, error: E.Geometry.InvalidLaplacianComputation.WithContext("Scalar field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeLaplacian(scalarField: scalarField, grid: gridPoints, resolution: sampling.Resolution, gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    public sealed record DivergenceFieldRequest(Vector3d[] VectorField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds) : FieldOperation;
 
-    /// <summary>Compute vector potential field: magnetic field B → (grid points[], vector potential A[]) solving ∇²A = -∇×B in Coulomb gauge.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Potential)> VectorPotentialField(
-        Vector3d[] magneticField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        (magneticField.Length == gridPoints.Length) switch {
-            false => ResultFactory.Create<(Point3d[], Vector3d[])>(
-                error: E.Geometry.InvalidVectorPotentialComputation.WithContext("Magnetic field length must match grid points")),
-            true => FieldsCompute.ComputeVectorPotential(
-                vectorField: magneticField,
-                grid: gridPoints,
-                resolution: sampling.Resolution,
-                gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)),
-        };
+    public sealed record LaplacianFieldRequest(double[] ScalarField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds) : FieldOperation;
 
-    /// <summary>Interpolate scalar field at query point: (field, grid, query) → scalar value.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<double> InterpolateScalar(
-        Point3d query,
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds,
-        InterpolationMode? mode = null) =>
-        ResultFactory.Create(value: (Field: scalarField, Grid: gridPoints, Mode: (RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon)) ? new NearestInterpolationMode() : mode ?? new TrilinearInterpolationMode()))
-            .Ensure(state => state.Field.Length == state.Grid.Length, error: E.Geometry.InvalidFieldInterpolation.WithContext("Scalar field length must match grid points"))
-            .Bind(state => FieldsCompute.InterpolateScalar(query: query, scalarField: state.Field, grid: state.Grid, resolution: sampling.Resolution, bounds: bounds, mode: state.Mode));
+    public sealed record VectorPotentialFieldRequest(Vector3d[] VectorField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds) : FieldOperation;
 
-    /// <summary>Interpolate vector field at query point: (field, grid, query) → vector value.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<Vector3d> InterpolateVector(
-        Point3d query,
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds,
-        InterpolationMode? mode = null) =>
-        ResultFactory.Create(value: (Field: vectorField, Grid: gridPoints, Mode: (RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon)) ? new NearestInterpolationMode() : mode ?? new TrilinearInterpolationMode()))
-            .Ensure(state => state.Field.Length == state.Grid.Length, error: E.Geometry.InvalidFieldInterpolation.WithContext("Vector field length must match grid points"))
-            .Bind(state => FieldsCompute.InterpolateVector(query: query, vectorField: state.Field, grid: state.Grid, resolution: sampling.Resolution, bounds: bounds, mode: state.Mode));
+    public sealed record ScalarInterpolationRequest(
+        Point3d Query,
+        double[] ScalarField,
+        Point3d[] Grid,
+        FieldSampling Sampling,
+        BoundingBox Bounds,
+        InterpolationMode Mode) : FieldOperation {
+        public ScalarInterpolationRequest(Point3d Query, double[] ScalarField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds)
+            : this(Query, ScalarField, Grid, Sampling, Bounds, new TrilinearInterpolationMode()) { }
+    }
 
-    /// <summary>Trace streamlines along vector field: (field, seeds) → curves[].</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<Curve[]> Streamlines(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        Point3d[] seeds,
-        FieldSampling sampling,
-        BoundingBox bounds,
-        IGeometryContext context,
-        IntegrationScheme? scheme = null) =>
-        ResultFactory.Create(value: (vectorField, gridPoints, seeds))
-            .Ensure(state => state.vectorField.Length == state.gridPoints.Length, error: E.Geometry.InvalidScalarField.WithContext("Vector field length must match grid points"))
-            .Ensure(state => state.seeds.Length > 0, error: E.Geometry.InvalidStreamlineSeeds)
-            .Bind(state => FieldsCompute.IntegrateStreamlines(
-                vectorField: state.vectorField,
-                gridPoints: state.gridPoints,
-                seeds: state.seeds,
-                stepSize: sampling.StepSize,
-                scheme: scheme ?? new RungeKutta4IntegrationScheme(),
-                resolution: sampling.Resolution,
-                bounds: bounds,
-                context: context));
+    public sealed record VectorInterpolationRequest(
+        Point3d Query,
+        Vector3d[] VectorField,
+        Point3d[] Grid,
+        FieldSampling Sampling,
+        BoundingBox Bounds,
+        InterpolationMode Mode) : FieldOperation {
+        public VectorInterpolationRequest(Point3d Query, Vector3d[] VectorField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds)
+            : this(Query, VectorField, Grid, Sampling, Bounds, new TrilinearInterpolationMode()) { }
+    }
 
-    /// <summary>Extract isosurfaces from scalar field: (field, isovalues) → meshes[].</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<Mesh[]> Isosurfaces(
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        double[] isovalues) =>
-        ResultFactory.Create(value: (ScalarField: scalarField, GridPoints: gridPoints, Isovalues: isovalues))
-            .Ensure(state => state.ScalarField.Length == state.GridPoints.Length, error: E.Geometry.InvalidScalarField.WithContext("Scalar field length must match grid points"))
-            .Ensure(state => state.Isovalues.Length > 0, error: E.Geometry.InvalidIsovalue.WithContext("At least one isovalue required"))
-            .Ensure(v => v.Isovalues.All(value => RhinoMath.IsValidDouble(value)), error: E.Geometry.InvalidIsovalue.WithContext("All isovalues must be valid doubles"))
-            .Bind(state => FieldsCompute.ExtractIsosurfaces(
-                scalarField: state.ScalarField,
-                gridPoints: state.GridPoints,
-                resolution: sampling.Resolution,
-                isovalues: state.Isovalues));
+    public sealed record StreamlineRequest(
+        Vector3d[] VectorField,
+        Point3d[] Grid,
+        Point3d[] Seeds,
+        FieldSampling Sampling,
+        BoundingBox Bounds,
+        IntegrationScheme Scheme) : FieldOperation {
+        public StreamlineRequest(Vector3d[] VectorField, Point3d[] Grid, Point3d[] Seeds, FieldSampling Sampling, BoundingBox Bounds)
+            : this(VectorField, Grid, Seeds, Sampling, Bounds, new RungeKutta4IntegrationScheme()) { }
+    }
 
-    /// <summary>Compute Hessian field: scalar field → (grid points[], 3×3 hessian matrices[]) assuming uniform grid spacing.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1814:Prefer jagged arrays over multidimensional", Justification = "3x3 symmetric matrix structure is mathematically clear and appropriate")]
-    public static Result<(Point3d[] Grid, double[,][] Hessian)> HessianField(
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (ScalarField: scalarField, GridPoints: gridPoints))
-            .Ensure(v => v.ScalarField.Length == v.GridPoints.Length, error: E.Geometry.InvalidHessianComputation.WithContext("Scalar field length must match grid points"))
-            .Bind(state => FieldsCompute.ComputeHessian(
-                scalarField: state.ScalarField,
-                grid: state.GridPoints,
-                resolution: sampling.Resolution,
-                gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    public sealed record IsosurfaceRequest(double[] ScalarField, Point3d[] Grid, FieldSampling Sampling, double[] Isovalues) : FieldOperation;
 
-    /// <summary>Compute directional derivative field: (gradient field, direction) → (grid points[], directional derivatives[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] DirectionalDerivatives)> DirectionalDerivativeField(
-        Vector3d[] gradientField,
-        Point3d[] gridPoints,
-        Vector3d direction) =>
-        ResultFactory.Create(value: (gradientField, gridPoints))
-            .Ensure(v => v.gradientField.Length == v.gridPoints.Length, error: E.Geometry.InvalidDirectionalDerivative.WithContext("Gradient field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeDirectionalDerivative(gradientField: gradientField, grid: gridPoints, direction: direction));
+    public sealed record HessianFieldRequest(double[] ScalarField, Point3d[] Grid, FieldSampling Sampling, BoundingBox Bounds) : FieldOperation;
 
-    /// <summary>Compute vector field magnitude: vector field → (grid points[], magnitudes[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Magnitudes)> FieldMagnitude(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldMagnitude.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeFieldMagnitude(vectorField: vectorField, grid: gridPoints));
+    public sealed record DirectionalDerivativeRequest(Vector3d[] GradientField, Point3d[] Grid, Vector3d Direction) : FieldOperation;
 
-    /// <summary>Normalize vector field: vector field → (grid points[], normalized vectors[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Normalized)> NormalizeField(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldNormalization.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.NormalizeVectorField(vectorField: vectorField, grid: gridPoints));
+    public sealed record FieldMagnitudeRequest(Vector3d[] VectorField, Point3d[] Grid) : FieldOperation;
 
-    /// <summary>Scalar-vector field product: (scalar field, vector field, component) → (grid points[], product[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Product)> ScalarVectorProduct(
-        double[] scalarField,
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        VectorComponent component) =>
-        ResultFactory.Create(value: (scalarField, vectorField, gridPoints))
-            .Ensure(v => v.scalarField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("Scalar field length must match grid points"))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ScalarVectorProduct(scalarField: scalarField, vectorField: vectorField, grid: gridPoints, component: component));
+    public sealed record NormalizeFieldRequest(Vector3d[] VectorField, Point3d[] Grid) : FieldOperation;
 
-    /// <summary>Vector-vector dot product field: (vector field 1, vector field 2) → (grid points[], dot products[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] DotProduct)> VectorDotProduct(
-        Vector3d[] vectorField1,
-        Vector3d[] vectorField2,
-        Point3d[] gridPoints) =>
-        ResultFactory.Create(value: (vectorField1, vectorField2, gridPoints))
-            .Ensure(v => v.vectorField1.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("First vector field length must match grid points"))
-            .Ensure(v => v.vectorField2.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("Second vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.VectorDotProduct(vectorField1: vectorField1, vectorField2: vectorField2, grid: gridPoints));
+    public sealed record ScalarVectorProductRequest(double[] ScalarField, Vector3d[] VectorField, Point3d[] Grid, VectorComponent Component) : FieldOperation;
 
-    /// <summary>Detect and classify critical points: (scalar field, gradient, hessian) → critical points[] classified as min/max/saddle.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1814:Prefer jagged arrays over multidimensional", Justification = "3x3 Hessian matrix parameter is mathematically appropriate")]
-    public static Result<CriticalPoint[]> CriticalPoints(
-        double[] scalarField,
-        Vector3d[] gradientField,
-        double[,][] hessian,
-        Point3d[] gridPoints,
-        FieldSampling sampling) =>
-        (hessian.GetLength(0) == 3
-            && hessian.GetLength(1) == 3
-            && Enumerable.Range(0, 3).All(row =>
-                Enumerable.Range(0, 3).All(col =>
-                    hessian[row, col] is not null
-                    && hessian[row, col].Length == gridPoints.Length))) switch {
-                        false => ResultFactory.Create<CriticalPoint[]>(
-                            error: E.Geometry.InvalidCriticalPointDetection.WithContext("Hessian must be a 3x3 tensor with entries per grid sample")),
-                        true => FieldsCompute.DetectCriticalPoints(
-                            scalarField: scalarField,
-                            gradientField: gradientField,
-                            hessian: hessian,
-                            grid: gridPoints,
-                            resolution: sampling.Resolution),
-                    };
+    public sealed record VectorDotProductRequest(Vector3d[] FirstField, Vector3d[] SecondField, Point3d[] Grid) : FieldOperation;
 
-    /// <summary>Compute field statistics: scalar field → (min, max, mean, stddev, extreme locations).</summary>
+    public sealed record CriticalPointsRequest(double[] ScalarField, Vector3d[] GradientField, double[,][] Hessian, Point3d[] Grid, FieldSampling Sampling) : FieldOperation;
+
+    public sealed record FieldStatisticsRequest(double[] ScalarField, Point3d[] Grid) : FieldOperation;
+
+    /// <summary>Compute signed distance field samples.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<FieldStatistics> ComputeStatistics(
-        double[] scalarField,
-        Point3d[] gridPoints) =>
-        (scalarField.Length == gridPoints.Length) switch {
-            false => ResultFactory.Create<FieldStatistics>(
-                error: E.Geometry.InvalidFieldStatistics.WithContext("Scalar field length must match grid points")),
-            true => FieldsCompute.ComputeFieldStatistics(
-                scalarField: scalarField,
-                grid: gridPoints),
-        };
+    public static Result<ScalarFieldSamples> DistanceField(DistanceFieldRequest request, IGeometryContext context) =>
+        FieldsCore.DistanceField(request: request, context: context);
+
+    /// <summary>Compute gradient field samples from geometry.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<VectorFieldSamples> GradientField(GradientFieldRequest request, IGeometryContext context) =>
+        FieldsCore.GradientField(request: request, context: context);
+
+    /// <summary>Compute curl of a vector field.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<VectorFieldSamples> CurlField(CurlFieldRequest request, IGeometryContext context) =>
+        FieldsCore.CurlField(request: request, context: context);
+
+    /// <summary>Compute divergence of a vector field.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<ScalarFieldSamples> DivergenceField(DivergenceFieldRequest request, IGeometryContext context) =>
+        FieldsCore.DivergenceField(request: request, context: context);
+
+    /// <summary>Compute Laplacian of a scalar field.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<ScalarFieldSamples> LaplacianField(LaplacianFieldRequest request, IGeometryContext context) =>
+        FieldsCore.LaplacianField(request: request, context: context);
+
+    /// <summary>Compute vector potential satisfying ∇²A = -∇×B.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<VectorFieldSamples> VectorPotentialField(VectorPotentialFieldRequest request, IGeometryContext context) =>
+        FieldsCore.VectorPotentialField(request: request, context: context);
+
+    /// <summary>Interpolate scalar field at query point.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<double> InterpolateScalar(ScalarInterpolationRequest request, IGeometryContext context) =>
+        FieldsCore.InterpolateScalar(request: request, context: context);
+
+    /// <summary>Interpolate vector field at query point.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<Vector3d> InterpolateVector(VectorInterpolationRequest request, IGeometryContext context) =>
+        FieldsCore.InterpolateVector(request: request, context: context);
+
+    /// <summary>Trace streamlines along vector field.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<Curve[]> Streamlines(StreamlineRequest request, IGeometryContext context) =>
+        FieldsCore.Streamlines(request: request, context: context);
+
+    /// <summary>Extract isosurfaces from scalar field.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<Mesh[]> Isosurfaces(IsosurfaceRequest request, IGeometryContext context) =>
+        FieldsCore.Isosurfaces(request: request, context: context);
+
+    /// <summary>Compute Hessian tensor field from scalar field samples.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<HessianFieldSamples> HessianField(HessianFieldRequest request, IGeometryContext context) =>
+        FieldsCore.HessianField(request: request, context: context);
+
+    /// <summary>Compute directional derivative field along vector.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<ScalarFieldSamples> DirectionalDerivativeField(DirectionalDerivativeRequest request, IGeometryContext context) =>
+        FieldsCore.DirectionalDerivativeField(request: request, context: context);
+
+    /// <summary>Compute vector field magnitude.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<ScalarFieldSamples> FieldMagnitude(FieldMagnitudeRequest request, IGeometryContext context) =>
+        FieldsCore.FieldMagnitude(request: request, context: context);
+
+    /// <summary>Normalize vector field samples.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<VectorFieldSamples> NormalizeField(NormalizeFieldRequest request, IGeometryContext context) =>
+        FieldsCore.NormalizeField(request: request, context: context);
+
+    /// <summary>Compute scalar-vector product field for a selected component.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<ScalarFieldSamples> ScalarVectorProduct(ScalarVectorProductRequest request, IGeometryContext context) =>
+        FieldsCore.ScalarVectorProduct(request: request, context: context);
+
+    /// <summary>Compute dot product between two vector fields.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<ScalarFieldSamples> VectorDotProduct(VectorDotProductRequest request, IGeometryContext context) =>
+        FieldsCore.VectorDotProduct(request: request, context: context);
+
+    /// <summary>Detect and classify critical points.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<CriticalPoint[]> CriticalPoints(CriticalPointsRequest request, IGeometryContext context) =>
+        FieldsCore.CriticalPoints(request: request, context: context);
+
+    /// <summary>Compute descriptive statistics for scalar field samples.</summary>
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Result<FieldStatistics> ComputeStatistics(FieldStatisticsRequest request, IGeometryContext context) =>
+        FieldsCore.ComputeStatistics(request: request, context: context);
 }

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -9,10 +9,11 @@ namespace Arsenal.Rhino.Fields;
 /// <summary>Configuration constants for fields operations.</summary>
 [Pure]
 internal static class FieldsConfig {
-    /// <summary>Distance field metadata containing validation mode, operation name, and buffer size.</summary>
+    /// <summary>Distance field metadata containing validation mode and operation names.</summary>
     internal sealed record DistanceFieldMetadata(
         V ValidationMode,
-        string OperationName,
+        string DistanceOperationName,
+        string GradientOperationName,
         int BufferSize);
 
     /// <summary>Distance field configuration by geometry type.</summary>
@@ -20,21 +21,51 @@ internal static class FieldsConfig {
         new Dictionary<Type, DistanceFieldMetadata> {
             [typeof(Mesh)] = new(
                 ValidationMode: V.Standard | V.MeshSpecific,
-                OperationName: "Fields.MeshDistance",
+                DistanceOperationName: "Fields.MeshDistance",
+                GradientOperationName: "Fields.MeshGradient",
                 BufferSize: 4096),
             [typeof(Brep)] = new(
                 ValidationMode: V.Standard | V.Topology,
-                OperationName: "Fields.BrepDistance",
+                DistanceOperationName: "Fields.BrepDistance",
+                GradientOperationName: "Fields.BrepGradient",
                 BufferSize: 8192),
             [typeof(Curve)] = new(
                 ValidationMode: V.Standard | V.Degeneracy,
-                OperationName: "Fields.CurveDistance",
+                DistanceOperationName: "Fields.CurveDistance",
+                GradientOperationName: "Fields.CurveGradient",
                 BufferSize: 2048),
             [typeof(Surface)] = new(
                 ValidationMode: V.Standard | V.BoundingBox,
-                OperationName: "Fields.SurfaceDistance",
+                DistanceOperationName: "Fields.SurfaceDistance",
+                GradientOperationName: "Fields.SurfaceGradient",
                 BufferSize: 4096),
         }.ToFrozenDictionary();
+
+    /// <summary>General field operation metadata keyed by request type.</summary>
+    internal static readonly FrozenDictionary<Type, FieldOperationMetadata> FieldOperations =
+        new Dictionary<Type, FieldOperationMetadata> {
+            [typeof(Fields.CurlFieldRequest)] = new(V.None, "Fields.Curl"),
+            [typeof(Fields.DivergenceFieldRequest)] = new(V.None, "Fields.Divergence"),
+            [typeof(Fields.LaplacianFieldRequest)] = new(V.None, "Fields.Laplacian"),
+            [typeof(Fields.VectorPotentialFieldRequest)] = new(V.None, "Fields.VectorPotential"),
+            [typeof(Fields.ScalarInterpolationRequest)] = new(V.None, "Fields.ScalarInterpolation"),
+            [typeof(Fields.VectorInterpolationRequest)] = new(V.None, "Fields.VectorInterpolation"),
+            [typeof(Fields.StreamlineRequest)] = new(V.None, "Fields.Streamlines"),
+            [typeof(Fields.IsosurfaceRequest)] = new(V.None, "Fields.Isosurfaces"),
+            [typeof(Fields.HessianFieldRequest)] = new(V.None, "Fields.Hessian"),
+            [typeof(Fields.DirectionalDerivativeRequest)] = new(V.None, "Fields.DirectionalDerivative"),
+            [typeof(Fields.FieldMagnitudeRequest)] = new(V.None, "Fields.Magnitude"),
+            [typeof(Fields.NormalizeFieldRequest)] = new(V.None, "Fields.Normalize"),
+            [typeof(Fields.ScalarVectorProductRequest)] = new(V.None, "Fields.ScalarVectorProduct"),
+            [typeof(Fields.VectorDotProductRequest)] = new(V.None, "Fields.VectorDotProduct"),
+            [typeof(Fields.CriticalPointsRequest)] = new(V.None, "Fields.CriticalPoints"),
+            [typeof(Fields.FieldStatisticsRequest)] = new(V.None, "Fields.Statistics"),
+        }.ToFrozenDictionary();
+
+    /// <summary>Metadata for dataset-driven field operations.</summary>
+    internal sealed record FieldOperationMetadata(
+        V ValidationMode,
+        string OperationName);
 
     /// <summary>Field sampling resolution limits: default 32, range [8, 256].</summary>
     internal const int DefaultResolution = 32;

--- a/libs/rhino/fields/FieldsCore.cs
+++ b/libs/rhino/fields/FieldsCore.cs
@@ -6,6 +6,7 @@ using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
+using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Fields;
@@ -13,57 +14,263 @@ namespace Arsenal.Rhino.Fields;
 /// <summary>Fields dispatch registry with UnifiedOperation integration.</summary>
 [Pure]
 internal static class FieldsCore {
-    private sealed record DistanceOperationMetadata(
-        Func<GeometryBase, Fields.FieldSampling, int, IGeometryContext, Result<IReadOnlyList<(Point3d[], double[])>>> Executor,
+    private sealed record DistanceOperationEntry(
+        Func<GeometryBase, Fields.FieldSampling, BoundingBox, int, IGeometryContext, Result<Fields.ScalarFieldSamples>> Executor,
         FieldsConfig.DistanceFieldMetadata Metadata);
 
-    private static readonly FrozenDictionary<Type, DistanceOperationMetadata> DistanceDispatch =
+    private static readonly FrozenDictionary<Type, DistanceOperationEntry> DistanceDispatch =
         FieldsConfig.DistanceFields
             .ToDictionary(
                 keySelector: static entry => entry.Key,
-                elementSelector: static entry => new DistanceOperationMetadata(
+                elementSelector: static entry => new DistanceOperationEntry(
                     Executor: entry.Key == typeof(Mesh)
-                        ? static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Mesh>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,])
+                        ? static (geometry, sampling, bounds, bufferSize, context) => ExecuteDistanceField<Mesh>(geometry, sampling, bounds, bufferSize, context)
                         : entry.Key == typeof(Brep)
-                            ? static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Brep>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,])
+                            ? static (geometry, sampling, bounds, bufferSize, context) => ExecuteDistanceField<Brep>(geometry, sampling, bounds, bufferSize, context)
                             : entry.Key == typeof(Curve)
-                                ? static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Curve>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,])
-                                : static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Surface>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,]),
+                                ? static (geometry, sampling, bounds, bufferSize, context) => ExecuteDistanceField<Curve>(geometry, sampling, bounds, bufferSize, context)
+                                : static (geometry, sampling, bounds, bufferSize, context) => ExecuteDistanceField<Surface>(geometry, sampling, bounds, bufferSize, context),
                     Metadata: entry.Value))
             .ToFrozenDictionary();
 
-    [Pure]
-    internal static Result<(Point3d[] Grid, double[] Distances)> DistanceField(
+    internal static Result<Fields.ScalarFieldSamples> DistanceField(Fields.DistanceFieldRequest request, IGeometryContext context) =>
+        ExecuteGeometryOperation(
+            geometry: request.Geometry,
+            sampling: request.Sampling,
+            context: context,
+            operationNameSelector: static meta => meta.DistanceOperationName,
+            executor: static (geometry, sampling, bounds, entry, ctx) =>
+                entry.Executor(geometry, sampling, bounds, entry.Metadata.BufferSize, ctx));
+
+    internal static Result<Fields.VectorFieldSamples> GradientField(Fields.GradientFieldRequest request, IGeometryContext context) =>
+        ExecuteGeometryOperation(
+            geometry: request.Geometry,
+            sampling: request.Sampling,
+            context: context,
+            operationNameSelector: static meta => meta.GradientOperationName,
+            executor: static (geometry, sampling, bounds, entry, ctx) =>
+                entry.Executor(geometry, sampling, bounds, entry.Metadata.BufferSize, ctx)
+                    .Bind(distance => FieldsCompute.ComputeGradient(
+                        distances: distance.Values,
+                        grid: distance.Grid,
+                        resolution: sampling.Resolution,
+                        gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1))));
+
+    internal static Result<Fields.VectorFieldSamples> CurlField(Fields.CurlFieldRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeCurl(
+                vectorField: item.VectorField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                gridDelta: (item.Bounds.Max - item.Bounds.Min) / (item.Sampling.Resolution - 1)));
+
+    internal static Result<Fields.ScalarFieldSamples> DivergenceField(Fields.DivergenceFieldRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeDivergence(
+                vectorField: item.VectorField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                gridDelta: (item.Bounds.Max - item.Bounds.Min) / (item.Sampling.Resolution - 1)));
+
+    internal static Result<Fields.ScalarFieldSamples> LaplacianField(Fields.LaplacianFieldRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeLaplacian(
+                scalarField: item.ScalarField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                gridDelta: (item.Bounds.Max - item.Bounds.Min) / (item.Sampling.Resolution - 1)));
+
+    internal static Result<Fields.VectorFieldSamples> VectorPotentialField(Fields.VectorPotentialFieldRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeVectorPotential(
+                vectorField: item.VectorField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                gridDelta: (item.Bounds.Max - item.Bounds.Min) / (item.Sampling.Resolution - 1)));
+
+    internal static Result<double> InterpolateScalar(Fields.ScalarInterpolationRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.InterpolateScalar(
+                query: item.Query,
+                scalarField: item.ScalarField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                bounds: item.Bounds,
+                mode: RequiresNearest(item.Bounds) ? new Fields.NearestInterpolationMode() : item.Mode));
+
+    internal static Result<Vector3d> InterpolateVector(Fields.VectorInterpolationRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.InterpolateVector(
+                query: item.Query,
+                vectorField: item.VectorField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                bounds: item.Bounds,
+                mode: RequiresNearest(item.Bounds) ? new Fields.NearestInterpolationMode() : item.Mode));
+
+    internal static Result<Curve[]> Streamlines(Fields.StreamlineRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: item => FieldsCompute.IntegrateStreamlines(
+                vectorField: item.VectorField,
+                gridPoints: item.Grid,
+                seeds: item.Seeds,
+                stepSize: item.Sampling.StepSize,
+                scheme: item.Scheme,
+                resolution: item.Sampling.Resolution,
+                bounds: item.Bounds,
+                context: context));
+
+    internal static Result<Mesh[]> Isosurfaces(Fields.IsosurfaceRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ExtractIsosurfaces(
+                scalarField: item.ScalarField,
+                gridPoints: item.Grid,
+                resolution: item.Sampling.Resolution,
+                isovalues: item.Isovalues));
+
+    internal static Result<Fields.HessianFieldSamples> HessianField(Fields.HessianFieldRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeHessian(
+                scalarField: item.ScalarField,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution,
+                gridDelta: (item.Bounds.Max - item.Bounds.Min) / (item.Sampling.Resolution - 1)));
+
+    internal static Result<Fields.ScalarFieldSamples> DirectionalDerivativeField(Fields.DirectionalDerivativeRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeDirectionalDerivative(
+                gradientField: item.GradientField,
+                grid: item.Grid,
+                direction: item.Direction));
+
+    internal static Result<Fields.ScalarFieldSamples> FieldMagnitude(Fields.FieldMagnitudeRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeFieldMagnitude(
+                vectorField: item.VectorField,
+                grid: item.Grid));
+
+    internal static Result<Fields.VectorFieldSamples> NormalizeField(Fields.NormalizeFieldRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.NormalizeVectorField(
+                vectorField: item.VectorField,
+                grid: item.Grid));
+
+    internal static Result<Fields.ScalarFieldSamples> ScalarVectorProduct(Fields.ScalarVectorProductRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ScalarVectorProduct(
+                scalarField: item.ScalarField,
+                vectorField: item.VectorField,
+                grid: item.Grid,
+                component: item.Component));
+
+    internal static Result<Fields.ScalarFieldSamples> VectorDotProduct(Fields.VectorDotProductRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.VectorDotProduct(
+                vectorField1: item.FirstField,
+                vectorField2: item.SecondField,
+                grid: item.Grid));
+
+    internal static Result<Fields.CriticalPoint[]> CriticalPoints(Fields.CriticalPointsRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.DetectCriticalPoints(
+                scalarField: item.ScalarField,
+                gradientField: item.GradientField,
+                hessian: item.Hessian,
+                grid: item.Grid,
+                resolution: item.Sampling.Resolution));
+
+    internal static Result<Fields.FieldStatistics> ComputeStatistics(Fields.FieldStatisticsRequest request, IGeometryContext context) =>
+        ExecuteOperation(
+            request: request,
+            context: context,
+            executor: static item => FieldsCompute.ComputeFieldStatistics(
+                scalarField: item.ScalarField,
+                grid: item.Grid));
+
+    private static Result<TOut> ExecuteGeometryOperation<TOut>(
         GeometryBase geometry,
         Fields.FieldSampling sampling,
-        IGeometryContext context) =>
+        IGeometryContext context,
+        Func<FieldsConfig.DistanceFieldMetadata, string> operationNameSelector,
+        Func<GeometryBase, Fields.FieldSampling, BoundingBox, DistanceOperationEntry, IGeometryContext, Result<TOut>> executor) =>
         geometry is null
-            ? ResultFactory.Create<(Point3d[], double[])>(
-                error: E.Geometry.UnsupportedAnalysis.WithContext("Geometry cannot be null"))
-            : !DistanceDispatch.TryGetValue(geometry.GetType(), out DistanceOperationMetadata? metadata)
-                ? ResultFactory.Create<(Point3d[], double[])>(
-                    error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {geometry.GetType().Name}"))
+            ? ResultFactory.Create<TOut>(error: E.Geometry.UnsupportedAnalysis.WithContext("Geometry cannot be null"))
+            : !DistanceDispatch.TryGetValue(geometry.GetType(), out DistanceOperationEntry? entry)
+                ? ResultFactory.Create<TOut>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {geometry.GetType().Name}"))
                 : UnifiedOperation.Apply(
                     input: geometry,
-                    operation: (Func<GeometryBase, Result<IReadOnlyList<(Point3d[], double[])>>>)(item => metadata.Executor(item, sampling, metadata.Metadata.BufferSize, context)),
-                    config: new OperationConfig<GeometryBase, (Point3d[], double[])> {
+                    operation: (Func<GeometryBase, Result<IReadOnlyList<TOut>>>)(item => {
+                        BoundingBox bounds = sampling.Bounds ?? item.GetBoundingBox(accurate: true);
+                        return !bounds.IsValid
+                            ? ResultFactory.Create<IReadOnlyList<TOut>>(error: E.Geometry.InvalidFieldBounds)
+                            : executor(item, sampling, bounds, entry, context)
+                                .Map(result => (IReadOnlyList<TOut>)[result,]);
+                    }),
+                    config: new OperationConfig<GeometryBase, TOut> {
                         Context = context,
-                        ValidationMode = metadata.Metadata.ValidationMode,
-                        OperationName = metadata.Metadata.OperationName,
-                        EnableDiagnostics = false,
-                    }).Map(results => results[0]);
+                        ValidationMode = entry.Metadata.ValidationMode,
+                        OperationName = operationNameSelector(entry.Metadata),
+                    }).Map(result => result[0]);
+
+    private static Result<TOut> ExecuteOperation<TRequest, TOut>(
+        TRequest request,
+        IGeometryContext context,
+        Func<TRequest, Result<TOut>> executor) where TRequest : Fields.FieldOperation =>
+        !FieldsConfig.FieldOperations.TryGetValue(typeof(TRequest), out FieldsConfig.FieldOperationMetadata? metadata)
+            ? ResultFactory.Create<TOut>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Unsupported field request: {typeof(TRequest).Name}"))
+            : UnifiedOperation.Apply(
+                input: request,
+                operation: (Func<TRequest, Result<IReadOnlyList<TOut>>>)(item => executor(item).Map(value => (IReadOnlyList<TOut>)[value,])),
+                config: new OperationConfig<TRequest, TOut> {
+                    Context = context,
+                    ValidationMode = metadata.ValidationMode,
+                    OperationName = metadata.OperationName,
+                }).Map(result => result[0]);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool RequiresNearest(BoundingBox bounds) =>
+        RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon)
+            || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon)
+            || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<(Point3d[], double[])> ExecuteDistanceField<T>(
+    private static Result<Fields.ScalarFieldSamples> ExecuteDistanceField<T>(
         GeometryBase geometry,
         Fields.FieldSampling sampling,
+        BoundingBox bounds,
         int bufferSize,
         IGeometryContext context) where T : GeometryBase {
         T typed = (T)geometry;
-        BoundingBox bounds = sampling.Bounds ?? typed.GetBoundingBox(accurate: true);
-        if (!bounds.IsValid) {
-            return ResultFactory.Create<(Point3d[], double[])>(error: E.Geometry.InvalidFieldBounds);
-        }
         int resolution = sampling.Resolution;
         int totalSamples = resolution * resolution * resolution;
         int actualBufferSize = Math.Max(totalSamples, bufferSize);
@@ -75,16 +282,20 @@ internal static class FieldsCore {
             for (int i = 0; i < resolution; i++) {
                 for (int j = 0; j < resolution; j++) {
                     for (int k = 0; k < resolution; k++) {
-                        grid[gridIndex++] = new(bounds.Min.X + (i * delta.X), bounds.Min.Y + (j * delta.Y), bounds.Min.Z + (k * delta.Z));
+                        grid[gridIndex++] = new(
+                            bounds.Min.X + (i * delta.X),
+                            bounds.Min.Y + (j * delta.Y),
+                            bounds.Min.Z + (k * delta.Z));
                     }
                 }
             }
+
             for (int i = 0; i < totalSamples; i++) {
                 Point3d closest = typed switch {
-                    Mesh m => m.ClosestPoint(grid[i]),
-                    Brep b => b.ClosestPoint(grid[i]),
-                    Curve c => c.ClosestPoint(grid[i], out double t) ? c.PointAt(t) : grid[i],
-                    Surface s => s.ClosestPoint(grid[i], out double u, out double v) ? s.PointAt(u, v) : grid[i],
+                    Mesh mesh => mesh.ClosestPoint(grid[i]),
+                    Brep brep => brep.ClosestPoint(grid[i]),
+                    Curve curve => curve.ClosestPoint(grid[i], out double t) ? curve.PointAt(t) : grid[i],
+                    Surface surface => surface.ClosestPoint(grid[i], out double u, out double v) ? surface.PointAt(u, v) : grid[i],
                     _ => grid[i],
                 };
                 double unsignedDist = grid[i].DistanceTo(closest);
@@ -95,9 +306,10 @@ internal static class FieldsCore {
                 };
                 distances[i] = inside ? -unsignedDist : unsignedDist;
             }
+
             Point3d[] finalGrid = [.. grid[..totalSamples]];
             double[] finalDistances = [.. distances[..totalSamples]];
-            return ResultFactory.Create(value: (Grid: finalGrid, Distances: finalDistances));
+            return ResultFactory.Create(value: new Fields.ScalarFieldSamples(finalGrid, finalDistances));
         } finally {
             ArrayPool<Point3d>.Shared.Return(grid, clearArray: true);
             ArrayPool<double>.Shared.Return(distances, clearArray: true);


### PR DESCRIPTION
## Summary
- redesign `Fields` public API around algebraic request records and shared result structs
- consolidate field operation metadata and dispatch in `FieldsConfig`/`FieldsCore` with `UnifiedOperation`
- update compute layer to produce strongly typed results and add the missing validations

## Testing
- dotnet build *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da00059a88321a00bc39d5a08facf)