### PR TITLE
Refactor fields API to unified operations

### DIFF
--- a/libs/rhino/fields/Fields.cs
+++ b/libs/rhino/fields/Fields.cs
@@ -1,15 +1,13 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
-using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Fields;
 
-/// <summary>Scalar and vector field operations for computational field analysis.</summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MA0049:Type name should not match containing namespace", Justification = "Fields is the primary API entry point")]
+/// <summary>Scalar and vector field operations modeled as algebraic requests.</summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MA0049:Type name should not match containing namespace", Justification = "Fields is the public API entry point")]
 public static class Fields {
     /// <summary>Field sampling specification with grid resolution, bounds, and step size.</summary>
     public sealed record FieldSampling {
@@ -25,47 +23,62 @@ public static class Fields {
                 FieldsConfig.MinStepSize,
                 FieldsConfig.MaxStepSize);
         }
+
         /// <summary>Default sampling instance (resolution: 32, step size: 0.01).</summary>
         public static FieldSampling Default { get; } = new();
+
         /// <summary>Grid resolution (cube root of sample count), clamped to [8, 256].</summary>
         public int Resolution { get; }
+
         /// <summary>Sample region bounding box (null uses geometry bounds).</summary>
         public BoundingBox? Bounds { get; }
+
         /// <summary>Integration/sampling step size, clamped to [√ε, 1.0].</summary>
         public double StepSize { get; }
     }
 
     /// <summary>Base type for field interpolation strategies.</summary>
     public abstract record InterpolationMode;
+
     /// <summary>Nearest-neighbor interpolation.</summary>
     public sealed record NearestInterpolationMode : InterpolationMode;
+
     /// <summary>Trilinear interpolation.</summary>
     public sealed record TrilinearInterpolationMode : InterpolationMode;
 
     /// <summary>Base type for streamline integration methods.</summary>
     public abstract record IntegrationScheme;
+
     /// <summary>Explicit Euler integration.</summary>
     public sealed record EulerIntegrationScheme : IntegrationScheme;
+
     /// <summary>Midpoint (RK2) integration.</summary>
     public sealed record MidpointIntegrationScheme : IntegrationScheme;
+
     /// <summary>Classical RK4 integration.</summary>
     public sealed record RungeKutta4IntegrationScheme : IntegrationScheme;
 
     /// <summary>Vector component selector for field composition.</summary>
     public abstract record VectorComponent;
+
     /// <summary>X-component selector.</summary>
     public sealed record XComponent : VectorComponent;
+
     /// <summary>Y-component selector.</summary>
     public sealed record YComponent : VectorComponent;
+
     /// <summary>Z-component selector.</summary>
     public sealed record ZComponent : VectorComponent;
 
     /// <summary>Critical point classification.</summary>
     public abstract record CriticalPointKind;
+
     /// <summary>Local minimum point.</summary>
     public sealed record MinimumCriticalPoint : CriticalPointKind;
+
     /// <summary>Local maximum point.</summary>
     public sealed record MaximumCriticalPoint : CriticalPointKind;
+
     /// <summary>Saddle point.</summary>
     public sealed record SaddleCriticalPoint : CriticalPointKind;
 
@@ -77,252 +90,74 @@ public static class Fields {
     [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
     public readonly record struct FieldStatistics(double Min, double Max, double Mean, double StdDev, Point3d MinLocation, Point3d MaxLocation);
 
-    /// <summary>Compute signed distance field: geometry → (grid points[], distances[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Distances)> DistanceField<T>(
-        T geometry,
-        FieldSampling? sampling,
-        IGeometryContext context) where T : GeometryBase =>
-        FieldsCore.DistanceField(
-            geometry: geometry,
-            sampling: sampling ?? FieldSampling.Default,
-            context: context);
+    /// <summary>Scalar field samples with grid data and sampling metadata.</summary>
+    public sealed record ScalarFieldSamples(Point3d[] Grid, double[] Values, FieldSampling Sampling, BoundingBox Bounds);
 
-    /// <summary>Compute gradient field: geometry → (grid points[], gradient vectors[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Gradients)> GradientField<T>(
-        T geometry,
-        FieldSampling? sampling,
-        IGeometryContext context) where T : GeometryBase =>
-        DistanceField(geometry: geometry, sampling: sampling, context: context).Bind(distanceField => {
-            FieldSampling samplingValue = sampling ?? FieldSampling.Default;
-            BoundingBox bounds = samplingValue.Bounds ?? geometry.GetBoundingBox(accurate: true);
-            Vector3d gridDelta = (bounds.Max - bounds.Min) / (samplingValue.Resolution - 1);
-            return FieldsCompute.ComputeGradient(
-                distances: distanceField.Distances,
-                grid: distanceField.Grid,
-                resolution: samplingValue.Resolution,
-                gridDelta: gridDelta);
-        });
+    /// <summary>Vector field samples with grid data and sampling metadata.</summary>
+    public sealed record VectorFieldSamples(Point3d[] Grid, Vector3d[] Vectors, FieldSampling Sampling, BoundingBox Bounds);
 
-    /// <summary>Compute curl field: vector field → (grid points[], curl vectors[]) where curl = ∇×F with row-major grid order.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Curl)> CurlField(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidCurlComputation.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeCurl(vectorField: vectorField, grid: gridPoints, resolution: sampling.Resolution, gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    /// <summary>Hessian field samples storing tensors per grid point.</summary>
+    public sealed record HessianFieldSamples(Point3d[] Grid, double[,][] Hessians, FieldSampling Sampling, BoundingBox Bounds);
 
-    /// <summary>Compute divergence field: vector field → (grid points[], divergence scalars[]) where divergence = ∇·F with row-major grid order.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Divergence)> DivergenceField(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidDivergenceComputation.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeDivergence(vectorField: vectorField, grid: gridPoints, resolution: sampling.Resolution, gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    /// <summary>Base type for algebraic field operations.</summary>
+    public abstract record FieldOperation<TResult>;
 
-    /// <summary>Compute Laplacian field: scalar field → (grid points[], Laplacian scalars[]) where Laplacian = ∇²f with row-major grid order.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Laplacian)> LaplacianField(
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (scalarField, gridPoints))
-            .Ensure(v => v.scalarField.Length == v.gridPoints.Length, error: E.Geometry.InvalidLaplacianComputation.WithContext("Scalar field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeLaplacian(scalarField: scalarField, grid: gridPoints, resolution: sampling.Resolution, gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    /// <summary>Distance field operation from geometry.</summary>
+    public sealed record DistanceFieldOperation<TGeometry>(TGeometry Geometry, FieldSampling? Sampling = null) : FieldOperation<ScalarFieldSamples> where TGeometry : GeometryBase;
 
-    /// <summary>Compute vector potential field: magnetic field B → (grid points[], vector potential A[]) solving ∇²A = -∇×B in Coulomb gauge.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Potential)> VectorPotentialField(
-        Vector3d[] magneticField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        (magneticField.Length == gridPoints.Length) switch {
-            false => ResultFactory.Create<(Point3d[], Vector3d[])>(
-                error: E.Geometry.InvalidVectorPotentialComputation.WithContext("Magnetic field length must match grid points")),
-            true => FieldsCompute.ComputeVectorPotential(
-                vectorField: magneticField,
-                grid: gridPoints,
-                resolution: sampling.Resolution,
-                gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)),
-        };
+    /// <summary>Gradient computation from scalar field.</summary>
+    public sealed record GradientFieldOperation(ScalarFieldSamples Field) : FieldOperation<VectorFieldSamples>;
 
-    /// <summary>Interpolate scalar field at query point: (field, grid, query) → scalar value.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<double> InterpolateScalar(
-        Point3d query,
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds,
-        InterpolationMode? mode = null) =>
-        ResultFactory.Create(value: (Field: scalarField, Grid: gridPoints, Mode: (RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon)) ? new NearestInterpolationMode() : mode ?? new TrilinearInterpolationMode()))
-            .Ensure(state => state.Field.Length == state.Grid.Length, error: E.Geometry.InvalidFieldInterpolation.WithContext("Scalar field length must match grid points"))
-            .Bind(state => FieldsCompute.InterpolateScalar(query: query, scalarField: state.Field, grid: state.Grid, resolution: sampling.Resolution, bounds: bounds, mode: state.Mode));
+    /// <summary>Curl computation from vector field.</summary>
+    public sealed record CurlFieldOperation(VectorFieldSamples Field) : FieldOperation<VectorFieldSamples>;
 
-    /// <summary>Interpolate vector field at query point: (field, grid, query) → vector value.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<Vector3d> InterpolateVector(
-        Point3d query,
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds,
-        InterpolationMode? mode = null) =>
-        ResultFactory.Create(value: (Field: vectorField, Grid: gridPoints, Mode: (RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon) || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon)) ? new NearestInterpolationMode() : mode ?? new TrilinearInterpolationMode()))
-            .Ensure(state => state.Field.Length == state.Grid.Length, error: E.Geometry.InvalidFieldInterpolation.WithContext("Vector field length must match grid points"))
-            .Bind(state => FieldsCompute.InterpolateVector(query: query, vectorField: state.Field, grid: state.Grid, resolution: sampling.Resolution, bounds: bounds, mode: state.Mode));
+    /// <summary>Divergence computation from vector field.</summary>
+    public sealed record DivergenceFieldOperation(VectorFieldSamples Field) : FieldOperation<ScalarFieldSamples>;
 
-    /// <summary>Trace streamlines along vector field: (field, seeds) → curves[].</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<Curve[]> Streamlines(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        Point3d[] seeds,
-        FieldSampling sampling,
-        BoundingBox bounds,
-        IGeometryContext context,
-        IntegrationScheme? scheme = null) =>
-        ResultFactory.Create(value: (vectorField, gridPoints, seeds))
-            .Ensure(state => state.vectorField.Length == state.gridPoints.Length, error: E.Geometry.InvalidScalarField.WithContext("Vector field length must match grid points"))
-            .Ensure(state => state.seeds.Length > 0, error: E.Geometry.InvalidStreamlineSeeds)
-            .Bind(state => FieldsCompute.IntegrateStreamlines(
-                vectorField: state.vectorField,
-                gridPoints: state.gridPoints,
-                seeds: state.seeds,
-                stepSize: sampling.StepSize,
-                scheme: scheme ?? new RungeKutta4IntegrationScheme(),
-                resolution: sampling.Resolution,
-                bounds: bounds,
-                context: context));
+    /// <summary>Laplacian computation from scalar field.</summary>
+    public sealed record LaplacianFieldOperation(ScalarFieldSamples Field) : FieldOperation<ScalarFieldSamples>;
 
-    /// <summary>Extract isosurfaces from scalar field: (field, isovalues) → meshes[].</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<Mesh[]> Isosurfaces(
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        double[] isovalues) =>
-        ResultFactory.Create(value: (ScalarField: scalarField, GridPoints: gridPoints, Isovalues: isovalues))
-            .Ensure(state => state.ScalarField.Length == state.GridPoints.Length, error: E.Geometry.InvalidScalarField.WithContext("Scalar field length must match grid points"))
-            .Ensure(state => state.Isovalues.Length > 0, error: E.Geometry.InvalidIsovalue.WithContext("At least one isovalue required"))
-            .Ensure(v => v.Isovalues.All(value => RhinoMath.IsValidDouble(value)), error: E.Geometry.InvalidIsovalue.WithContext("All isovalues must be valid doubles"))
-            .Bind(state => FieldsCompute.ExtractIsosurfaces(
-                scalarField: state.ScalarField,
-                gridPoints: state.GridPoints,
-                resolution: sampling.Resolution,
-                isovalues: state.Isovalues));
+    /// <summary>Vector potential computation from vector field.</summary>
+    public sealed record VectorPotentialFieldOperation(VectorFieldSamples Field) : FieldOperation<VectorFieldSamples>;
 
-    /// <summary>Compute Hessian field: scalar field → (grid points[], 3×3 hessian matrices[]) assuming uniform grid spacing.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1814:Prefer jagged arrays over multidimensional", Justification = "3x3 symmetric matrix structure is mathematically clear and appropriate")]
-    public static Result<(Point3d[] Grid, double[,][] Hessian)> HessianField(
-        double[] scalarField,
-        Point3d[] gridPoints,
-        FieldSampling sampling,
-        BoundingBox bounds) =>
-        ResultFactory.Create(value: (ScalarField: scalarField, GridPoints: gridPoints))
-            .Ensure(v => v.ScalarField.Length == v.GridPoints.Length, error: E.Geometry.InvalidHessianComputation.WithContext("Scalar field length must match grid points"))
-            .Bind(state => FieldsCompute.ComputeHessian(
-                scalarField: state.ScalarField,
-                grid: state.GridPoints,
-                resolution: sampling.Resolution,
-                gridDelta: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)));
+    /// <summary>Scalar interpolation query.</summary>
+    public sealed record ScalarInterpolationOperation(ScalarFieldSamples Field, Point3d Query, InterpolationMode? Mode = null) : FieldOperation<double>;
 
-    /// <summary>Compute directional derivative field: (gradient field, direction) → (grid points[], directional derivatives[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] DirectionalDerivatives)> DirectionalDerivativeField(
-        Vector3d[] gradientField,
-        Point3d[] gridPoints,
-        Vector3d direction) =>
-        ResultFactory.Create(value: (gradientField, gridPoints))
-            .Ensure(v => v.gradientField.Length == v.gridPoints.Length, error: E.Geometry.InvalidDirectionalDerivative.WithContext("Gradient field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeDirectionalDerivative(gradientField: gradientField, grid: gridPoints, direction: direction));
+    /// <summary>Vector interpolation query.</summary>
+    public sealed record VectorInterpolationOperation(VectorFieldSamples Field, Point3d Query, InterpolationMode? Mode = null) : FieldOperation<Vector3d>;
 
-    /// <summary>Compute vector field magnitude: vector field → (grid points[], magnitudes[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Magnitudes)> FieldMagnitude(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldMagnitude.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ComputeFieldMagnitude(vectorField: vectorField, grid: gridPoints));
+    /// <summary>Streamline integration request.</summary>
+    public sealed record StreamlineIntegrationOperation(VectorFieldSamples Field, Point3d[] Seeds, IntegrationScheme? Scheme = null) : FieldOperation<Curve[]>;
 
-    /// <summary>Normalize vector field: vector field → (grid points[], normalized vectors[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, Vector3d[] Normalized)> NormalizeField(
-        Vector3d[] vectorField,
-        Point3d[] gridPoints) =>
-        ResultFactory.Create(value: (vectorField, gridPoints))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldNormalization.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.NormalizeVectorField(vectorField: vectorField, grid: gridPoints));
+    /// <summary>Isosurface extraction request.</summary>
+    public sealed record IsosurfaceExtractionOperation(ScalarFieldSamples Field, double[] Isovalues) : FieldOperation<Mesh[]>;
 
-    /// <summary>Scalar-vector field product: (scalar field, vector field, component) → (grid points[], product[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] Product)> ScalarVectorProduct(
-        double[] scalarField,
-        Vector3d[] vectorField,
-        Point3d[] gridPoints,
-        VectorComponent component) =>
-        ResultFactory.Create(value: (scalarField, vectorField, gridPoints))
-            .Ensure(v => v.scalarField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("Scalar field length must match grid points"))
-            .Ensure(v => v.vectorField.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("Vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.ScalarVectorProduct(scalarField: scalarField, vectorField: vectorField, grid: gridPoints, component: component));
+    /// <summary>Hessian computation from scalar field.</summary>
+    public sealed record HessianFieldOperation(ScalarFieldSamples Field) : FieldOperation<HessianFieldSamples>;
 
-    /// <summary>Vector-vector dot product field: (vector field 1, vector field 2) → (grid points[], dot products[]).</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(Point3d[] Grid, double[] DotProduct)> VectorDotProduct(
-        Vector3d[] vectorField1,
-        Vector3d[] vectorField2,
-        Point3d[] gridPoints) =>
-        ResultFactory.Create(value: (vectorField1, vectorField2, gridPoints))
-            .Ensure(v => v.vectorField1.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("First vector field length must match grid points"))
-            .Ensure(v => v.vectorField2.Length == v.gridPoints.Length, error: E.Geometry.InvalidFieldComposition.WithContext("Second vector field length must match grid points"))
-            .Bind(_ => FieldsCompute.VectorDotProduct(vectorField1: vectorField1, vectorField2: vectorField2, grid: gridPoints));
+    /// <summary>Directional derivative computation from gradient field.</summary>
+    public sealed record DirectionalDerivativeOperation(VectorFieldSamples Field, Vector3d Direction) : FieldOperation<ScalarFieldSamples>;
 
-    /// <summary>Detect and classify critical points: (scalar field, gradient, hessian) → critical points[] classified as min/max/saddle.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1814:Prefer jagged arrays over multidimensional", Justification = "3x3 Hessian matrix parameter is mathematically appropriate")]
-    public static Result<CriticalPoint[]> CriticalPoints(
-        double[] scalarField,
-        Vector3d[] gradientField,
-        double[,][] hessian,
-        Point3d[] gridPoints,
-        FieldSampling sampling) =>
-        (hessian.GetLength(0) == 3
-            && hessian.GetLength(1) == 3
-            && Enumerable.Range(0, 3).All(row =>
-                Enumerable.Range(0, 3).All(col =>
-                    hessian[row, col] is not null
-                    && hessian[row, col].Length == gridPoints.Length))) switch {
-                        false => ResultFactory.Create<CriticalPoint[]>(
-                            error: E.Geometry.InvalidCriticalPointDetection.WithContext("Hessian must be a 3x3 tensor with entries per grid sample")),
-                        true => FieldsCompute.DetectCriticalPoints(
-                            scalarField: scalarField,
-                            gradientField: gradientField,
-                            hessian: hessian,
-                            grid: gridPoints,
-                            resolution: sampling.Resolution),
-                    };
+    /// <summary>Vector field magnitude computation.</summary>
+    public sealed record FieldMagnitudeOperation(VectorFieldSamples Field) : FieldOperation<ScalarFieldSamples>;
 
-    /// <summary>Compute field statistics: scalar field → (min, max, mean, stddev, extreme locations).</summary>
+    /// <summary>Vector field normalization.</summary>
+    public sealed record NormalizeFieldOperation(VectorFieldSamples Field) : FieldOperation<VectorFieldSamples>;
+
+    /// <summary>Scalar-vector field product.</summary>
+    public sealed record ScalarVectorProductOperation(ScalarFieldSamples Scalars, VectorFieldSamples Vectors, VectorComponent Component) : FieldOperation<ScalarFieldSamples>;
+
+    /// <summary>Vector-vector dot product field.</summary>
+    public sealed record VectorDotProductOperation(VectorFieldSamples First, VectorFieldSamples Second) : FieldOperation<ScalarFieldSamples>;
+
+    /// <summary>Critical point detection request.</summary>
+    public sealed record CriticalPointDetectionOperation(ScalarFieldSamples Scalars, VectorFieldSamples Gradients, HessianFieldSamples Hessian) : FieldOperation<CriticalPoint[]>;
+
+    /// <summary>Field statistics computation.</summary>
+    public sealed record FieldStatisticsOperation(ScalarFieldSamples Field) : FieldOperation<FieldStatistics>;
+
+    /// <summary>Execute a field operation using unified orchestration.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<FieldStatistics> ComputeStatistics(
-        double[] scalarField,
-        Point3d[] gridPoints) =>
-        (scalarField.Length == gridPoints.Length) switch {
-            false => ResultFactory.Create<FieldStatistics>(
-                error: E.Geometry.InvalidFieldStatistics.WithContext("Scalar field length must match grid points")),
-            true => FieldsCompute.ComputeFieldStatistics(
-                scalarField: scalarField,
-                grid: gridPoints),
-        };
+    public static Result<TResult> Execute<TResult>(FieldOperation<TResult> operation, IGeometryContext context) =>
+        FieldsCore.Execute(operation: operation, context: context);
 }

--- a/libs/rhino/fields/FieldsConfig.cs
+++ b/libs/rhino/fields/FieldsConfig.cs
@@ -15,6 +15,11 @@ internal static class FieldsConfig {
         string OperationName,
         int BufferSize);
 
+    /// <summary>General field operation metadata containing validation mode and operation name.</summary>
+    internal sealed record OperationMetadata(
+        V ValidationMode,
+        string OperationName);
+
     /// <summary>Distance field configuration by geometry type.</summary>
     internal static readonly FrozenDictionary<Type, DistanceFieldMetadata> DistanceFields =
         new Dictionary<Type, DistanceFieldMetadata> {
@@ -34,6 +39,62 @@ internal static class FieldsConfig {
                 ValidationMode: V.Standard | V.BoundingBox,
                 OperationName: "Fields.SurfaceDistance",
                 BufferSize: 4096),
+        }.ToFrozenDictionary();
+
+    /// <summary>Field operation metadata registry keyed by request type.</summary>
+    internal static readonly FrozenDictionary<Type, OperationMetadata> Operations =
+        new Dictionary<Type, OperationMetadata> {
+            [typeof(Fields.GradientFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Gradient"),
+            [typeof(Fields.CurlFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Curl"),
+            [typeof(Fields.DivergenceFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Divergence"),
+            [typeof(Fields.LaplacianFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Laplacian"),
+            [typeof(Fields.VectorPotentialFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.VectorPotential"),
+            [typeof(Fields.ScalarInterpolationOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.InterpolateScalar"),
+            [typeof(Fields.VectorInterpolationOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.InterpolateVector"),
+            [typeof(Fields.StreamlineIntegrationOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Streamlines"),
+            [typeof(Fields.IsosurfaceExtractionOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Isosurfaces"),
+            [typeof(Fields.HessianFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Hessian"),
+            [typeof(Fields.DirectionalDerivativeOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.DirectionalDerivative"),
+            [typeof(Fields.FieldMagnitudeOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Magnitude"),
+            [typeof(Fields.NormalizeFieldOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Normalize"),
+            [typeof(Fields.ScalarVectorProductOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.ScalarVectorProduct"),
+            [typeof(Fields.VectorDotProductOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.VectorDotProduct"),
+            [typeof(Fields.CriticalPointDetectionOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.CriticalPoints"),
+            [typeof(Fields.FieldStatisticsOperation)] = new(
+                ValidationMode: V.None,
+                OperationName: "Fields.Statistics"),
         }.ToFrozenDictionary();
 
     /// <summary>Field sampling resolution limits: default 32, range [8, 256].</summary>

--- a/libs/rhino/fields/FieldsCore.cs
+++ b/libs/rhino/fields/FieldsCore.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Collections.Frozen;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
@@ -6,6 +8,7 @@ using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
+using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Fields;
@@ -13,57 +16,152 @@ namespace Arsenal.Rhino.Fields;
 /// <summary>Fields dispatch registry with UnifiedOperation integration.</summary>
 [Pure]
 internal static class FieldsCore {
-    private sealed record DistanceOperationMetadata(
-        Func<GeometryBase, Fields.FieldSampling, int, IGeometryContext, Result<IReadOnlyList<(Point3d[], double[])>>> Executor,
-        FieldsConfig.DistanceFieldMetadata Metadata);
-
-    private static readonly FrozenDictionary<Type, DistanceOperationMetadata> DistanceDispatch =
-        FieldsConfig.DistanceFields
-            .ToDictionary(
-                keySelector: static entry => entry.Key,
-                elementSelector: static entry => new DistanceOperationMetadata(
-                    Executor: entry.Key == typeof(Mesh)
-                        ? static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Mesh>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,])
-                        : entry.Key == typeof(Brep)
-                            ? static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Brep>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,])
-                            : entry.Key == typeof(Curve)
-                                ? static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Curve>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,])
-                                : static (geometry, sampling, bufferSize, context) => ExecuteDistanceField<Surface>(geometry, sampling, bufferSize, context).Map(result => (IReadOnlyList<(Point3d[], double[])>)[result,]),
-                    Metadata: entry.Value))
-            .ToFrozenDictionary();
+    private static readonly FrozenDictionary<Type, FieldsConfig.DistanceFieldMetadata> DistanceFields =
+        FieldsConfig.DistanceFields;
 
     [Pure]
-    internal static Result<(Point3d[] Grid, double[] Distances)> DistanceField(
-        GeometryBase geometry,
-        Fields.FieldSampling sampling,
-        IGeometryContext context) =>
-        geometry is null
-            ? ResultFactory.Create<(Point3d[], double[])>(
-                error: E.Geometry.UnsupportedAnalysis.WithContext("Geometry cannot be null"))
-            : !DistanceDispatch.TryGetValue(geometry.GetType(), out DistanceOperationMetadata? metadata)
-                ? ResultFactory.Create<(Point3d[], double[])>(
-                    error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {geometry.GetType().Name}"))
-                : UnifiedOperation.Apply(
-                    input: geometry,
-                    operation: (Func<GeometryBase, Result<IReadOnlyList<(Point3d[], double[])>>>)(item => metadata.Executor(item, sampling, metadata.Metadata.BufferSize, context)),
-                    config: new OperationConfig<GeometryBase, (Point3d[], double[])> {
-                        Context = context,
-                        ValidationMode = metadata.Metadata.ValidationMode,
-                        OperationName = metadata.Metadata.OperationName,
-                        EnableDiagnostics = false,
-                    }).Map(results => results[0]);
+    internal static Result<TResult> Execute<TResult>(Fields.FieldOperation<TResult> operation, IGeometryContext context) =>
+        operation switch {
+            null => ResultFactory.Create<TResult>(error: E.Geometry.UnsupportedAnalysis.WithContext("Operation cannot be null")),
+            Fields.DistanceFieldOperation<Mesh> mesh => ExecuteDistance(mesh, context),
+            Fields.DistanceFieldOperation<Brep> brep => ExecuteDistance(brep, context),
+            Fields.DistanceFieldOperation<Curve> curve => ExecuteDistance(curve, context),
+            Fields.DistanceFieldOperation<Surface> surface => ExecuteDistance(surface, context),
+            Fields.GradientFieldOperation gradient => Apply(
+                operation: gradient,
+                context: context,
+                executor: static (op, _) => ExecuteGradient(op)),
+            Fields.CurlFieldOperation curl => Apply(
+                operation: curl,
+                context: context,
+                executor: static (op, _) => ExecuteCurl(op)),
+            Fields.DivergenceFieldOperation divergence => Apply(
+                operation: divergence,
+                context: context,
+                executor: static (op, _) => ExecuteDivergence(op)),
+            Fields.LaplacianFieldOperation laplacian => Apply(
+                operation: laplacian,
+                context: context,
+                executor: static (op, _) => ExecuteLaplacian(op)),
+            Fields.VectorPotentialFieldOperation potential => Apply(
+                operation: potential,
+                context: context,
+                executor: static (op, _) => ExecuteVectorPotential(op)),
+            Fields.ScalarInterpolationOperation interpolateScalar => Apply(
+                operation: interpolateScalar,
+                context: context,
+                executor: static (op, _) => ExecuteScalarInterpolation(op)),
+            Fields.VectorInterpolationOperation interpolateVector => Apply(
+                operation: interpolateVector,
+                context: context,
+                executor: static (op, _) => ExecuteVectorInterpolation(op)),
+            Fields.StreamlineIntegrationOperation streamlines => Apply(
+                operation: streamlines,
+                context: context,
+                executor: static (op, ctx) => ExecuteStreamlines(op, ctx)),
+            Fields.IsosurfaceExtractionOperation isosurfaces => Apply(
+                operation: isosurfaces,
+                context: context,
+                executor: static (op, _) => ExecuteIsosurfaces(op)),
+            Fields.HessianFieldOperation hessian => Apply(
+                operation: hessian,
+                context: context,
+                executor: static (op, _) => ExecuteHessian(op)),
+            Fields.DirectionalDerivativeOperation directional => Apply(
+                operation: directional,
+                context: context,
+                executor: static (op, _) => ExecuteDirectionalDerivative(op)),
+            Fields.FieldMagnitudeOperation magnitude => Apply(
+                operation: magnitude,
+                context: context,
+                executor: static (op, _) => ExecuteFieldMagnitude(op)),
+            Fields.NormalizeFieldOperation normalize => Apply(
+                operation: normalize,
+                context: context,
+                executor: static (op, _) => ExecuteNormalizeField(op)),
+            Fields.ScalarVectorProductOperation scalarVector => Apply(
+                operation: scalarVector,
+                context: context,
+                executor: static (op, _) => ExecuteScalarVectorProduct(op)),
+            Fields.VectorDotProductOperation vectorDot => Apply(
+                operation: vectorDot,
+                context: context,
+                executor: static (op, _) => ExecuteVectorDotProduct(op)),
+            Fields.CriticalPointDetectionOperation criticalPoints => Apply(
+                operation: criticalPoints,
+                context: context,
+                executor: static (op, _) => ExecuteCriticalPoints(op)),
+            Fields.FieldStatisticsOperation statistics => Apply(
+                operation: statistics,
+                context: context,
+                executor: static (op, _) => ExecuteStatistics(op)),
+            _ => ResultFactory.Create<TResult>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Unsupported field operation: {operation.GetType().Name}")),
+        };
 
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<(Point3d[], double[])> ExecuteDistanceField<T>(
-        GeometryBase geometry,
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<TResult> Apply<TResult, TOperation>(
+        TOperation operation,
+        IGeometryContext context,
+        Func<TOperation, IGeometryContext, Result<TResult>> executor) where TOperation : Fields.FieldOperation<TResult> =>
+        FieldsConfig.Operations.TryGetValue(typeof(TOperation), out FieldsConfig.OperationMetadata? metadata)
+            ? UnifiedOperation.Apply(
+                input: operation,
+                operation: (Func<TOperation, Result<IReadOnlyList<TResult>>>)(item =>
+                    executor(item, context).Map(static result => (IReadOnlyList<TResult>)[result,])),
+                config: new OperationConfig<TOperation, TResult> {
+                    Context = context,
+                    ValidationMode = metadata.ValidationMode,
+                    OperationName = metadata.OperationName,
+                    EnableDiagnostics = false,
+                }).Map(static results => results[0])
+            : ResultFactory.Create<TResult>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Unknown field operation: {typeof(TOperation).Name}"));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Result<Fields.ScalarFieldSamples> ExecuteDistance<TGeometry>(
+        Fields.DistanceFieldOperation<TGeometry> operation,
+        IGeometryContext context) where TGeometry : GeometryBase =>
+        operation.Geometry is null
+            ? ResultFactory.Create<Fields.ScalarFieldSamples>(error: E.Geometry.UnsupportedAnalysis.WithContext("Geometry cannot be null"))
+            : !DistanceFields.TryGetValue(typeof(TGeometry), out FieldsConfig.DistanceFieldMetadata? metadata)
+                ? ResultFactory.Create<Fields.ScalarFieldSamples>(error: E.Geometry.UnsupportedAnalysis.WithContext($"Distance field not supported for {typeof(TGeometry).Name}"))
+                : UnifiedOperation.Apply(
+                    input: operation.Geometry,
+                    operation: (Func<TGeometry, Result<IReadOnlyList<Fields.ScalarFieldSamples>>>)(geometry =>
+                        ComputeDistanceSamples(
+                            geometry: geometry,
+                            sampling: operation.Sampling ?? Fields.FieldSampling.Default,
+                            metadata: metadata,
+                            context: context).Map(static result => (IReadOnlyList<Fields.ScalarFieldSamples>)[result,])),
+                    config: new OperationConfig<TGeometry, Fields.ScalarFieldSamples> {
+                        Context = context,
+                        ValidationMode = metadata.ValidationMode,
+                        OperationName = metadata.OperationName,
+                        EnableDiagnostics = false,
+                    }).Map(static results => results[0]);
+
+    private static Result<Fields.ScalarFieldSamples> ComputeDistanceSamples<TGeometry>(
+        TGeometry geometry,
         Fields.FieldSampling sampling,
+        FieldsConfig.DistanceFieldMetadata metadata,
+        IGeometryContext context) where TGeometry : GeometryBase {
+        BoundingBox bounds = sampling.Bounds ?? geometry.GetBoundingBox(accurate: true);
+        return bounds.IsValid switch {
+            false => ResultFactory.Create<Fields.ScalarFieldSamples>(error: E.Geometry.InvalidFieldBounds),
+            true => ExecuteDistanceField(
+                geometry: geometry,
+                sampling: sampling,
+                bounds: bounds,
+                bufferSize: metadata.BufferSize,
+                context: context),
+        };
+    }
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteDistanceField<TGeometry>(
+        TGeometry geometry,
+        Fields.FieldSampling sampling,
+        BoundingBox bounds,
         int bufferSize,
-        IGeometryContext context) where T : GeometryBase {
-        T typed = (T)geometry;
-        BoundingBox bounds = sampling.Bounds ?? typed.GetBoundingBox(accurate: true);
-        if (!bounds.IsValid) {
-            return ResultFactory.Create<(Point3d[], double[])>(error: E.Geometry.InvalidFieldBounds);
-        }
+        IGeometryContext context) where TGeometry : GeometryBase {
         int resolution = sampling.Resolution;
         int totalSamples = resolution * resolution * resolution;
         int actualBufferSize = Math.Max(totalSamples, bufferSize);
@@ -75,32 +173,300 @@ internal static class FieldsCore {
             for (int i = 0; i < resolution; i++) {
                 for (int j = 0; j < resolution; j++) {
                     for (int k = 0; k < resolution; k++) {
-                        grid[gridIndex++] = new(bounds.Min.X + (i * delta.X), bounds.Min.Y + (j * delta.Y), bounds.Min.Z + (k * delta.Z));
+                        grid[gridIndex++] = new Point3d(
+                            bounds.Min.X + (i * delta.X),
+                            bounds.Min.Y + (j * delta.Y),
+                            bounds.Min.Z + (k * delta.Z));
                     }
                 }
             }
+
             for (int i = 0; i < totalSamples; i++) {
-                Point3d closest = typed switch {
-                    Mesh m => m.ClosestPoint(grid[i]),
-                    Brep b => b.ClosestPoint(grid[i]),
-                    Curve c => c.ClosestPoint(grid[i], out double t) ? c.PointAt(t) : grid[i],
-                    Surface s => s.ClosestPoint(grid[i], out double u, out double v) ? s.PointAt(u, v) : grid[i],
+                Point3d closest = geometry switch {
+                    Mesh mesh => mesh.ClosestPoint(grid[i]),
+                    Brep brep => brep.ClosestPoint(grid[i]),
+                    Curve curve => curve.ClosestPoint(grid[i], out double t) ? curve.PointAt(t) : grid[i],
+                    Surface surface => surface.ClosestPoint(grid[i], out double u, out double v) ? surface.PointAt(u, v) : grid[i],
                     _ => grid[i],
                 };
                 double unsignedDist = grid[i].DistanceTo(closest);
-                bool inside = typed switch {
+                bool inside = geometry switch {
                     Brep brep => brep.IsPointInside(grid[i], tolerance: context.AbsoluteTolerance * FieldsConfig.InsideOutsideToleranceMultiplier, strictlyIn: false),
                     Mesh mesh when mesh.IsClosed => mesh.IsPointInside(grid[i], tolerance: context.AbsoluteTolerance, strictlyIn: false),
                     _ => false,
                 };
                 distances[i] = inside ? -unsignedDist : unsignedDist;
             }
+
             Point3d[] finalGrid = [.. grid[..totalSamples]];
             double[] finalDistances = [.. distances[..totalSamples]];
-            return ResultFactory.Create(value: (Grid: finalGrid, Distances: finalDistances));
+            return ResultFactory.Create(value: new Fields.ScalarFieldSamples(
+                Grid: finalGrid,
+                Values: finalDistances,
+                Sampling: sampling,
+                Bounds: bounds));
         } finally {
             ArrayPool<Point3d>.Shared.Return(grid, clearArray: true);
             ArrayPool<double>.Shared.Return(distances, clearArray: true);
         }
+    }
+
+    private static Result<Fields.VectorFieldSamples> ExecuteGradient(Fields.GradientFieldOperation operation) =>
+        ResolveGridDelta(operation.Field.Sampling, operation.Field.Bounds)
+            .Bind(delta => FieldsCompute.ComputeGradient(
+                distances: operation.Field.Values,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                gridDelta: delta))
+            .Map(result => new Fields.VectorFieldSamples(
+                Grid: result.Grid,
+                Vectors: result.Gradients,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.VectorFieldSamples> ExecuteCurl(Fields.CurlFieldOperation operation) =>
+        ResolveGridDelta(operation.Field.Sampling, operation.Field.Bounds)
+            .Bind(delta => FieldsCompute.ComputeCurl(
+                vectorField: operation.Field.Vectors,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                gridDelta: delta))
+            .Map(result => new Fields.VectorFieldSamples(
+                Grid: result.Grid,
+                Vectors: result.Curl,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteDivergence(Fields.DivergenceFieldOperation operation) =>
+        ResolveGridDelta(operation.Field.Sampling, operation.Field.Bounds)
+            .Bind(delta => FieldsCompute.ComputeDivergence(
+                vectorField: operation.Field.Vectors,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                gridDelta: delta))
+            .Map(result => new Fields.ScalarFieldSamples(
+                Grid: result.Grid,
+                Values: result.Divergence,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteLaplacian(Fields.LaplacianFieldOperation operation) =>
+        ResolveGridDelta(operation.Field.Sampling, operation.Field.Bounds)
+            .Bind(delta => FieldsCompute.ComputeLaplacian(
+                scalarField: operation.Field.Values,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                gridDelta: delta))
+            .Map(result => new Fields.ScalarFieldSamples(
+                Grid: result.Grid,
+                Values: result.Laplacian,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.VectorFieldSamples> ExecuteVectorPotential(Fields.VectorPotentialFieldOperation operation) =>
+        ResolveGridDelta(operation.Field.Sampling, operation.Field.Bounds)
+            .Bind(delta => FieldsCompute.ComputeVectorPotential(
+                vectorField: operation.Field.Vectors,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                gridDelta: delta))
+            .Map(result => new Fields.VectorFieldSamples(
+                Grid: result.Grid,
+                Vectors: result.Potential,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<double> ExecuteScalarInterpolation(Fields.ScalarInterpolationOperation operation) =>
+        (operation.Field.Values.Length == operation.Field.Grid.Length) switch {
+            false => ResultFactory.Create<double>(error: E.Geometry.InvalidFieldInterpolation.WithContext("Scalar field length must match grid points")),
+            true => FieldsCompute.InterpolateScalar(
+                query: operation.Query,
+                scalarField: operation.Field.Values,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                bounds: operation.Field.Bounds,
+                mode: ResolveInterpolationMode(operation.Mode, operation.Field.Bounds)),
+        };
+
+    private static Result<Vector3d> ExecuteVectorInterpolation(Fields.VectorInterpolationOperation operation) =>
+        (operation.Field.Vectors.Length == operation.Field.Grid.Length) switch {
+            false => ResultFactory.Create<Vector3d>(error: E.Geometry.InvalidFieldInterpolation.WithContext("Vector field length must match grid points")),
+            true => FieldsCompute.InterpolateVector(
+                query: operation.Query,
+                vectorField: operation.Field.Vectors,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                bounds: operation.Field.Bounds,
+                mode: ResolveInterpolationMode(operation.Mode, operation.Field.Bounds)),
+        };
+
+    private static Result<Curve[]> ExecuteStreamlines(Fields.StreamlineIntegrationOperation operation, IGeometryContext context) =>
+        (operation.Field.Vectors.Length == operation.Field.Grid.Length, operation.Seeds.Length > 0) switch {
+            (false, _) => ResultFactory.Create<Curve[]>(error: E.Geometry.InvalidScalarField.WithContext("Vector field length must match grid points")),
+            (_, false) => ResultFactory.Create<Curve[]>(error: E.Geometry.InvalidStreamlineSeeds),
+            (true, true) => FieldsCompute.IntegrateStreamlines(
+                vectorField: operation.Field.Vectors,
+                gridPoints: operation.Field.Grid,
+                seeds: operation.Seeds,
+                stepSize: operation.Field.Sampling.StepSize,
+                scheme: operation.Scheme ?? new Fields.RungeKutta4IntegrationScheme(),
+                resolution: operation.Field.Sampling.Resolution,
+                bounds: operation.Field.Bounds,
+                context: context),
+        };
+
+    private static Result<Mesh[]> ExecuteIsosurfaces(Fields.IsosurfaceExtractionOperation operation) =>
+        (operation.Field.Values.Length == operation.Field.Grid.Length, operation.Isovalues.Length > 0, AreValidIsovalues(operation.Isovalues)) switch {
+            (false, _, _) => ResultFactory.Create<Mesh[]>(error: E.Geometry.InvalidScalarField.WithContext("Scalar field length must match grid points")),
+            (_, false, _) => ResultFactory.Create<Mesh[]>(error: E.Geometry.InvalidIsovalue.WithContext("At least one isovalue required")),
+            (_, _, false) => ResultFactory.Create<Mesh[]>(error: E.Geometry.InvalidIsovalue.WithContext("All isovalues must be valid doubles")),
+            (true, true, true) => FieldsCompute.ExtractIsosurfaces(
+                scalarField: operation.Field.Values,
+                gridPoints: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                isovalues: operation.Isovalues),
+        };
+
+    private static Result<Fields.HessianFieldSamples> ExecuteHessian(Fields.HessianFieldOperation operation) =>
+        ResolveGridDelta(operation.Field.Sampling, operation.Field.Bounds)
+            .Bind(delta => FieldsCompute.ComputeHessian(
+                scalarField: operation.Field.Values,
+                grid: operation.Field.Grid,
+                resolution: operation.Field.Sampling.Resolution,
+                gridDelta: delta))
+            .Map(result => new Fields.HessianFieldSamples(
+                Grid: result.Grid,
+                Hessians: result.Hessian,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteDirectionalDerivative(Fields.DirectionalDerivativeOperation operation) =>
+        (operation.Field.Vectors.Length == operation.Field.Grid.Length) switch {
+            false => ResultFactory.Create<Fields.ScalarFieldSamples>(error: E.Geometry.InvalidDirectionalDerivative.WithContext("Gradient field length must match grid points")),
+            true => FieldsCompute.ComputeDirectionalDerivative(
+                gradientField: operation.Field.Vectors,
+                grid: operation.Field.Grid,
+                direction: operation.Direction)
+                .Map(result => new Fields.ScalarFieldSamples(
+                    Grid: result.Grid,
+                    Values: result.DirectionalDerivatives,
+                    Sampling: operation.Field.Sampling,
+                    Bounds: operation.Field.Bounds)),
+        };
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteFieldMagnitude(Fields.FieldMagnitudeOperation operation) =>
+        FieldsCompute.ComputeFieldMagnitude(
+            vectorField: operation.Field.Vectors,
+            grid: operation.Field.Grid)
+            .Map(result => new Fields.ScalarFieldSamples(
+                Grid: result.Grid,
+                Values: result.Magnitudes,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.VectorFieldSamples> ExecuteNormalizeField(Fields.NormalizeFieldOperation operation) =>
+        FieldsCompute.NormalizeVectorField(
+            vectorField: operation.Field.Vectors,
+            grid: operation.Field.Grid)
+            .Map(result => new Fields.VectorFieldSamples(
+                Grid: result.Grid,
+                Vectors: result.Normalized,
+                Sampling: operation.Field.Sampling,
+                Bounds: operation.Field.Bounds));
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteScalarVectorProduct(Fields.ScalarVectorProductOperation operation) =>
+        (operation.Scalars.Grid.Length == operation.Vectors.Grid.Length) switch {
+            false => ResultFactory.Create<Fields.ScalarFieldSamples>(error: E.Geometry.InvalidFieldComposition.WithContext("Grid definitions must match")),
+            true => FieldsCompute.ScalarVectorProduct(
+                scalarField: operation.Scalars.Values,
+                vectorField: operation.Vectors.Vectors,
+                grid: operation.Scalars.Grid,
+                component: operation.Component)
+                .Map(result => new Fields.ScalarFieldSamples(
+                    Grid: result.Grid,
+                    Values: result.Product,
+                    Sampling: operation.Scalars.Sampling,
+                    Bounds: operation.Scalars.Bounds)),
+        };
+
+    private static Result<Fields.ScalarFieldSamples> ExecuteVectorDotProduct(Fields.VectorDotProductOperation operation) =>
+        (operation.First.Grid.Length == operation.Second.Grid.Length) switch {
+            false => ResultFactory.Create<Fields.ScalarFieldSamples>(error: E.Geometry.InvalidFieldComposition.WithContext("Grid definitions must match")),
+            true => FieldsCompute.VectorDotProduct(
+                vectorField1: operation.First.Vectors,
+                vectorField2: operation.Second.Vectors,
+                grid: operation.First.Grid)
+                .Map(result => new Fields.ScalarFieldSamples(
+                    Grid: result.Grid,
+                    Values: result.DotProduct,
+                    Sampling: operation.First.Sampling,
+                    Bounds: operation.First.Bounds)),
+        };
+
+    private static Result<Fields.CriticalPoint[]> ExecuteCriticalPoints(Fields.CriticalPointDetectionOperation operation) =>
+        ValidateHessian(operation)
+            .Bind(_ => FieldsCompute.DetectCriticalPoints(
+                scalarField: operation.Scalars.Values,
+                gradientField: operation.Gradients.Vectors,
+                hessian: operation.Hessian.Hessians,
+                grid: operation.Scalars.Grid,
+                resolution: operation.Scalars.Sampling.Resolution));
+
+    private static Result<Fields.FieldStatistics> ExecuteStatistics(Fields.FieldStatisticsOperation operation) =>
+        FieldsCompute.ComputeFieldStatistics(
+            scalarField: operation.Field.Values,
+            grid: operation.Field.Grid);
+
+    private static Result<Vector3d> ResolveGridDelta(Fields.FieldSampling sampling, BoundingBox bounds) =>
+        bounds.IsValid switch {
+            false => ResultFactory.Create<Vector3d>(error: E.Geometry.InvalidFieldBounds),
+            true => ResultFactory.Create(value: (bounds.Max - bounds.Min) / (sampling.Resolution - 1)),
+        };
+
+    private static Fields.InterpolationMode ResolveInterpolationMode(Fields.InterpolationMode? requested, BoundingBox bounds) {
+        bool degenerate = RhinoMath.EpsilonEquals(bounds.Max.X, bounds.Min.X, epsilon: RhinoMath.SqrtEpsilon)
+            || RhinoMath.EpsilonEquals(bounds.Max.Y, bounds.Min.Y, epsilon: RhinoMath.SqrtEpsilon)
+            || RhinoMath.EpsilonEquals(bounds.Max.Z, bounds.Min.Z, epsilon: RhinoMath.SqrtEpsilon);
+        return degenerate
+            ? new Fields.NearestInterpolationMode()
+            : requested ?? new Fields.TrilinearInterpolationMode();
+    }
+
+    private static bool AreValidIsovalues(double[] isovalues) {
+        for (int i = 0; i < isovalues.Length; i++) {
+            if (!RhinoMath.IsValidDouble(isovalues[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static Result<bool> ValidateHessian(Fields.CriticalPointDetectionOperation operation) {
+        int scalarLength = operation.Scalars.Grid.Length;
+        int gradientLength = operation.Gradients.Grid.Length;
+        int hessianLength = operation.Hessian.Grid.Length;
+        double[,][] tensors = operation.Hessian.Hessians;
+        bool validShape = tensors.GetLength(0) == 3 && tensors.GetLength(1) == 3;
+        bool validEntries = HasValidHessianEntries(tensors, scalarLength);
+        return (scalarLength == gradientLength, scalarLength == hessianLength, validShape && validEntries) switch {
+            (false, _, _) => ResultFactory.Create<bool>(error: E.Geometry.InvalidCriticalPointDetection.WithContext("Scalar and gradient grids must match")),
+            (_, false, _) => ResultFactory.Create<bool>(error: E.Geometry.InvalidCriticalPointDetection.WithContext("Scalar and hessian grids must match")),
+            (_, _, false) => ResultFactory.Create<bool>(error: E.Geometry.InvalidCriticalPointDetection.WithContext("Hessian tensor must be 3x3 with entries per grid sample")),
+            (true, true, true) => ResultFactory.Create(value: true),
+        };
+    }
+
+    private static bool HasValidHessianEntries(double[,][] hessian, int expectedLength) {
+        for (int row = 0; row < hessian.GetLength(0); row++) {
+            for (int col = 0; col < hessian.GetLength(1); col++) {
+                double[]? entries = hessian[row, col];
+                if (entries is null || entries.Length != expectedLength) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- replace the legacy `Fields` entrypoints with algebraic request/response records and a single `Execute` dispatcher
- consolidate operation metadata into FrozenDictionary tables and rework `FieldsCore` to route every operation through `UnifiedOperation`
- keep the compute layer unchanged while adapting it to the new strongly typed samples/results that carry sampling metadata

## Testing
- `dotnet build` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da0077bcc83218d0ba8af8a6df4c6)