### PR TITLE
Refactor analysis API into algebraic dispatch

### DIFF
--- a/libs/rhino/analysis/Analysis.cs
+++ b/libs/rhino/analysis/Analysis.cs
@@ -1,9 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
 using Rhino.Geometry;
 
@@ -17,6 +15,36 @@ public static class Analysis {
         /// <summary>Evaluation point in world coordinates.</summary>
         public Point3d Location { get; }
     }
+
+    /// <summary>Base request for differential geometry evaluation.</summary>
+    public abstract record DifferentialRequest;
+
+    /// <summary>Curve differential geometry request.</summary>
+    public sealed record CurveAnalysis(Curve Geometry, double? Parameter = null, int DerivativeOrder = AnalysisConfig.DefaultDerivativeOrder) : DifferentialRequest;
+
+    /// <summary>Surface differential geometry request.</summary>
+    public sealed record SurfaceAnalysis(Surface Geometry, (double U, double V)? Parameter = null, int DerivativeOrder = AnalysisConfig.DefaultDerivativeOrder) : DifferentialRequest;
+
+    /// <summary>Brep differential geometry request.</summary>
+    public sealed record BrepAnalysis(Brep Geometry, (double U, double V)? Parameter = null, int FaceIndex = 0, Point3d? TestPoint = null, int DerivativeOrder = AnalysisConfig.DefaultDerivativeOrder) : DifferentialRequest;
+
+    /// <summary>Extrusion differential geometry request.</summary>
+    public sealed record ExtrusionAnalysis(Extrusion Geometry, (double U, double V)? Parameter = null, int FaceIndex = 0, Point3d? TestPoint = null, int DerivativeOrder = AnalysisConfig.DefaultDerivativeOrder) : DifferentialRequest;
+
+    /// <summary>Mesh topology and manifold request.</summary>
+    public sealed record MeshAnalysis(Mesh Geometry, int VertexIndex = 0) : DifferentialRequest;
+
+    /// <summary>Base metric request for quality analysis.</summary>
+    public abstract record MetricRequest;
+
+    /// <summary>Surface quality sampling request.</summary>
+    public sealed record SurfaceQualityRequest(Surface Geometry) : MetricRequest;
+
+    /// <summary>Curve fairness evaluation request.</summary>
+    public sealed record CurveFairnessRequest(Curve Geometry) : MetricRequest;
+
+    /// <summary>Mesh element quality request.</summary>
+    public sealed record MeshElementQualityRequest(Mesh Geometry) : MetricRequest;
 
     /// <summary>Curve differential geometry: derivatives, curvature, frames, discontinuities, length, centroid.</summary>
     [DebuggerDisplay("{DebuggerDisplay}")]
@@ -102,88 +130,50 @@ public static class Analysis {
             $"Mesh @ {this.Location} | V={this.Volume:F3} | A={this.Area:F3}{(this.IsClosed ? " [closed]" : "")}{(this.IsManifold ? " [manifold]" : "")}");
     }
 
-    /// <summary>Analyzes curve differential geometry at specified parameter.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<CurveData> Analyze(
-        Curve curve,
-        IGeometryContext context,
-        double? parameter = null,
-        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) =>
-        AnalysisCore.Execute(curve, context, t: parameter, uv: null, index: null, testPoint: null, derivativeOrder: derivativeOrder)
-            .Map(results => (CurveData)results[0]);
+    /// <summary>Surface curvature sampling result.</summary>
+    public sealed record SurfaceQualityResult(
+        double[] GaussianCurvatures,
+        double[] MeanCurvatures,
+        (double U, double V)[] SingularityLocations,
+        double UniformityScore);
 
-    /// <summary>Analyzes surface differential geometry at specified UV parameters.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<SurfaceData> Analyze(
-        Surface surface,
-        IGeometryContext context,
-        (double u, double v)? uvParameter = null,
-        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) =>
-        AnalysisCore.Execute(surface, context, t: null, uv: uvParameter, index: null, testPoint: null, derivativeOrder: derivativeOrder)
-            .Map(results => (SurfaceData)results[0]);
+    /// <summary>Curve fairness evaluation result.</summary>
+    public sealed record CurveFairnessResult(
+        double SmoothnessScore,
+        double[] CurvatureValues,
+        (double Parameter, bool IsSharp)[] InflectionPoints,
+        double BendingEnergy);
 
-    /// <summary>Analyzes Brep surface, topology, and proximity to test point.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<BrepData> Analyze(
-        Brep brep,
-        IGeometryContext context,
-        (double u, double v)? uvParameter = null,
-        int faceIndex = 0,
-        Point3d? testPoint = null,
-        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) =>
-        AnalysisCore.Execute(brep, context, t: null, uv: uvParameter, index: faceIndex, testPoint: testPoint, derivativeOrder: derivativeOrder)
-            .Map(results => (BrepData)results[0]);
+    /// <summary>Mesh quality metrics for FEA.</summary>
+    public sealed record MeshElementQualityResult(
+        double[] AspectRatios,
+        double[] Skewness,
+        double[] Jacobians,
+        int[] ProblematicFaceIndices,
+        (int WarningCount, int CriticalCount) QualityFlags);
 
-    /// <summary>Analyzes mesh topology and manifold properties at vertex.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<MeshData> Analyze(
-        Mesh mesh,
-        IGeometryContext context,
-        int vertexIndex = 0) =>
-        AnalysisCore.Execute(mesh, context, t: null, uv: null, index: vertexIndex, testPoint: null, derivativeOrder: 0)
-            .Map(results => (MeshData)results[0]);
+    /// <summary>Analyzes a single differential request.</summary>
+    [Pure]
+    public static Result<IResult> Analyze(DifferentialRequest request, IGeometryContext context) =>
+        AnalysisCore.Analyze(request: request, context: context);
 
-    /// <summary>Batch analysis for multiple geometry instances with unified error handling.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<IReadOnlyList<IResult>> AnalyzeMultiple<T>(
-        IReadOnlyList<T> geometries,
-        IGeometryContext context,
-        double? parameter = null,
-        (double u, double v)? uvParameter = null,
-        int? index = null,
-        Point3d? testPoint = null,
-        int derivativeOrder = AnalysisConfig.DefaultDerivativeOrder) where T : GeometryBase =>
-        UnifiedOperation.Apply(
-            geometries,
-            (Func<object, Result<IReadOnlyList<IResult>>>)(item =>
-                AnalysisCore.Execute(item, context, parameter, uvParameter, index, testPoint, derivativeOrder)),
-            new OperationConfig<object, IResult> {
-                Context = context,
-                ValidationMode = Core.Validation.V.None,
-                EnableCache = true,
-                AccumulateErrors = false,
-                OperationName = "Analysis.Multiple",
-                EnableDiagnostics = false,
-            });
+    /// <summary>Batch analysis for multiple differential requests.</summary>
+    [Pure]
+    public static Result<IReadOnlyList<IResult>> AnalyzeMany(IReadOnlyList<DifferentialRequest> requests, IGeometryContext context) =>
+        AnalysisCore.AnalyzeMany(requests: requests, context: context);
 
     /// <summary>Analyzes surface quality via curvature sampling and singularity detection.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(double[] GaussianCurvatures, double[] MeanCurvatures, (double U, double V)[] SingularityLocations, double UniformityScore)> AnalyzeSurfaceQuality(
-        Surface surface,
-        IGeometryContext context) =>
-        AnalysisCompute.SurfaceQuality(surface: surface, context: context);
+    [Pure]
+    public static Result<SurfaceQualityResult> AnalyzeSurfaceQuality(SurfaceQualityRequest request, IGeometryContext context) =>
+        AnalysisCore.AnalyzeSurfaceQuality(request: request, context: context);
 
     /// <summary>Analyzes curve fairness via curvature variation and inflection detection.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(double SmoothnessScore, double[] CurvatureValues, (double Parameter, bool IsSharp)[] InflectionPoints, double BendingEnergy)> AnalyzeCurveFairness(
-        Curve curve,
-        IGeometryContext context) =>
-        AnalysisCompute.CurveFairness(curve: curve, context: context);
+    [Pure]
+    public static Result<CurveFairnessResult> AnalyzeCurveFairness(CurveFairnessRequest request, IGeometryContext context) =>
+        AnalysisCore.AnalyzeCurveFairness(request: request, context: context);
 
     /// <summary>Analyzes mesh quality for FEA via aspect ratio, skewness, and Jacobian metrics.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<(double[] AspectRatios, double[] Skewness, double[] Jacobians, int[] ProblematicFaceIndices, (int WarningCount, int CriticalCount) QualityFlags)> AnalyzeMeshForFEA(
-        Mesh mesh,
-        IGeometryContext context) =>
-        AnalysisCompute.MeshForFEA(mesh: mesh, context: context);
+    [Pure]
+    public static Result<MeshElementQualityResult> AnalyzeMeshForFEA(MeshElementQualityRequest request, IGeometryContext context) =>
+        AnalysisCore.AnalyzeMeshForFEA(request: request, context: context);
 }

--- a/libs/rhino/analysis/AnalysisCompute.cs
+++ b/libs/rhino/analysis/AnalysisCompute.cs
@@ -1,10 +1,6 @@
 using System.Buffers;
 using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
-using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 
@@ -12,175 +8,309 @@ namespace Arsenal.Rhino.Analysis;
 
 /// <summary>Dense geometric quality analysis algorithms.</summary>
 internal static class AnalysisCompute {
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<(double[] GaussianSamples, double[] MeanSamples, (double U, double V)[] Singularities, double UniformityScore)> SurfaceQuality(Surface surface, IGeometryContext context) =>
-        ResultFactory.Create(value: surface)
-            .Validate(args: [context, V.Standard | V.BoundingBox | V.UVDomain,])
-            .Bind(validSurface => {
-                int gridSize = Math.Max(2, (int)Math.Sqrt(AnalysisConfig.SurfaceQualitySampleCount));
-                int totalSamples = gridSize * gridSize;
-                (double u, double v)[] uvGrid = new (double, double)[totalSamples];
-                SurfaceCurvature[] curvatures = new SurfaceCurvature[totalSamples];
-                int validCount = 0;
-                int uvIndex = 0;
-                double gridDivisor = gridSize - 1.0;
+    [Pure]
+    internal static bool TryCurveData(Curve curve, IGeometryContext context, double? parameter, int derivativeOrder, out Analysis.CurveData result) {
+        double param = parameter ?? curve.Domain.Mid;
+        double[] buffer = ArrayPool<double>.Shared.Rent(AnalysisConfig.MaxDiscontinuities);
+        try {
+            int discCount = 0;
+            double s = curve.Domain.Min;
+            while (discCount < AnalysisConfig.MaxDiscontinuities && curve.GetNextDiscontinuity(Continuity.C1_continuous, s, curve.Domain.Max, out double discontinuity)) {
+                buffer[discCount] = discontinuity;
+                discCount++;
+                s = discontinuity + context.AbsoluteTolerance;
+            }
 
-                for (int i = 0; i < gridSize; i++) {
-                    double u = validSurface.Domain(0).ParameterAt(i / gridDivisor);
-                    for (int j = 0; j < gridSize; j++) {
-                        double v = validSurface.Domain(1).ParameterAt(j / gridDivisor);
-                        uvGrid[uvIndex++] = (u, v);
-                        SurfaceCurvature sc = validSurface.CurvatureAt(u: u, v: v);
-                        if (RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)) {
-                            curvatures[validCount++] = sc;
-                        }
-                    }
+            if (!curve.FrameAt(param, out Plane frame)) {
+                result = new Analysis.CurveData(Point3d.Unset, [], 0.0, Plane.Unset, [], 0.0, [], [], 0.0, Point3d.Unset);
+                return false;
+            }
+
+            AreaMassProperties? amp = AreaMassProperties.Compute(curve);
+            Vector3d[] derivatives = curve.DerivativeAt(param, derivativeOrder) is Vector3d[] d ? d : [];
+            double[] frameParams = new double[AnalysisConfig.CurveFrameSampleCount];
+            for (int i = 0; i < AnalysisConfig.CurveFrameSampleCount; i++) {
+                frameParams[i] = curve.Domain.ParameterAt(AnalysisConfig.CurveFrameSampleCount > 1 ? i / (AnalysisConfig.CurveFrameSampleCount - 1.0) : 0.5);
+            }
+            Plane[] frames = curve.GetPerpendicularFrames(frameParams) is Plane[] pf ? pf : [];
+            double[] discontinuities = buffer.AsSpan(0, discCount).ToArray();
+            Continuity[] discTypes = [.. discontinuities.Select(dp => curve.IsContinuous(Continuity.C2_continuous, dp) ? Continuity.C1_continuous : Continuity.C0_continuous),];
+
+            result = amp is not null
+                ? new Analysis.CurveData(
+                    curve.PointAt(param), derivatives, curve.CurvatureAt(param).Length, frame,
+                    frames,
+                    curve.TorsionAt(param), discontinuities,
+                    discTypes,
+                    curve.GetLength(), amp.Centroid)
+                : new Analysis.CurveData(Point3d.Unset, [], 0.0, Plane.Unset, [], 0.0, [], [], 0.0, Point3d.Unset);
+            return amp is not null;
+        } finally {
+            ArrayPool<double>.Shared.Return(buffer, clearArray: true);
+        }
+    }
+
+    [Pure]
+    internal static bool TrySurfaceData(Surface surface, IGeometryContext _, (double, double)? parameter, int derivativeOrder, out Analysis.SurfaceData result) {
+        (double u, double v) = parameter ?? (surface.Domain(0).Mid, surface.Domain(1).Mid);
+        bool evaluated = surface.Evaluate(u, v, derivativeOrder, out Point3d _, out Vector3d[] derivatives) && surface.FrameAt(u, v, out Plane frame);
+        SurfaceCurvature curvature = surface.CurvatureAt(u, v);
+        AreaMassProperties? amp = evaluated ? AreaMassProperties.Compute(surface) : null;
+        bool valid = evaluated && amp is not null && RhinoMath.IsValidDouble(curvature.Gaussian) && RhinoMath.IsValidDouble(curvature.Mean);
+        result = valid
+            ? new Analysis.SurfaceData(
+                surface.PointAt(u, v), derivatives, curvature.Gaussian, curvature.Mean, curvature.Kappa(0), curvature.Kappa(1),
+                curvature.Direction(0), curvature.Direction(1), frame, frame.Normal,
+                surface.IsAtSeam(u, v) != 0, surface.IsAtSingularity(u, v, exact: true), amp!.Area, amp.Centroid)
+            : new Analysis.SurfaceData(Point3d.Unset, [], 0.0, 0.0, 0.0, 0.0, Vector3d.Unset, Vector3d.Unset, Plane.Unset, Vector3d.Unset, false, false, 0.0, Point3d.Unset);
+        return valid;
+    }
+
+    [Pure]
+    internal static bool TryBrepData(Brep brep, IGeometryContext context, (double, double)? parameter, int faceIndex, Point3d? testPoint, int derivativeOrder, out Analysis.BrepData result) {
+        int fIdx = RhinoMath.Clamp(faceIndex, 0, brep.Faces.Count - 1);
+        using Surface sf = brep.Faces[fIdx].UnderlyingSurface();
+        (double u, double v) = parameter ?? (sf.Domain(0).Mid, sf.Domain(1).Mid);
+        Point3d point = testPoint ?? brep.GetBoundingBox(accurate: false).Center;
+        bool eval = sf.Evaluate(u, v, derivativeOrder, out Point3d _, out Vector3d[] derivs) && sf.FrameAt(u, v, out Plane frame);
+        bool hasClosest = brep.ClosestPoint(point, out Point3d cp, out ComponentIndex ci, out double uOut, out double vOut, context.AbsoluteTolerance * AnalysisConfig.BrepClosestPointToleranceMultiplier, out Vector3d _);
+        SurfaceCurvature curvature = sf.CurvatureAt(u, v);
+        using AreaMassProperties? amp = eval ? AreaMassProperties.Compute(brep) : null;
+        using VolumeMassProperties? vmp = eval ? VolumeMassProperties.Compute(brep) : null;
+        bool valid = eval && hasClosest && amp is not null && vmp is not null && RhinoMath.IsValidDouble(curvature.Gaussian) && RhinoMath.IsValidDouble(curvature.Mean);
+        result = valid
+            ? new Analysis.BrepData(
+                sf.PointAt(u, v), derivs, curvature.Gaussian, curvature.Mean, curvature.Kappa(0), curvature.Kappa(1),
+                curvature.Direction(0), curvature.Direction(1), frame, frame.Normal,
+                [.. brep.Vertices.Select((vertex, i) => (i, vertex.Location)),],
+                [.. brep.Edges.Select((edge, i) => (i, new Line(edge.PointAtStart, edge.PointAtEnd))),],
+                brep.IsManifold, brep.IsSolid, cp, point.DistanceTo(cp),
+                ci, (uOut, vOut), amp!.Area, vmp!.Volume, vmp.Centroid)
+            : new Analysis.BrepData(Point3d.Unset, [], 0.0, 0.0, 0.0, 0.0, Vector3d.Unset, Vector3d.Unset, Plane.Unset, Vector3d.Unset, [], [], false, false, Point3d.Unset, 0.0, new ComponentIndex(), (0.0, 0.0), 0.0, 0.0, Point3d.Unset);
+        return valid;
+    }
+
+    [Pure]
+    internal static bool TryExtrusionData(Extrusion extrusion, IGeometryContext context, (double, double)? parameter, int faceIndex, Point3d? testPoint, int derivativeOrder, out Analysis.BrepData result) {
+        Brep? brep = extrusion.ToBrep();
+        if (brep is null) {
+            result = new Analysis.BrepData(Point3d.Unset, [], 0.0, 0.0, 0.0, 0.0, Vector3d.Unset, Vector3d.Unset, Plane.Unset, Vector3d.Unset, [], [], false, false, Point3d.Unset, 0.0, new ComponentIndex(), (0.0, 0.0), 0.0, 0.0, Point3d.Unset);
+            return false;
+        }
+
+        using (brep) {
+            return TryBrepData(brep, context, parameter, faceIndex, testPoint, derivativeOrder, out result);
+        }
+    }
+
+    [Pure]
+    internal static bool TryMeshData(Mesh mesh, IGeometryContext context, int vertexIndex, out Analysis.MeshData result) {
+        int vIdx = RhinoMath.Clamp(vertexIndex, 0, mesh.Vertices.Count - 1);
+        Vector3d normal = mesh.Normals.Count > vIdx ? mesh.Normals[vIdx] : Vector3d.ZAxis;
+        using AreaMassProperties? amp = AreaMassProperties.Compute(mesh);
+        using VolumeMassProperties? vmp = VolumeMassProperties.Compute(mesh);
+        bool valid = amp is not null && vmp is not null;
+        result = valid
+            ? new Analysis.MeshData(
+                mesh.Vertices[vIdx], new Plane(mesh.Vertices[vIdx], normal), normal,
+                [.. Enumerable.Range(0, mesh.TopologyVertices.Count).Select(i => (i, (Point3d)mesh.TopologyVertices[i])),],
+                [.. Enumerable.Range(0, mesh.TopologyEdges.Count).Select(i => (i, mesh.TopologyEdges.EdgeLine(i))),],
+                mesh.IsManifold(topologicalTest: true, out bool _, out bool _), mesh.IsClosed, amp!.Area, vmp!.Volume)
+            : new Analysis.MeshData(Point3d.Unset, Plane.Unset, Vector3d.Unset, [], [], false, false, 0.0, 0.0);
+        return valid;
+    }
+
+    [Pure]
+    internal static bool TrySurfaceQuality(Surface surface, IGeometryContext context, out Analysis.SurfaceQualityResult result, out string? failureReason) {
+        int gridSize = Math.Max(2, (int)Math.Sqrt(AnalysisConfig.SurfaceQualitySampleCount));
+        int totalSamples = gridSize * gridSize;
+        (double u, double v)[] uvGrid = new (double, double)[totalSamples];
+        SurfaceCurvature[] curvatures = new SurfaceCurvature[totalSamples];
+        int validCount = 0;
+        int uvIndex = 0;
+        double gridDivisor = gridSize - 1.0;
+
+        for (int i = 0; i < gridSize; i++) {
+            double u = surface.Domain(0).ParameterAt(i / gridDivisor);
+            for (int j = 0; j < gridSize; j++) {
+                double v = surface.Domain(1).ParameterAt(j / gridDivisor);
+                uvGrid[uvIndex] = (u, v);
+                uvIndex++;
+                SurfaceCurvature curvature = surface.CurvatureAt(u: u, v: v);
+                bool valid = RhinoMath.IsValidDouble(curvature.Gaussian) && RhinoMath.IsValidDouble(curvature.Mean);
+                curvatures[validCount] = valid ? curvature : default;
+                validCount += valid ? 1 : 0;
+            }
+        }
+
+        SurfaceCurvature[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
+        Interval uDomain = surface.Domain(0);
+        Interval vDomain = surface.Domain(1);
+        double uSpan = uDomain.Length;
+        double vSpan = vDomain.Length;
+        double singularityThresholdU = RhinoMath.Clamp(
+            uSpan * AnalysisConfig.SingularityProximityFactor,
+            RhinoMath.SqrtEpsilon,
+            uSpan * AnalysisConfig.SingularityBoundaryFraction);
+        double singularityThresholdV = RhinoMath.Clamp(
+            vSpan * AnalysisConfig.SingularityProximityFactor,
+            RhinoMath.SqrtEpsilon,
+            vSpan * AnalysisConfig.SingularityBoundaryFraction);
+
+        double[] gaussianSorted = validCurvatures.Select(curvature => Math.Abs(curvature.Gaussian)).Order().ToArray();
+        double medianGaussian = gaussianSorted.Length switch {
+            0 => 0.0,
+            1 => gaussianSorted[0],
+            _ => gaussianSorted.Length % 2 is 0
+                ? (gaussianSorted[(gaussianSorted.Length / 2) - 1] + gaussianSorted[gaussianSorted.Length / 2]) / 2.0
+                : gaussianSorted[gaussianSorted.Length / 2],
+        };
+
+        double averageGaussian = validCurvatures.Length > 0
+            ? validCurvatures.Average(curvature => Math.Abs(curvature.Gaussian))
+            : 0.0;
+        double stdDevGaussian = validCurvatures.Length > 0
+            ? Math.Sqrt(validCurvatures.Sum(curvature => Math.Pow(Math.Abs(curvature.Gaussian) - averageGaussian, 2)) / validCurvatures.Length)
+            : 0.0;
+
+        bool hasSamples = validCurvatures.Length > 0;
+        result = hasSamples
+            ? new Analysis.SurfaceQualityResult(
+                validCurvatures.Select(curvature => curvature.Gaussian).ToArray(),
+                validCurvatures.Select(curvature => curvature.Mean).ToArray(),
+                uvGrid.Where(uv =>
+                    surface.IsAtSingularity(u: uv.u, v: uv.v, exact: false)
+                    || Math.Min(Math.Abs(uv.u - uDomain.Min), Math.Abs(uDomain.Max - uv.u)) <= singularityThresholdU
+                    || Math.Min(Math.Abs(uv.v - vDomain.Min), Math.Abs(vDomain.Max - uv.v)) <= singularityThresholdV).ToArray(),
+                RhinoMath.Clamp(medianGaussian > context.AbsoluteTolerance ? (1.0 - (stdDevGaussian / (medianGaussian * AnalysisConfig.HighCurvatureMultiplier))) : gaussianSorted[^1] < context.AbsoluteTolerance ? 1.0 : 0.0, 0.0, 1.0))
+            : new Analysis.SurfaceQualityResult([], [], [], 0.0);
+        failureReason = hasSamples ? null : "No valid curvature samples";
+        return hasSamples;
+    }
+
+    [Pure]
+    internal static bool TryCurveFairness(Curve curve, IGeometryContext context, out Analysis.CurveFairnessResult result, out string? failureReason) {
+        const int maxSamples = AnalysisConfig.CurveFairnessSampleCount;
+        (double Parameter, Vector3d Curvature)[] samples = new (double, Vector3d)[maxSamples];
+        double[] curvatures = new double[maxSamples];
+        int validCount = 0;
+        const double sampleDivisor = maxSamples - 1.0;
+
+        for (int i = 0; i < maxSamples; i++) {
+            double t = curve.Domain.ParameterAt(i / sampleDivisor);
+            Vector3d curvature = curve.CurvatureAt(t);
+            bool valid = curvature.IsValid;
+            samples[validCount] = valid ? (t, curvature) : samples[validCount];
+            curvatures[validCount] = valid ? curvature.Length : curvatures[validCount];
+            validCount += valid ? 1 : 0;
+        }
+
+        (double Parameter, Vector3d Curvature)[] validSamples = samples.AsSpan(0, validCount).ToArray();
+        double[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
+        double curveLength = curve.GetLength();
+        double averageDifference = validCurvatures.Length > 1
+            ? Enumerable.Range(1, validCurvatures.Length - 1).Sum(i => Math.Abs(validCurvatures[i] - validCurvatures[i - 1])) / (validCurvatures.Length - 1)
+            : 0.0;
+        double maxCurvature = validCurvatures.Length > 0 ? validCurvatures.Max() : 0.0;
+        double energyMetric = maxCurvature > context.AbsoluteTolerance && validCurvatures.Length > 0
+            ? (validCurvatures.Sum(k => k * k) * (curveLength / (AnalysisConfig.CurveFairnessSampleCount - 1))) / (maxCurvature * curveLength)
+            : 0.0;
+
+        Analysis.CurveFairnessResult computed = validSamples.Length > 2
+            ? new Analysis.CurveFairnessResult(
+                RhinoMath.Clamp(1.0 / (1.0 + (averageDifference * AnalysisConfig.SmoothnessSensitivity)), 0.0, 1.0),
+                validCurvatures,
+                Enumerable.Range(1, validCurvatures.Length - 2)
+                    .Where(i => Math.Abs((validCurvatures[i] - validCurvatures[i - 1]) - (validCurvatures[i + 1] - validCurvatures[i])) > AnalysisConfig.InflectionSharpnessThreshold || ((validCurvatures[i] - validCurvatures[i - 1]) * (validCurvatures[i + 1] - validCurvatures[i])) < 0)
+                    .Select(i => (validSamples[i].Parameter, Math.Abs(validCurvatures[i] - validCurvatures[i - 1]) > AnalysisConfig.InflectionSharpnessThreshold))
+                    .ToArray(),
+                energyMetric)
+            : new Analysis.CurveFairnessResult([], [], [], 0.0);
+        result = computed;
+        failureReason = validSamples.Length > 2 ? null : "Insufficient valid curvature samples";
+        return validSamples.Length > 2;
+    }
+
+    [Pure]
+    internal static bool TryMeshForFEA(Mesh mesh, IGeometryContext context, out Analysis.MeshElementQualityResult result) {
+        Point3d[] vertices = ArrayPool<Point3d>.Shared.Rent(4);
+        double[] edgeLengths = ArrayPool<double>.Shared.Rent(4);
+        try {
+            (double AspectRatio, double Skewness, double Jacobian)[] metrics = [.. Enumerable.Range(0, mesh.Faces.Count).Select(i => {
+                Point3d center = mesh.Faces.GetFaceCenter(i);
+                MeshFace face = mesh.Faces[i];
+                bool isQuad = face.IsQuad;
+                bool validIndices = face.A >= 0 && face.A < mesh.Vertices.Count
+                    && face.B >= 0 && face.B < mesh.Vertices.Count
+                    && face.C >= 0 && face.C < mesh.Vertices.Count
+                    && (!isQuad || (face.D >= 0 && face.D < mesh.Vertices.Count));
+
+                vertices[0] = validIndices ? (Point3d)mesh.Vertices[face.A] : center;
+                vertices[1] = validIndices ? (Point3d)mesh.Vertices[face.B] : center;
+                vertices[2] = validIndices ? (Point3d)mesh.Vertices[face.C] : center;
+                vertices[3] = validIndices && isQuad ? (Point3d)mesh.Vertices[face.D] : vertices[0];
+
+                int vertCount = isQuad ? 4 : 3;
+
+                double minEdge = double.MaxValue;
+                double maxEdge = double.MinValue;
+                for (int j = 0; j < vertCount; j++) {
+                    double length = vertices[j].DistanceTo(vertices[(j + 1) % vertCount]);
+                    edgeLengths[j] = length;
+                    minEdge = length < minEdge ? length : minEdge;
+                    maxEdge = length > maxEdge ? length : maxEdge;
                 }
-                SurfaceCurvature[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
-                Interval uDomain = validSurface.Domain(0);
-                Interval vDomain = validSurface.Domain(1);
-                double uSpan = uDomain.Length;
-                double vSpan = vDomain.Length;
-                double singularityThresholdU = RhinoMath.Clamp(
-                    uSpan * AnalysisConfig.SingularityProximityFactor,
-                    RhinoMath.SqrtEpsilon,
-                    uSpan * AnalysisConfig.SingularityBoundaryFraction);
-                double singularityThresholdV = RhinoMath.Clamp(
-                    vSpan * AnalysisConfig.SingularityProximityFactor,
-                    RhinoMath.SqrtEpsilon,
-                    vSpan * AnalysisConfig.SingularityBoundaryFraction);
-                return validCurvatures.Length > 0
-                    && validCurvatures.Select(sc => Math.Abs(sc.Gaussian)).Order().ToArray() is double[] gaussianSorted
-                    && (gaussianSorted.Length % 2 is 0 ? (gaussianSorted[(gaussianSorted.Length / 2) - 1] + gaussianSorted[gaussianSorted.Length / 2]) / 2.0 : gaussianSorted[gaussianSorted.Length / 2]) is double medianGaussian
-                    && validCurvatures.Average(sc => Math.Abs(sc.Gaussian)) is double avgGaussian
-                    && Math.Sqrt(validCurvatures.Sum(sc => Math.Pow(Math.Abs(sc.Gaussian) - avgGaussian, 2)) / validCurvatures.Length) is double stdDevGaussian
-                    ? ResultFactory.Create(value: (
-                        GaussianSamples: validCurvatures.Select(sc => sc.Gaussian).ToArray(),
-                        MeanSamples: validCurvatures.Select(sc => sc.Mean).ToArray(),
-                        Singularities: uvGrid.Where(uv =>
-                            validSurface.IsAtSingularity(u: uv.u, v: uv.v, exact: false)
-                            || Math.Min(Math.Abs(uv.u - uDomain.Min), Math.Abs(uDomain.Max - uv.u)) <= singularityThresholdU
-                            || Math.Min(Math.Abs(uv.v - vDomain.Min), Math.Abs(vDomain.Max - uv.v)) <= singularityThresholdV).ToArray(),
-                        UniformityScore: RhinoMath.Clamp(medianGaussian > context.AbsoluteTolerance ? (1.0 - (stdDevGaussian / (medianGaussian * AnalysisConfig.HighCurvatureMultiplier))) : gaussianSorted[^1] < context.AbsoluteTolerance ? 1.0 : 0.0, 0.0, 1.0)))
-                    : ResultFactory.Create<(double[], double[], (double, double)[], double)>(error: E.Geometry.SurfaceAnalysisFailed.WithContext("No valid curvature samples"));
-            });
+                double aspectRatio = maxEdge / (minEdge + context.AbsoluteTolerance);
 
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<(double SmoothnessScore, double[] CurvatureSamples, (double Parameter, bool IsSharp)[] InflectionPoints, double EnergyMetric)> CurveFairness(Curve curve, IGeometryContext context) =>
-        ResultFactory.Create(value: curve)
-            .Validate(args: [context, V.Standard | V.Degeneracy | V.SurfaceContinuity,])
-            .Bind(validCurve => {
-                const int maxSamples = AnalysisConfig.CurveFairnessSampleCount;
-                (double Parameter, Vector3d Curvature)[] samples = new (double, Vector3d)[maxSamples];
-                double[] curvatures = new double[maxSamples];
-                int validCount = 0;
-                const double sampleDivisor = maxSamples - 1.0;
+                double skewness = isQuad
+                    ? ((double[])[
+                        Vector3d.VectorAngle(vertices[1] - vertices[0], vertices[3] - vertices[0]),
+                        Vector3d.VectorAngle(vertices[2] - vertices[1], vertices[0] - vertices[1]),
+                        Vector3d.VectorAngle(vertices[3] - vertices[2], vertices[1] - vertices[2]),
+                        Vector3d.VectorAngle(vertices[0] - vertices[3], vertices[2] - vertices[3]),
+                    ]).Max(angle => Math.Abs(RhinoMath.ToDegrees(angle) - AnalysisConfig.QuadIdealAngleDegrees)) / AnalysisConfig.QuadIdealAngleDegrees
+                    : (vertices[1] - vertices[0], vertices[2] - vertices[0], vertices[2] - vertices[1]) is (Vector3d ab, Vector3d ac, Vector3d bc)
+                        ? (
+                            RhinoMath.ToDegrees(Vector3d.VectorAngle(ab, ac)),
+                            RhinoMath.ToDegrees(Vector3d.VectorAngle(bc, -ab)),
+                            RhinoMath.ToDegrees(Vector3d.VectorAngle(-ac, -bc))
+                        ) is (double angleA, double angleB, double angleC)
+                            ? Math.Max(Math.Abs(angleA - AnalysisConfig.TriangleIdealAngleDegrees), Math.Max(Math.Abs(angleB - AnalysisConfig.TriangleIdealAngleDegrees), Math.Abs(angleC - AnalysisConfig.TriangleIdealAngleDegrees))) / AnalysisConfig.TriangleIdealAngleDegrees
+                            : 1.0
+                        : 1.0;
 
-                for (int i = 0; i < maxSamples; i++) {
-                    double t = validCurve.Domain.ParameterAt(i / sampleDivisor);
-                    Vector3d curvature = validCurve.CurvatureAt(t);
-                    if (curvature.IsValid) {
-                        samples[validCount] = (t, curvature);
-                        curvatures[validCount] = curvature.Length;
-                        validCount++;
-                    }
-                }
-                (double Parameter, Vector3d Curvature)[] validSamples = samples.AsSpan(0, validCount).ToArray();
-                double[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
-                return validSamples.Length > 2
-                    && Enumerable.Range(1, validCurvatures.Length - 1).Sum(i => Math.Abs(validCurvatures[i] - validCurvatures[i - 1])) / (validCurvatures.Length - 1) is double avgDiff
-                    && validCurve.GetLength() is double curveLength
-                    ? ResultFactory.Create(value: (
-                        SmoothnessScore: RhinoMath.Clamp(1.0 / (1.0 + (avgDiff * AnalysisConfig.SmoothnessSensitivity)), 0.0, 1.0),
-                        CurvatureSamples: validCurvatures,
-                        InflectionPoints: Enumerable.Range(1, validCurvatures.Length - 2)
-                            .Where(i => Math.Abs((validCurvatures[i] - validCurvatures[i - 1]) - (validCurvatures[i + 1] - validCurvatures[i])) > AnalysisConfig.InflectionSharpnessThreshold || ((validCurvatures[i] - validCurvatures[i - 1]) * (validCurvatures[i + 1] - validCurvatures[i])) < 0)
-                            .Select(i => (validSamples[i].Parameter, Math.Abs(validCurvatures[i] - validCurvatures[i - 1]) > AnalysisConfig.InflectionSharpnessThreshold))
-                            .ToArray(),
-                        EnergyMetric: validCurvatures.Max() is double maxCurv && maxCurv > context.AbsoluteTolerance
-                            ? (validCurvatures.Sum(k => k * k) * (curveLength / (AnalysisConfig.CurveFairnessSampleCount - 1))) / (maxCurv * curveLength)
-                            : 0.0))
-                    : ResultFactory.Create<(double, double[], (double, bool)[], double)>(error: E.Geometry.CurveAnalysisFailed.WithContext("Insufficient valid curvature samples"));
-            });
+                double jacobian = isQuad
+                    ? edgeLengths.Take(4).Average() is double avgLen && avgLen > context.AbsoluteTolerance
+                        ? ((double[])[
+                            Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[3] - vertices[0]).Length,
+                            Vector3d.CrossProduct(vertices[2] - vertices[1], vertices[0] - vertices[1]).Length,
+                            Vector3d.CrossProduct(vertices[3] - vertices[2], vertices[1] - vertices[2]).Length,
+                            Vector3d.CrossProduct(vertices[0] - vertices[3], vertices[2] - vertices[3]).Length,
+                        ]).Min() / ((avgLen * avgLen) + context.AbsoluteTolerance)
+                        : 0.0
+                    : edgeLengths.Take(3).Average() is double triAvgLen && triAvgLen > context.AbsoluteTolerance
+                        ? Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[2] - vertices[0]).Length / ((2.0 * triAvgLen * triAvgLen) + context.AbsoluteTolerance)
+                        : 0.0;
 
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<(double[] AspectRatios, double[] Skewness, double[] Jacobians, int[] ProblematicFaces, (int Warning, int Critical) Counts)> MeshForFEA(Mesh mesh, IGeometryContext context) =>
-        ResultFactory.Create(value: mesh)
-            .Validate(args: [context, V.Standard | V.MeshSpecific,])
-            .Bind(validMesh => {
-                Point3d[] vertices = ArrayPool<Point3d>.Shared.Rent(4);
-                double[] edgeLengths = ArrayPool<double>.Shared.Rent(4);
-                try {
-                    (double AspectRatio, double Skewness, double Jacobian)[] metrics = [.. Enumerable.Range(0, validMesh.Faces.Count).Select(i => {
-                        Point3d center = validMesh.Faces.GetFaceCenter(i);
-                        MeshFace face = validMesh.Faces[i];
-                        bool isQuad = face.IsQuad;
-                        bool validIndices = face.A >= 0 && face.A < validMesh.Vertices.Count
-                            && face.B >= 0 && face.B < validMesh.Vertices.Count
-                            && face.C >= 0 && face.C < validMesh.Vertices.Count
-                            && (!isQuad || (face.D >= 0 && face.D < validMesh.Vertices.Count));
-
-                        vertices[0] = validIndices ? (Point3d)validMesh.Vertices[face.A] : center;
-                        vertices[1] = validIndices ? (Point3d)validMesh.Vertices[face.B] : center;
-                        vertices[2] = validIndices ? (Point3d)validMesh.Vertices[face.C] : center;
-                        vertices[3] = validIndices && isQuad ? (Point3d)validMesh.Vertices[face.D] : vertices[0];
-
-                        int vertCount = isQuad ? 4 : 3;
-
-                        double minEdge = double.MaxValue;
-                        double maxEdge = double.MinValue;
-                        for (int j = 0; j < vertCount; j++) {
-                            double length = vertices[j].DistanceTo(vertices[(j + 1) % vertCount]);
-                            edgeLengths[j] = length;
-                            minEdge = length < minEdge ? length : minEdge;
-                            maxEdge = length > maxEdge ? length : maxEdge;
-                        }
-                        double aspectRatio = maxEdge / (minEdge + context.AbsoluteTolerance);
-
-                        double skewness = isQuad
-                            ? ((double[])[
-                                Vector3d.VectorAngle(vertices[1] - vertices[0], vertices[3] - vertices[0]),
-                                Vector3d.VectorAngle(vertices[2] - vertices[1], vertices[0] - vertices[1]),
-                                Vector3d.VectorAngle(vertices[3] - vertices[2], vertices[1] - vertices[2]),
-                                Vector3d.VectorAngle(vertices[0] - vertices[3], vertices[2] - vertices[3]),
-                            ]).Max(angle => Math.Abs(RhinoMath.ToDegrees(angle) - AnalysisConfig.QuadIdealAngleDegrees)) / AnalysisConfig.QuadIdealAngleDegrees
-                            : (vertices[1] - vertices[0], vertices[2] - vertices[0], vertices[2] - vertices[1]) is (Vector3d ab, Vector3d ac, Vector3d bc)
-                                ? (
-                                    RhinoMath.ToDegrees(Vector3d.VectorAngle(ab, ac)),
-                                    RhinoMath.ToDegrees(Vector3d.VectorAngle(bc, -ab)),
-                                    RhinoMath.ToDegrees(Vector3d.VectorAngle(-ac, -bc))
-                                ) is (double angleA, double angleB, double angleC)
-                                    ? Math.Max(Math.Abs(angleA - AnalysisConfig.TriangleIdealAngleDegrees), Math.Max(Math.Abs(angleB - AnalysisConfig.TriangleIdealAngleDegrees), Math.Abs(angleC - AnalysisConfig.TriangleIdealAngleDegrees))) / AnalysisConfig.TriangleIdealAngleDegrees
-                                    : 1.0
-                                : 1.0;
-
-                        double jacobian = isQuad
-                            ? edgeLengths.Take(4).Average() is double avgLen && avgLen > context.AbsoluteTolerance
-                                ? ((double[])[
-                                    Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[3] - vertices[0]).Length,
-                                    Vector3d.CrossProduct(vertices[2] - vertices[1], vertices[0] - vertices[1]).Length,
-                                    Vector3d.CrossProduct(vertices[3] - vertices[2], vertices[1] - vertices[2]).Length,
-                                    Vector3d.CrossProduct(vertices[0] - vertices[3], vertices[2] - vertices[3]).Length,
-                                ]).Min() / ((avgLen * avgLen) + context.AbsoluteTolerance)
-                                : 0.0
-                            : edgeLengths.Take(3).Average() is double triAvgLen && triAvgLen > context.AbsoluteTolerance
-                                ? Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[2] - vertices[0]).Length / ((2.0 * triAvgLen * triAvgLen) + context.AbsoluteTolerance)
-                                : 0.0;
-
-                        return (AspectRatio: aspectRatio, Skewness: skewness, Jacobian: jacobian);
-                    }),
-                    ];
-                    return metrics.Length > 0
-                        ? ResultFactory.Create<(double[], double[], double[], int[], (int, int))>(value: (
-                            [.. metrics.Select(m => m.AspectRatio),],
-                            [.. metrics.Select(m => m.Skewness),],
-                            [.. metrics.Select(m => m.Jacobian),],
-                            [.. metrics.Select((m, i) => (m, i)).Where(pair => pair.m.AspectRatio > AnalysisConfig.AspectRatioCritical || pair.m.Skewness > AnalysisConfig.SkewnessCritical || pair.m.Jacobian < AnalysisConfig.JacobianCritical).Select(pair => pair.i),],
-                            (metrics.Count(m => m.AspectRatio > AnalysisConfig.AspectRatioWarning || m.Skewness > AnalysisConfig.SkewnessWarning || m.Jacobian < AnalysisConfig.JacobianWarning), metrics.Count(m => m.AspectRatio > AnalysisConfig.AspectRatioCritical || m.Skewness > AnalysisConfig.SkewnessCritical || m.Jacobian < AnalysisConfig.JacobianCritical))))
-                        : ResultFactory.Create<(double[], double[], double[], int[], (int, int))>(error: E.Geometry.MeshAnalysisFailed);
-                } finally {
-                    ArrayPool<Point3d>.Shared.Return(vertices, clearArray: true);
-                    ArrayPool<double>.Shared.Return(edgeLengths, clearArray: true);
-                }
-            });
+                return (AspectRatio: aspectRatio, Skewness: skewness, Jacobian: jacobian);
+            }),
+            ];
+            bool hasMetrics = metrics.Length > 0;
+            result = hasMetrics
+                ? new Analysis.MeshElementQualityResult(
+                    [.. metrics.Select(m => m.AspectRatio),],
+                    [.. metrics.Select(m => m.Skewness),],
+                    [.. metrics.Select(m => m.Jacobian),],
+                    [.. metrics.Select((metric, i) => (metric, i)).Where(pair => pair.metric.AspectRatio > AnalysisConfig.AspectRatioCritical || pair.metric.Skewness > AnalysisConfig.SkewnessCritical || pair.metric.Jacobian < AnalysisConfig.JacobianCritical).Select(pair => pair.i),],
+                    (
+                        metrics.Count(metric => metric.AspectRatio > AnalysisConfig.AspectRatioWarning || metric.Skewness > AnalysisConfig.SkewnessWarning || metric.Jacobian < AnalysisConfig.JacobianWarning),
+                        metrics.Count(metric => metric.AspectRatio > AnalysisConfig.AspectRatioCritical || metric.Skewness > AnalysisConfig.SkewnessCritical || metric.Jacobian < AnalysisConfig.JacobianCritical)
+                    ))
+                : new Analysis.MeshElementQualityResult([], [], [], [], (0, 0));
+            return hasMetrics;
+        } finally {
+            ArrayPool<Point3d>.Shared.Return(vertices, clearArray: true);
+            ArrayPool<double>.Shared.Return(edgeLengths, clearArray: true);
+        }
+    }
 }

--- a/libs/rhino/analysis/AnalysisConfig.cs
+++ b/libs/rhino/analysis/AnalysisConfig.cs
@@ -5,61 +5,63 @@ using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Analysis;
 
-/// <summary>Validation modes and constants for differential geometry.</summary>
+/// <summary>Validation modes, metadata, and constants for differential geometry.</summary>
 internal static class AnalysisConfig {
-    /// <summary>Type-to-validation mode mapping for geometry analysis.</summary>
-    internal static readonly FrozenDictionary<Type, V> ValidationModes =
-        new Dictionary<Type, V> {
-            [typeof(Curve)] = V.Standard | V.Degeneracy,
-            [typeof(NurbsCurve)] = V.Standard | V.Degeneracy | V.NurbsGeometry,
-            [typeof(LineCurve)] = V.Standard | V.Degeneracy,
-            [typeof(ArcCurve)] = V.Standard | V.Degeneracy,
-            [typeof(PolyCurve)] = V.Standard | V.Degeneracy | V.PolycurveStructure,
-            [typeof(PolylineCurve)] = V.Standard | V.Degeneracy,
-            [typeof(Surface)] = V.Standard | V.UVDomain,
-            [typeof(NurbsSurface)] = V.Standard | V.NurbsGeometry | V.UVDomain,
-            [typeof(PlaneSurface)] = V.Standard,
-            [typeof(Brep)] = V.Standard | V.Topology,
-            [typeof(Extrusion)] = V.Standard | V.Topology | V.ExtrusionGeometry,
-            [typeof(Mesh)] = V.Standard | V.MeshSpecific,
+    internal static readonly FrozenDictionary<Type, DifferentialGeometryMetadata> DifferentialGeometry =
+        new Dictionary<Type, DifferentialGeometryMetadata> {
+            [typeof(Curve)] = new(V.Standard | V.Degeneracy, "Analysis.Curve"),
+            [typeof(NurbsCurve)] = new(V.Standard | V.Degeneracy | V.NurbsGeometry, "Analysis.Curve"),
+            [typeof(LineCurve)] = new(V.Standard | V.Degeneracy, "Analysis.Curve"),
+            [typeof(ArcCurve)] = new(V.Standard | V.Degeneracy, "Analysis.Curve"),
+            [typeof(PolyCurve)] = new(V.Standard | V.Degeneracy | V.PolycurveStructure, "Analysis.Curve"),
+            [typeof(PolylineCurve)] = new(V.Standard | V.Degeneracy, "Analysis.Curve"),
+            [typeof(Surface)] = new(V.Standard | V.UVDomain, "Analysis.Surface"),
+            [typeof(NurbsSurface)] = new(V.Standard | V.NurbsGeometry | V.UVDomain, "Analysis.Surface"),
+            [typeof(PlaneSurface)] = new(V.Standard, "Analysis.Surface"),
+            [typeof(Brep)] = new(V.Standard | V.Topology, "Analysis.Brep"),
+            [typeof(Extrusion)] = new(V.Standard | V.Topology | V.ExtrusionGeometry, "Analysis.Brep"),
+            [typeof(Mesh)] = new(V.Standard | V.MeshSpecific, "Analysis.Mesh"),
         }.ToFrozenDictionary();
 
-    /// <summary>Maximum discontinuity count per curve for C1/C2 detection.</summary>
+    internal static readonly MetricOperationMetadata SurfaceQualityMetadata = new(
+        ValidationMode: V.Standard | V.BoundingBox | V.UVDomain,
+        OperationName: "Analysis.SurfaceQuality");
+
+    internal static readonly MetricOperationMetadata CurveFairnessMetadata = new(
+        ValidationMode: V.Standard | V.Degeneracy | V.SurfaceContinuity,
+        OperationName: "Analysis.CurveFairness");
+
+    internal static readonly MetricOperationMetadata MeshElementQualityMetadata = new(
+        ValidationMode: V.Standard | V.MeshSpecific,
+        OperationName: "Analysis.MeshForFEA");
+
+    internal const string MultipleOperationName = "Analysis.Multiple";
     internal const int MaxDiscontinuities = 20;
-    /// <summary>Default derivative order for position, tangent, and curvature computation.</summary>
     internal const int DefaultDerivativeOrder = 2;
-    /// <summary>Number of perpendicular frames sampled along curve domain.</summary>
     internal const int CurveFrameSampleCount = 5;
-    /// <summary>Sample count for curve fairness curvature comb analysis.</summary>
     internal const int CurveFairnessSampleCount = 50;
-
-    /// <summary>Grid dimension for surface quality UV sampling (10×10).</summary>
     internal const int SurfaceQualityGridDimension = 10;
-    /// <summary>Total surface quality sample count derived from grid dimensions.</summary>
     internal const int SurfaceQualitySampleCount = SurfaceQualityGridDimension * SurfaceQualityGridDimension;
-
-    /// <summary>Domain fraction defining boundary proximity for singularity detection.</summary>
     internal const double SingularityBoundaryFraction = 0.1;
-    /// <summary>Singularity proximity threshold as domain fraction.</summary>
     internal const double SingularityProximityFactor = 0.01;
-    /// <summary>High curvature threshold as multiplier of median for anomaly detection.</summary>
     internal const double HighCurvatureMultiplier = 5.0;
-    /// <summary>Threshold for detecting sharp inflection points via curvature change.</summary>
     internal const double InflectionSharpnessThreshold = 0.5;
-    /// <summary>Sensitivity factor for smoothness scoring via curvature variation.</summary>
     internal const double SmoothnessSensitivity = 10.0;
-    /// <summary>Brep closest point tolerance multiplier relative to context.</summary>
     internal const double BrepClosestPointToleranceMultiplier = 100.0;
-
-    /// <summary>Mesh FEA quality thresholds.</summary>
     internal const double AspectRatioWarning = 3.0;
     internal const double AspectRatioCritical = 10.0;
     internal const double SkewnessWarning = 0.5;
     internal const double SkewnessCritical = 0.85;
     internal const double JacobianWarning = 0.3;
     internal const double JacobianCritical = 0.1;
-
-    /// <summary>Ideal interior angles for element types.</summary>
     internal const double TriangleIdealAngleDegrees = 60.0;
     internal static readonly double QuadIdealAngleDegrees = RhinoMath.ToDegrees(RhinoMath.HalfPI);
+
+    internal sealed record DifferentialGeometryMetadata(
+        V ValidationMode,
+        string OperationName);
+
+    internal sealed record MetricOperationMetadata(
+        V ValidationMode,
+        string OperationName);
 }


### PR DESCRIPTION
## Summary
- refactored the Analysis API around algebraic request/result records for differential and quality evaluations
- centralized analysis metadata into FrozenDictionary tables and routed UnifiedOperation dispatch through AnalysisCore
- moved algorithmic implementations to the compute layer returning raw geometry data for UnifiedOperation wrapping

## Testing
- dotnet test *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4812c1608321a9cd7ede214945b0)