### PR TITLE
Refactor analysis metadata and dispatch

### DIFF
--- a/libs/rhino/analysis/AnalysisCompute.cs
+++ b/libs/rhino/analysis/AnalysisCompute.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Buffers;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
 using Arsenal.Core.Errors;
 using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 
@@ -13,174 +14,320 @@ namespace Arsenal.Rhino.Analysis;
 /// <summary>Dense geometric quality analysis algorithms.</summary>
 internal static class AnalysisCompute {
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<(double[] GaussianSamples, double[] MeanSamples, (double U, double V)[] Singularities, double UniformityScore)> SurfaceQuality(Surface surface, IGeometryContext context) =>
-        ResultFactory.Create(value: surface)
-            .Validate(args: [context, V.Standard | V.BoundingBox | V.UVDomain,])
-            .Bind(validSurface => {
-                int gridSize = Math.Max(2, (int)Math.Sqrt(AnalysisConfig.SurfaceQualitySampleCount));
-                int totalSamples = gridSize * gridSize;
-                (double u, double v)[] uvGrid = new (double, double)[totalSamples];
-                SurfaceCurvature[] curvatures = new SurfaceCurvature[totalSamples];
-                int validCount = 0;
-                int uvIndex = 0;
-                double gridDivisor = gridSize - 1.0;
-
-                for (int i = 0; i < gridSize; i++) {
-                    double u = validSurface.Domain(0).ParameterAt(i / gridDivisor);
-                    for (int j = 0; j < gridSize; j++) {
-                        double v = validSurface.Domain(1).ParameterAt(j / gridDivisor);
-                        uvGrid[uvIndex++] = (u, v);
-                        SurfaceCurvature sc = validSurface.CurvatureAt(u: u, v: v);
-                        if (RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)) {
-                            curvatures[validCount++] = sc;
-                        }
+    internal static Result<Analysis.CurveData> CurveDifferential(
+        Curve curve,
+        IGeometryContext context,
+        double parameter,
+        int derivativeOrder,
+        AnalysisConfig.DifferentialMetadata metadata) {
+        double[] buffer = ArrayPool<double>.Shared.Rent(metadata.MaxDiscontinuities);
+        try {
+            (int discCount, double s) = (0, curve.Domain.Min);
+            while (discCount < metadata.MaxDiscontinuities && curve.GetNextDiscontinuity(Continuity.C1_continuous, s, curve.Domain.Max, out double td)) {
+                buffer[discCount] = td;
+                discCount++;
+                s = td + context.AbsoluteTolerance;
+            }
+            double[] discontinuities = buffer.AsSpan(0, discCount).ToArray();
+            return curve.FrameAt(parameter, out Plane frame)
+                ? ((Func<Result<Analysis.CurveData>>)(() => {
+                    using AreaMassProperties? amp = AreaMassProperties.Compute(curve);
+                    Vector3d[] derivatives = curve.DerivativeAt(parameter, derivativeOrder) is Vector3d[] d ? d : [];
+                    double[] frameParams = new double[metadata.FrameSampleCount];
+                    for (int i = 0; i < metadata.FrameSampleCount; i++) {
+                        frameParams[i] = curve.Domain.ParameterAt(metadata.FrameSampleCount > 1 ? i / (metadata.FrameSampleCount - 1.0) : 0.5);
                     }
-                }
-                SurfaceCurvature[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
-                Interval uDomain = validSurface.Domain(0);
-                Interval vDomain = validSurface.Domain(1);
-                double uSpan = uDomain.Length;
-                double vSpan = vDomain.Length;
-                double singularityThresholdU = RhinoMath.Clamp(
-                    uSpan * AnalysisConfig.SingularityProximityFactor,
-                    RhinoMath.SqrtEpsilon,
-                    uSpan * AnalysisConfig.SingularityBoundaryFraction);
-                double singularityThresholdV = RhinoMath.Clamp(
-                    vSpan * AnalysisConfig.SingularityProximityFactor,
-                    RhinoMath.SqrtEpsilon,
-                    vSpan * AnalysisConfig.SingularityBoundaryFraction);
-                return validCurvatures.Length > 0
-                    && validCurvatures.Select(sc => Math.Abs(sc.Gaussian)).Order().ToArray() is double[] gaussianSorted
-                    && (gaussianSorted.Length % 2 is 0 ? (gaussianSorted[(gaussianSorted.Length / 2) - 1] + gaussianSorted[gaussianSorted.Length / 2]) / 2.0 : gaussianSorted[gaussianSorted.Length / 2]) is double medianGaussian
-                    && validCurvatures.Average(sc => Math.Abs(sc.Gaussian)) is double avgGaussian
-                    && Math.Sqrt(validCurvatures.Sum(sc => Math.Pow(Math.Abs(sc.Gaussian) - avgGaussian, 2)) / validCurvatures.Length) is double stdDevGaussian
-                    ? ResultFactory.Create(value: (
-                        GaussianSamples: validCurvatures.Select(sc => sc.Gaussian).ToArray(),
-                        MeanSamples: validCurvatures.Select(sc => sc.Mean).ToArray(),
-                        Singularities: uvGrid.Where(uv =>
-                            validSurface.IsAtSingularity(u: uv.u, v: uv.v, exact: false)
-                            || Math.Min(Math.Abs(uv.u - uDomain.Min), Math.Abs(uDomain.Max - uv.u)) <= singularityThresholdU
-                            || Math.Min(Math.Abs(uv.v - vDomain.Min), Math.Abs(vDomain.Max - uv.v)) <= singularityThresholdV).ToArray(),
-                        UniformityScore: RhinoMath.Clamp(medianGaussian > context.AbsoluteTolerance ? (1.0 - (stdDevGaussian / (medianGaussian * AnalysisConfig.HighCurvatureMultiplier))) : gaussianSorted[^1] < context.AbsoluteTolerance ? 1.0 : 0.0, 0.0, 1.0)))
-                    : ResultFactory.Create<(double[], double[], (double, double)[], double)>(error: E.Geometry.SurfaceAnalysisFailed.WithContext("No valid curvature samples"));
-            });
+                    Plane[] frames = curve.GetPerpendicularFrames(frameParams) is Plane[] pf ? pf : [];
+                    return amp is not null
+                        ? ResultFactory.Create(value: new Analysis.CurveData(
+                            curve.PointAt(parameter),
+                            derivatives,
+                            curve.CurvatureAt(parameter).Length,
+                            frame,
+                            frames,
+                            curve.TorsionAt(parameter),
+                            discontinuities,
+                            [.. discontinuities.Select(dp => curve.IsContinuous(Continuity.C2_continuous, dp) ? Continuity.C1_continuous : Continuity.C0_continuous),],
+                            curve.GetLength(),
+                            amp.Centroid))
+                        : ResultFactory.Create<Analysis.CurveData>(error: E.Geometry.CurveAnalysisFailed);
+                }))()
+                : ResultFactory.Create<Analysis.CurveData>(error: E.Geometry.CurveAnalysisFailed);
+        } finally {
+            ArrayPool<double>.Shared.Return(buffer, clearArray: true);
+        }
+    }
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<(double SmoothnessScore, double[] CurvatureSamples, (double Parameter, bool IsSharp)[] InflectionPoints, double EnergyMetric)> CurveFairness(Curve curve, IGeometryContext context) =>
-        ResultFactory.Create(value: curve)
-            .Validate(args: [context, V.Standard | V.Degeneracy | V.SurfaceContinuity,])
-            .Bind(validCurve => {
-                const int maxSamples = AnalysisConfig.CurveFairnessSampleCount;
-                (double Parameter, Vector3d Curvature)[] samples = new (double, Vector3d)[maxSamples];
-                double[] curvatures = new double[maxSamples];
-                int validCount = 0;
-                const double sampleDivisor = maxSamples - 1.0;
-
-                for (int i = 0; i < maxSamples; i++) {
-                    double t = validCurve.Domain.ParameterAt(i / sampleDivisor);
-                    Vector3d curvature = validCurve.CurvatureAt(t);
-                    if (curvature.IsValid) {
-                        samples[validCount] = (t, curvature);
-                        curvatures[validCount] = curvature.Length;
-                        validCount++;
-                    }
-                }
-                (double Parameter, Vector3d Curvature)[] validSamples = samples.AsSpan(0, validCount).ToArray();
-                double[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
-                return validSamples.Length > 2
-                    && Enumerable.Range(1, validCurvatures.Length - 1).Sum(i => Math.Abs(validCurvatures[i] - validCurvatures[i - 1])) / (validCurvatures.Length - 1) is double avgDiff
-                    && validCurve.GetLength() is double curveLength
-                    ? ResultFactory.Create(value: (
-                        SmoothnessScore: RhinoMath.Clamp(1.0 / (1.0 + (avgDiff * AnalysisConfig.SmoothnessSensitivity)), 0.0, 1.0),
-                        CurvatureSamples: validCurvatures,
-                        InflectionPoints: Enumerable.Range(1, validCurvatures.Length - 2)
-                            .Where(i => Math.Abs((validCurvatures[i] - validCurvatures[i - 1]) - (validCurvatures[i + 1] - validCurvatures[i])) > AnalysisConfig.InflectionSharpnessThreshold || ((validCurvatures[i] - validCurvatures[i - 1]) * (validCurvatures[i + 1] - validCurvatures[i])) < 0)
-                            .Select(i => (validSamples[i].Parameter, Math.Abs(validCurvatures[i] - validCurvatures[i - 1]) > AnalysisConfig.InflectionSharpnessThreshold))
-                            .ToArray(),
-                        EnergyMetric: validCurvatures.Max() is double maxCurv && maxCurv > context.AbsoluteTolerance
-                            ? (validCurvatures.Sum(k => k * k) * (curveLength / (AnalysisConfig.CurveFairnessSampleCount - 1))) / (maxCurv * curveLength)
-                            : 0.0))
-                    : ResultFactory.Create<(double, double[], (double, bool)[], double)>(error: E.Geometry.CurveAnalysisFailed.WithContext("Insufficient valid curvature samples"));
-            });
+    internal static Result<Analysis.SurfaceData> SurfaceDifferential(
+        Surface surface,
+        double u,
+        double v,
+        int derivativeOrder) =>
+        surface.Evaluate(u, v, derivativeOrder, out Point3d _, out Vector3d[] derivs) && surface.FrameAt(u, v, out Plane frame)
+            ? ((Func<Result<Analysis.SurfaceData>>)(() => {
+                SurfaceCurvature sc = surface.CurvatureAt(u, v);
+                using AreaMassProperties? amp = AreaMassProperties.Compute(surface);
+                return amp is not null && RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)
+                    ? ResultFactory.Create(value: new Analysis.SurfaceData(
+                        surface.PointAt(u, v),
+                        derivs,
+                        sc.Gaussian,
+                        sc.Mean,
+                        sc.Kappa(0),
+                        sc.Kappa(1),
+                        sc.Direction(0),
+                        sc.Direction(1),
+                        frame,
+                        frame.Normal,
+                        surface.IsAtSeam(u, v) != 0,
+                        surface.IsAtSingularity(u, v, exact: true),
+                        amp.Area,
+                        amp.Centroid))
+                    : ResultFactory.Create<Analysis.SurfaceData>(error: E.Geometry.SurfaceAnalysisFailed);
+            }))()
+            : ResultFactory.Create<Analysis.SurfaceData>(error: E.Geometry.SurfaceAnalysisFailed);
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<(double[] AspectRatios, double[] Skewness, double[] Jacobians, int[] ProblematicFaces, (int Warning, int Critical) Counts)> MeshForFEA(Mesh mesh, IGeometryContext context) =>
-        ResultFactory.Create(value: mesh)
-            .Validate(args: [context, V.Standard | V.MeshSpecific,])
-            .Bind(validMesh => {
-                Point3d[] vertices = ArrayPool<Point3d>.Shared.Rent(4);
-                double[] edgeLengths = ArrayPool<double>.Shared.Rent(4);
-                try {
-                    (double AspectRatio, double Skewness, double Jacobian)[] metrics = [.. Enumerable.Range(0, validMesh.Faces.Count).Select(i => {
-                        Point3d center = validMesh.Faces.GetFaceCenter(i);
-                        MeshFace face = validMesh.Faces[i];
-                        bool isQuad = face.IsQuad;
-                        bool validIndices = face.A >= 0 && face.A < validMesh.Vertices.Count
-                            && face.B >= 0 && face.B < validMesh.Vertices.Count
-                            && face.C >= 0 && face.C < validMesh.Vertices.Count
-                            && (!isQuad || (face.D >= 0 && face.D < validMesh.Vertices.Count));
+    internal static Result<Analysis.BrepData> BrepDifferential(
+        Brep brep,
+        IGeometryContext context,
+        (double U, double V) uv,
+        int faceIndex,
+        Point3d testPoint,
+        int derivativeOrder,
+        double toleranceMultiplier) {
+        int fIdx = RhinoMath.Clamp(faceIndex, 0, brep.Faces.Count - 1);
+        using Surface surface = brep.Faces[fIdx].UnderlyingSurface();
+        return surface.Evaluate(uv.U, uv.V, derivativeOrder, out Point3d _, out Vector3d[] derivs) && surface.FrameAt(uv.U, uv.V, out Plane frame)
+            && brep.ClosestPoint(testPoint, out Point3d cp, out ComponentIndex ci, out double uOut, out double vOut, context.AbsoluteTolerance * toleranceMultiplier, out Vector3d _)
+            ? ((Func<Result<Analysis.BrepData>>)(() => {
+                SurfaceCurvature sc = surface.CurvatureAt(uv.U, uv.V);
+                using AreaMassProperties? amp = AreaMassProperties.Compute(brep);
+                using VolumeMassProperties? vmp = VolumeMassProperties.Compute(brep);
+                return amp is not null && vmp is not null && RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)
+                    ? ResultFactory.Create(value: new Analysis.BrepData(
+                        surface.PointAt(uv.U, uv.V),
+                        derivs,
+                        sc.Gaussian,
+                        sc.Mean,
+                        sc.Kappa(0),
+                        sc.Kappa(1),
+                        sc.Direction(0),
+                        sc.Direction(1),
+                        frame,
+                        frame.Normal,
+                        [.. brep.Vertices.Select((vertex, i) => (i, vertex.Location)),],
+                        [.. brep.Edges.Select((edge, i) => (i, new Line(edge.PointAtStart, edge.PointAtEnd))),],
+                        brep.IsManifold,
+                        brep.IsSolid,
+                        cp,
+                        testPoint.DistanceTo(cp),
+                        ci,
+                        (uOut, vOut),
+                        amp.Area,
+                        vmp.Volume,
+                        vmp.Centroid))
+                    : ResultFactory.Create<Analysis.BrepData>(error: E.Geometry.BrepAnalysisFailed);
+            }))()
+            : ResultFactory.Create<Analysis.BrepData>(error: E.Geometry.BrepAnalysisFailed);
+    }
 
-                        vertices[0] = validIndices ? (Point3d)validMesh.Vertices[face.A] : center;
-                        vertices[1] = validIndices ? (Point3d)validMesh.Vertices[face.B] : center;
-                        vertices[2] = validIndices ? (Point3d)validMesh.Vertices[face.C] : center;
-                        vertices[3] = validIndices && isQuad ? (Point3d)validMesh.Vertices[face.D] : vertices[0];
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<Analysis.MeshData> MeshDifferential(
+        Mesh mesh,
+        int vertexIndex) {
+        int vIdx = RhinoMath.Clamp(vertexIndex, 0, mesh.Vertices.Count - 1);
+        Vector3d normal = mesh.Normals.Count > vIdx ? mesh.Normals[vIdx] : Vector3d.ZAxis;
+        return ((Func<Result<Analysis.MeshData>>)(() => {
+            using AreaMassProperties? amp = AreaMassProperties.Compute(mesh);
+            using VolumeMassProperties? vmp = VolumeMassProperties.Compute(mesh);
+            return amp is not null && vmp is not null
+                ? ResultFactory.Create(value: new Analysis.MeshData(
+                    mesh.Vertices[vIdx],
+                    new Plane(mesh.Vertices[vIdx], normal),
+                    normal,
+                    [.. Enumerable.Range(0, mesh.TopologyVertices.Count).Select(i => (i, (Point3d)mesh.TopologyVertices[i])),],
+                    [.. Enumerable.Range(0, mesh.TopologyEdges.Count).Select(i => (i, mesh.TopologyEdges.EdgeLine(i))),],
+                    mesh.IsManifold(topologicalTest: true, out bool _, out bool _),
+                    mesh.IsClosed,
+                    amp.Area,
+                    vmp.Volume))
+                : ResultFactory.Create<Analysis.MeshData>(error: E.Geometry.MeshAnalysisFailed);
+        }))();
+    }
 
-                        int vertCount = isQuad ? 4 : 3;
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(double[] GaussianSamples, double[] MeanSamples, (double U, double V)[] Singularities, double UniformityScore)> SurfaceQuality(
+        Surface surface,
+        IGeometryContext context,
+        AnalysisConfig.SurfaceQualityMetadata metadata) {
+        int gridSize = Math.Max(2, metadata.GridDimension);
+        int totalSamples = gridSize * gridSize;
+        (double u, double v)[] uvGrid = new (double, double)[totalSamples];
+        SurfaceCurvature[] curvatures = new SurfaceCurvature[totalSamples];
+        int validCount = 0;
+        int uvIndex = 0;
+        double gridDivisor = gridSize - 1.0;
 
-                        double minEdge = double.MaxValue;
-                        double maxEdge = double.MinValue;
-                        for (int j = 0; j < vertCount; j++) {
-                            double length = vertices[j].DistanceTo(vertices[(j + 1) % vertCount]);
-                            edgeLengths[j] = length;
-                            minEdge = length < minEdge ? length : minEdge;
-                            maxEdge = length > maxEdge ? length : maxEdge;
-                        }
-                        double aspectRatio = maxEdge / (minEdge + context.AbsoluteTolerance);
-
-                        double skewness = isQuad
-                            ? ((double[])[
-                                Vector3d.VectorAngle(vertices[1] - vertices[0], vertices[3] - vertices[0]),
-                                Vector3d.VectorAngle(vertices[2] - vertices[1], vertices[0] - vertices[1]),
-                                Vector3d.VectorAngle(vertices[3] - vertices[2], vertices[1] - vertices[2]),
-                                Vector3d.VectorAngle(vertices[0] - vertices[3], vertices[2] - vertices[3]),
-                            ]).Max(angle => Math.Abs(RhinoMath.ToDegrees(angle) - AnalysisConfig.QuadIdealAngleDegrees)) / AnalysisConfig.QuadIdealAngleDegrees
-                            : (vertices[1] - vertices[0], vertices[2] - vertices[0], vertices[2] - vertices[1]) is (Vector3d ab, Vector3d ac, Vector3d bc)
-                                ? (
-                                    RhinoMath.ToDegrees(Vector3d.VectorAngle(ab, ac)),
-                                    RhinoMath.ToDegrees(Vector3d.VectorAngle(bc, -ab)),
-                                    RhinoMath.ToDegrees(Vector3d.VectorAngle(-ac, -bc))
-                                ) is (double angleA, double angleB, double angleC)
-                                    ? Math.Max(Math.Abs(angleA - AnalysisConfig.TriangleIdealAngleDegrees), Math.Max(Math.Abs(angleB - AnalysisConfig.TriangleIdealAngleDegrees), Math.Abs(angleC - AnalysisConfig.TriangleIdealAngleDegrees))) / AnalysisConfig.TriangleIdealAngleDegrees
-                                    : 1.0
-                                : 1.0;
-
-                        double jacobian = isQuad
-                            ? edgeLengths.Take(4).Average() is double avgLen && avgLen > context.AbsoluteTolerance
-                                ? ((double[])[
-                                    Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[3] - vertices[0]).Length,
-                                    Vector3d.CrossProduct(vertices[2] - vertices[1], vertices[0] - vertices[1]).Length,
-                                    Vector3d.CrossProduct(vertices[3] - vertices[2], vertices[1] - vertices[2]).Length,
-                                    Vector3d.CrossProduct(vertices[0] - vertices[3], vertices[2] - vertices[3]).Length,
-                                ]).Min() / ((avgLen * avgLen) + context.AbsoluteTolerance)
-                                : 0.0
-                            : edgeLengths.Take(3).Average() is double triAvgLen && triAvgLen > context.AbsoluteTolerance
-                                ? Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[2] - vertices[0]).Length / ((2.0 * triAvgLen * triAvgLen) + context.AbsoluteTolerance)
-                                : 0.0;
-
-                        return (AspectRatio: aspectRatio, Skewness: skewness, Jacobian: jacobian);
-                    }),
-                    ];
-                    return metrics.Length > 0
-                        ? ResultFactory.Create<(double[], double[], double[], int[], (int, int))>(value: (
-                            [.. metrics.Select(m => m.AspectRatio),],
-                            [.. metrics.Select(m => m.Skewness),],
-                            [.. metrics.Select(m => m.Jacobian),],
-                            [.. metrics.Select((m, i) => (m, i)).Where(pair => pair.m.AspectRatio > AnalysisConfig.AspectRatioCritical || pair.m.Skewness > AnalysisConfig.SkewnessCritical || pair.m.Jacobian < AnalysisConfig.JacobianCritical).Select(pair => pair.i),],
-                            (metrics.Count(m => m.AspectRatio > AnalysisConfig.AspectRatioWarning || m.Skewness > AnalysisConfig.SkewnessWarning || m.Jacobian < AnalysisConfig.JacobianWarning), metrics.Count(m => m.AspectRatio > AnalysisConfig.AspectRatioCritical || m.Skewness > AnalysisConfig.SkewnessCritical || m.Jacobian < AnalysisConfig.JacobianCritical))))
-                        : ResultFactory.Create<(double[], double[], double[], int[], (int, int))>(error: E.Geometry.MeshAnalysisFailed);
-                } finally {
-                    ArrayPool<Point3d>.Shared.Return(vertices, clearArray: true);
-                    ArrayPool<double>.Shared.Return(edgeLengths, clearArray: true);
+        for (int i = 0; i < gridSize; i++) {
+            double u = surface.Domain(0).ParameterAt(i / gridDivisor);
+            for (int j = 0; j < gridSize; j++) {
+                double v = surface.Domain(1).ParameterAt(j / gridDivisor);
+                uvGrid[uvIndex] = (u, v);
+                uvIndex++;
+                SurfaceCurvature sc = surface.CurvatureAt(u: u, v: v);
+                if (RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)) {
+                    curvatures[validCount] = sc;
+                    validCount++;
                 }
-            });
+            }
+        }
+        SurfaceCurvature[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
+        Interval uDomain = surface.Domain(0);
+        Interval vDomain = surface.Domain(1);
+        double uSpan = uDomain.Length;
+        double vSpan = vDomain.Length;
+        double singularityThresholdU = RhinoMath.Clamp(
+            uSpan * metadata.SingularityProximityFactor,
+            RhinoMath.SqrtEpsilon,
+            uSpan * metadata.SingularityBoundaryFraction);
+        double singularityThresholdV = RhinoMath.Clamp(
+            vSpan * metadata.SingularityProximityFactor,
+            RhinoMath.SqrtEpsilon,
+            vSpan * metadata.SingularityBoundaryFraction);
+        return validCurvatures.Length > 0
+            && validCurvatures.Select(sc => Math.Abs(sc.Gaussian)).Order().ToArray() is double[] gaussianSorted
+            && (gaussianSorted.Length % 2 is 0 ? (gaussianSorted[(gaussianSorted.Length / 2) - 1] + gaussianSorted[gaussianSorted.Length / 2]) / 2.0 : gaussianSorted[gaussianSorted.Length / 2]) is double medianGaussian
+            && validCurvatures.Average(sc => Math.Abs(sc.Gaussian)) is double avgGaussian
+            && Math.Sqrt(validCurvatures.Sum(sc => Math.Pow(Math.Abs(sc.Gaussian) - avgGaussian, 2)) / validCurvatures.Length) is double stdDevGaussian
+            ? ResultFactory.Create(value: (
+                GaussianSamples: validCurvatures.Select(sc => sc.Gaussian).ToArray(),
+                MeanSamples: validCurvatures.Select(sc => sc.Mean).ToArray(),
+                Singularities: uvGrid.Where(uv =>
+                    surface.IsAtSingularity(u: uv.u, v: uv.v, exact: false)
+                    || Math.Min(Math.Abs(uv.u - uDomain.Min), Math.Abs(uDomain.Max - uv.u)) <= singularityThresholdU
+                    || Math.Min(Math.Abs(uv.v - vDomain.Min), Math.Abs(vDomain.Max - uv.v)) <= singularityThresholdV).ToArray(),
+                UniformityScore: RhinoMath.Clamp(medianGaussian > context.AbsoluteTolerance ? (1.0 - (stdDevGaussian / (medianGaussian * metadata.HighCurvatureMultiplier))) : gaussianSorted[^1] < context.AbsoluteTolerance ? 1.0 : 0.0, 0.0, 1.0)))
+            : ResultFactory.Create<(double[], double[], (double, double)[], double)>(error: E.Geometry.SurfaceAnalysisFailed.WithContext("No valid curvature samples"));
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(double SmoothnessScore, double[] CurvatureSamples, (double Parameter, bool IsSharp)[] InflectionPoints, double EnergyMetric)> CurveFairness(
+        Curve curve,
+        IGeometryContext context,
+        AnalysisConfig.CurveFairnessMetadata metadata) {
+        int sampleCount = metadata.SampleCount;
+        (double Parameter, Vector3d Curvature)[] samples = new (double, Vector3d)[sampleCount];
+        double[] curvatures = new double[sampleCount];
+        int validCount = 0;
+        double sampleDivisor = sampleCount - 1.0;
+
+        for (int i = 0; i < sampleCount; i++) {
+            double t = curve.Domain.ParameterAt(i / sampleDivisor);
+            Vector3d curvature = curve.CurvatureAt(t);
+            if (curvature.IsValid) {
+                samples[validCount] = (t, curvature);
+                curvatures[validCount] = curvature.Length;
+                validCount++;
+            }
+        }
+        (double Parameter, Vector3d Curvature)[] validSamples = samples.AsSpan(0, validCount).ToArray();
+        double[] validCurvatures = curvatures.AsSpan(0, validCount).ToArray();
+        return validSamples.Length > 2
+            && Enumerable.Range(1, validCurvatures.Length - 1).Sum(i => Math.Abs(validCurvatures[i] - validCurvatures[i - 1])) / (validCurvatures.Length - 1) is double avgDiff
+            && curve.GetLength() is double curveLength
+            ? ResultFactory.Create(value: (
+                SmoothnessScore: RhinoMath.Clamp(1.0 / (1.0 + (avgDiff * metadata.SmoothnessSensitivity)), 0.0, 1.0),
+                CurvatureSamples: validCurvatures,
+                InflectionPoints: Enumerable.Range(1, validCurvatures.Length - 2)
+                    .Where(i => Math.Abs((validCurvatures[i] - validCurvatures[i - 1]) - (validCurvatures[i + 1] - validCurvatures[i])) > metadata.InflectionSharpnessThreshold || ((validCurvatures[i] - validCurvatures[i - 1]) * (validCurvatures[i + 1] - validCurvatures[i])) < 0)
+                    .Select(i => (validSamples[i].Parameter, Math.Abs(validCurvatures[i] - validCurvatures[i - 1]) > metadata.InflectionSharpnessThreshold))
+                    .ToArray(),
+                EnergyMetric: validCurvatures.Max() is double maxCurv && maxCurv > context.AbsoluteTolerance
+                    ? (validCurvatures.Sum(k => k * k) * (curveLength / (metadata.SampleCount - 1))) / (maxCurv * curveLength)
+                    : 0.0))
+            : ResultFactory.Create<(double, double[], (double, bool)[], double)>(error: E.Geometry.CurveAnalysisFailed.WithContext("Insufficient valid curvature samples"));
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(double[] AspectRatios, double[] Skewness, double[] Jacobians, int[] ProblematicFaces, (int Warning,int Critical) Counts)> MeshForFEA(
+        Mesh mesh,
+        IGeometryContext context,
+        AnalysisConfig.MeshQualityMetadata metadata) {
+        Point3d[] vertices = ArrayPool<Point3d>.Shared.Rent(4);
+        double[] edgeLengths = ArrayPool<double>.Shared.Rent(4);
+        try {
+            (double AspectRatio, double Skewness, double Jacobian)[] metrics = [.. Enumerable.Range(0, mesh.Faces.Count).Select(i => {
+                Point3d center = mesh.Faces.GetFaceCenter(i);
+                MeshFace face = mesh.Faces[i];
+                bool isQuad = face.IsQuad;
+                bool validIndices = face.A >= 0 && face.A < mesh.Vertices.Count
+                    && face.B >= 0 && face.B < mesh.Vertices.Count
+                    && face.C >= 0 && face.C < mesh.Vertices.Count
+                    && (!isQuad || (face.D >= 0 && face.D < mesh.Vertices.Count));
+
+                vertices[0] = validIndices ? (Point3d)mesh.Vertices[face.A] : center;
+                vertices[1] = validIndices ? (Point3d)mesh.Vertices[face.B] : center;
+                vertices[2] = validIndices ? (Point3d)mesh.Vertices[face.C] : center;
+                vertices[3] = validIndices && isQuad ? (Point3d)mesh.Vertices[face.D] : vertices[0];
+
+                int vertCount = isQuad ? 4 : 3;
+
+                double minEdge = double.MaxValue;
+                double maxEdge = double.MinValue;
+                for (int j = 0; j < vertCount; j++) {
+                    double length = vertices[j].DistanceTo(vertices[(j + 1) % vertCount]);
+                    edgeLengths[j] = length;
+                    minEdge = length < minEdge ? length : minEdge;
+                    maxEdge = length > maxEdge ? length : maxEdge;
+                }
+                double aspectRatio = maxEdge / (minEdge + context.AbsoluteTolerance);
+
+                double skewness = isQuad
+                    ? ((double[])[
+                        Vector3d.VectorAngle(vertices[1] - vertices[0], vertices[3] - vertices[0]),
+                        Vector3d.VectorAngle(vertices[2] - vertices[1], vertices[0] - vertices[1]),
+                        Vector3d.VectorAngle(vertices[3] - vertices[2], vertices[1] - vertices[2]),
+                        Vector3d.VectorAngle(vertices[0] - vertices[3], vertices[2] - vertices[3]),
+                    ]).Max(angle => Math.Abs(RhinoMath.ToDegrees(angle) - metadata.QuadIdealAngleDegrees)) / metadata.QuadIdealAngleDegrees
+                    : (vertices[1] - vertices[0], vertices[2] - vertices[0], vertices[2] - vertices[1]) is (Vector3d ab, Vector3d ac, Vector3d bc)
+                        ? (
+                            RhinoMath.ToDegrees(Vector3d.VectorAngle(ab, ac)),
+                            RhinoMath.ToDegrees(Vector3d.VectorAngle(bc, -ab)),
+                            RhinoMath.ToDegrees(Vector3d.VectorAngle(-ac, -bc))
+                        ) is (double angleA, double angleB, double angleC)
+                            ? Math.Max(Math.Abs(angleA - metadata.TriangleIdealAngleDegrees), Math.Max(Math.Abs(angleB - metadata.TriangleIdealAngleDegrees), Math.Abs(angleC - metadata.TriangleIdealAngleDegrees))) / metadata.TriangleIdealAngleDegrees
+                            : 1.0
+                        : 1.0;
+
+                double jacobian = isQuad
+                    ? edgeLengths.Take(4).Average() is double avgLen && avgLen > context.AbsoluteTolerance
+                        ? ((double[])[
+                            Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[3] - vertices[0]).Length,
+                            Vector3d.CrossProduct(vertices[2] - vertices[1], vertices[0] - vertices[1]).Length,
+                            Vector3d.CrossProduct(vertices[3] - vertices[2], vertices[1] - vertices[2]).Length,
+                            Vector3d.CrossProduct(vertices[0] - vertices[3], vertices[2] - vertices[3]).Length,
+                        ]).Min() / ((avgLen * avgLen) + context.AbsoluteTolerance)
+                        : 0.0
+                    : edgeLengths.Take(3).Average() is double triAvgLen && triAvgLen > context.AbsoluteTolerance
+                        ? Vector3d.CrossProduct(vertices[1] - vertices[0], vertices[2] - vertices[0]).Length / ((2.0 * triAvgLen * triAvgLen) + context.AbsoluteTolerance)
+                        : 0.0;
+
+                return (AspectRatio: aspectRatio, Skewness: skewness, Jacobian: jacobian);
+            }),
+            ];
+            return metrics.Length > 0
+                ? ResultFactory.Create<(double[], double[], double[], int[], (int, int))>(value: (
+                    [.. metrics.Select(m => m.AspectRatio),],
+                    [.. metrics.Select(m => m.Skewness),],
+                    [.. metrics.Select(m => m.Jacobian),],
+                    [.. metrics.Select((m, i) => (m, i)).Where(pair => pair.m.AspectRatio > metadata.AspectRatioCritical || pair.m.Skewness > metadata.SkewnessCritical || pair.m.Jacobian < metadata.JacobianCritical).Select(pair => pair.i),],
+                    (metrics.Count(m => m.AspectRatio > metadata.AspectRatioWarning || m.Skewness > metadata.SkewnessWarning || m.Jacobian < metadata.JacobianWarning), metrics.Count(m => m.AspectRatio > metadata.AspectRatioCritical || m.Skewness > metadata.SkewnessCritical || m.Jacobian < metadata.JacobianCritical))))
+                : ResultFactory.Create<(double[], double[], double[], int[], (int, int))>(error: E.Geometry.MeshAnalysisFailed);
+        } finally {
+            ArrayPool<Point3d>.Shared.Return(vertices, clearArray: true);
+            ArrayPool<double>.Shared.Return(edgeLengths, clearArray: true);
+        }
+    }
 }

--- a/libs/rhino/analysis/AnalysisConfig.cs
+++ b/libs/rhino/analysis/AnalysisConfig.cs
@@ -1,65 +1,159 @@
+using System;
 using System.Collections.Frozen;
+using System.Diagnostics.Contracts;
 using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Analysis;
 
-/// <summary>Validation modes and constants for differential geometry.</summary>
+/// <summary>Unified metadata and constants for analysis operations.</summary>
+[Pure]
 internal static class AnalysisConfig {
-    /// <summary>Type-to-validation mode mapping for geometry analysis.</summary>
-    internal static readonly FrozenDictionary<Type, V> ValidationModes =
-        new Dictionary<Type, V> {
-            [typeof(Curve)] = V.Standard | V.Degeneracy,
-            [typeof(NurbsCurve)] = V.Standard | V.Degeneracy | V.NurbsGeometry,
-            [typeof(LineCurve)] = V.Standard | V.Degeneracy,
-            [typeof(ArcCurve)] = V.Standard | V.Degeneracy,
-            [typeof(PolyCurve)] = V.Standard | V.Degeneracy | V.PolycurveStructure,
-            [typeof(PolylineCurve)] = V.Standard | V.Degeneracy,
-            [typeof(Surface)] = V.Standard | V.UVDomain,
-            [typeof(NurbsSurface)] = V.Standard | V.NurbsGeometry | V.UVDomain,
-            [typeof(PlaneSurface)] = V.Standard,
-            [typeof(Brep)] = V.Standard | V.Topology,
-            [typeof(Extrusion)] = V.Standard | V.Topology | V.ExtrusionGeometry,
-            [typeof(Mesh)] = V.Standard | V.MeshSpecific,
+    internal static readonly FrozenDictionary<Type, DifferentialMetadata> DifferentialOperations =
+        new Dictionary<Type, DifferentialMetadata> {
+            [typeof(Curve)] = new(
+                ValidationMode: V.Standard | V.Degeneracy,
+                OperationName: "Analysis.Curve",
+                FrameSampleCount: 5,
+                MaxDiscontinuities: 20,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(NurbsCurve)] = new(
+                ValidationMode: V.Standard | V.Degeneracy | V.NurbsGeometry,
+                OperationName: "Analysis.NurbsCurve",
+                FrameSampleCount: 5,
+                MaxDiscontinuities: 20,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(LineCurve)] = new(
+                ValidationMode: V.Standard | V.Degeneracy,
+                OperationName: "Analysis.LineCurve",
+                FrameSampleCount: 5,
+                MaxDiscontinuities: 20,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(ArcCurve)] = new(
+                ValidationMode: V.Standard | V.Degeneracy,
+                OperationName: "Analysis.ArcCurve",
+                FrameSampleCount: 5,
+                MaxDiscontinuities: 20,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(PolyCurve)] = new(
+                ValidationMode: V.Standard | V.Degeneracy | V.PolycurveStructure,
+                OperationName: "Analysis.PolyCurve",
+                FrameSampleCount: 5,
+                MaxDiscontinuities: 20,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(PolylineCurve)] = new(
+                ValidationMode: V.Standard | V.Degeneracy,
+                OperationName: "Analysis.PolylineCurve",
+                FrameSampleCount: 5,
+                MaxDiscontinuities: 20,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(Surface)] = new(
+                ValidationMode: V.Standard | V.UVDomain,
+                OperationName: "Analysis.Surface",
+                FrameSampleCount: 0,
+                MaxDiscontinuities: 0,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(NurbsSurface)] = new(
+                ValidationMode: V.Standard | V.NurbsGeometry | V.UVDomain,
+                OperationName: "Analysis.NurbsSurface",
+                FrameSampleCount: 0,
+                MaxDiscontinuities: 0,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(PlaneSurface)] = new(
+                ValidationMode: V.Standard,
+                OperationName: "Analysis.PlaneSurface",
+                FrameSampleCount: 0,
+                MaxDiscontinuities: 0,
+                ClosestPointToleranceMultiplier: 1.0),
+            [typeof(Brep)] = new(
+                ValidationMode: V.Standard | V.Topology,
+                OperationName: "Analysis.Brep",
+                FrameSampleCount: 0,
+                MaxDiscontinuities: 0,
+                ClosestPointToleranceMultiplier: 100.0),
+            [typeof(Extrusion)] = new(
+                ValidationMode: V.Standard | V.Topology | V.ExtrusionGeometry,
+                OperationName: "Analysis.Extrusion",
+                FrameSampleCount: 0,
+                MaxDiscontinuities: 0,
+                ClosestPointToleranceMultiplier: 100.0),
+            [typeof(Mesh)] = new(
+                ValidationMode: V.Standard | V.MeshSpecific,
+                OperationName: "Analysis.Mesh",
+                FrameSampleCount: 0,
+                MaxDiscontinuities: 0,
+                ClosestPointToleranceMultiplier: 1.0),
         }.ToFrozenDictionary();
 
-    /// <summary>Maximum discontinuity count per curve for C1/C2 detection.</summary>
-    internal const int MaxDiscontinuities = 20;
-    /// <summary>Default derivative order for position, tangent, and curvature computation.</summary>
+    internal static readonly SurfaceQualityMetadata SurfaceQuality = new(
+        ValidationMode: V.Standard | V.BoundingBox | V.UVDomain,
+        OperationName: "Analysis.SurfaceQuality",
+        GridDimension: 10,
+        SingularityBoundaryFraction: 0.1,
+        SingularityProximityFactor: 0.01,
+        HighCurvatureMultiplier: 5.0);
+
+    internal static readonly CurveFairnessMetadata CurveFairness = new(
+        ValidationMode: V.Standard | V.Degeneracy | V.SurfaceContinuity,
+        OperationName: "Analysis.CurveFairness",
+        SampleCount: 50,
+        InflectionSharpnessThreshold: 0.5,
+        SmoothnessSensitivity: 10.0);
+
+    internal static readonly MeshQualityMetadata MeshQuality = new(
+        ValidationMode: V.Standard | V.MeshSpecific,
+        OperationName: "Analysis.MeshQuality",
+        AspectRatioWarning: 3.0,
+        AspectRatioCritical: 10.0,
+        SkewnessWarning: 0.5,
+        SkewnessCritical: 0.85,
+        JacobianWarning: 0.3,
+        JacobianCritical: 0.1,
+        TriangleIdealAngleDegrees: 60.0,
+        QuadIdealAngleDegrees: RhinoMath.ToDegrees(RhinoMath.HalfPI));
+
+    internal static readonly BatchMetadata Batch = new(
+        ValidationMode: V.None,
+        OperationName: "Analysis.Batch");
+
     internal const int DefaultDerivativeOrder = 2;
-    /// <summary>Number of perpendicular frames sampled along curve domain.</summary>
-    internal const int CurveFrameSampleCount = 5;
-    /// <summary>Sample count for curve fairness curvature comb analysis.</summary>
-    internal const int CurveFairnessSampleCount = 50;
 
-    /// <summary>Grid dimension for surface quality UV sampling (10×10).</summary>
-    internal const int SurfaceQualityGridDimension = 10;
-    /// <summary>Total surface quality sample count derived from grid dimensions.</summary>
-    internal const int SurfaceQualitySampleCount = SurfaceQualityGridDimension * SurfaceQualityGridDimension;
+    internal sealed record DifferentialMetadata(
+        V ValidationMode,
+        string OperationName,
+        int FrameSampleCount,
+        int MaxDiscontinuities,
+        double ClosestPointToleranceMultiplier);
 
-    /// <summary>Domain fraction defining boundary proximity for singularity detection.</summary>
-    internal const double SingularityBoundaryFraction = 0.1;
-    /// <summary>Singularity proximity threshold as domain fraction.</summary>
-    internal const double SingularityProximityFactor = 0.01;
-    /// <summary>High curvature threshold as multiplier of median for anomaly detection.</summary>
-    internal const double HighCurvatureMultiplier = 5.0;
-    /// <summary>Threshold for detecting sharp inflection points via curvature change.</summary>
-    internal const double InflectionSharpnessThreshold = 0.5;
-    /// <summary>Sensitivity factor for smoothness scoring via curvature variation.</summary>
-    internal const double SmoothnessSensitivity = 10.0;
-    /// <summary>Brep closest point tolerance multiplier relative to context.</summary>
-    internal const double BrepClosestPointToleranceMultiplier = 100.0;
+    internal sealed record SurfaceQualityMetadata(
+        V ValidationMode,
+        string OperationName,
+        int GridDimension,
+        double SingularityBoundaryFraction,
+        double SingularityProximityFactor,
+        double HighCurvatureMultiplier);
 
-    /// <summary>Mesh FEA quality thresholds.</summary>
-    internal const double AspectRatioWarning = 3.0;
-    internal const double AspectRatioCritical = 10.0;
-    internal const double SkewnessWarning = 0.5;
-    internal const double SkewnessCritical = 0.85;
-    internal const double JacobianWarning = 0.3;
-    internal const double JacobianCritical = 0.1;
+    internal sealed record CurveFairnessMetadata(
+        V ValidationMode,
+        string OperationName,
+        int SampleCount,
+        double InflectionSharpnessThreshold,
+        double SmoothnessSensitivity);
 
-    /// <summary>Ideal interior angles for element types.</summary>
-    internal const double TriangleIdealAngleDegrees = 60.0;
-    internal static readonly double QuadIdealAngleDegrees = RhinoMath.ToDegrees(RhinoMath.HalfPI);
+    internal sealed record MeshQualityMetadata(
+        V ValidationMode,
+        string OperationName,
+        double AspectRatioWarning,
+        double AspectRatioCritical,
+        double SkewnessWarning,
+        double SkewnessCritical,
+        double JacobianWarning,
+        double JacobianCritical,
+        double TriangleIdealAngleDegrees,
+        double QuadIdealAngleDegrees);
+
+    internal sealed record BatchMetadata(
+        V ValidationMode,
+        string OperationName);
 }

--- a/libs/rhino/analysis/AnalysisCore.cs
+++ b/libs/rhino/analysis/AnalysisCore.cs
@@ -1,4 +1,4 @@
-using System.Buffers;
+using System;
 using System.Collections.Frozen;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
@@ -7,157 +7,275 @@ using Arsenal.Core.Errors;
 using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
 using Arsenal.Core.Validation;
-using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Analysis;
 
-/// <summary>Differential geometry computation with pooled buffers and dispatch.</summary>
+/// <summary>Differential geometry computation with unified dispatch.</summary>
+[Pure]
 internal static class AnalysisCore {
-    private static readonly Func<Curve, IGeometryContext, double?, int, Result<Analysis.IResult>> CurveLogic = (cv, ctx, t, order) => {
-        double param = t ?? cv.Domain.Mid;
-        double[] buffer = ArrayPool<double>.Shared.Rent(AnalysisConfig.MaxDiscontinuities);
-        try {
-            (int discCount, double s) = (0, cv.Domain.Min);
-            while (discCount < AnalysisConfig.MaxDiscontinuities && cv.GetNextDiscontinuity(Continuity.C1_continuous, s, cv.Domain.Max, out double td)) {
-                buffer[discCount++] = td;
-                s = td + ctx.AbsoluteTolerance;
-            }
-            double[] disc = [.. buffer[..discCount]];
-            return cv.FrameAt(param, out Plane frame)
-                ? ((Func<Result<Analysis.IResult>>)(() => {
-                    using AreaMassProperties? amp = AreaMassProperties.Compute(cv);
-                    Vector3d[] derivatives = cv.DerivativeAt(param, order) is Vector3d[] d ? d : [];
-                    double[] frameParams = new double[AnalysisConfig.CurveFrameSampleCount];
-                    for (int i = 0; i < AnalysisConfig.CurveFrameSampleCount; i++) {
-                        frameParams[i] = cv.Domain.ParameterAt(AnalysisConfig.CurveFrameSampleCount > 1 ? i / (AnalysisConfig.CurveFrameSampleCount - 1.0) : 0.5);
-                    }
-                    Plane[] frames = cv.GetPerpendicularFrames(frameParams) is Plane[] pf ? pf : [];
-                    return amp is not null
-                        ? ResultFactory.Create(value: (Analysis.IResult)new Analysis.CurveData(
-                            cv.PointAt(param), derivatives, cv.CurvatureAt(param).Length, frame,
-                            frames,
-                            cv.TorsionAt(param), disc,
-                            [.. disc.Select(dp => cv.IsContinuous(Continuity.C2_continuous, dp) ? Continuity.C1_continuous : Continuity.C0_continuous),],
-                            cv.GetLength(), amp.Centroid))
-                        : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.CurveAnalysisFailed);
-                }))()
-                : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.CurveAnalysisFailed);
-        } finally {
-            ArrayPool<double>.Shared.Return(buffer, clearArray: true);
-        }
-    };
-
-    private static readonly Func<Surface, IGeometryContext, (double, double)?, int, Result<Analysis.IResult>> SurfaceLogic = (sf, _, uv, order) => {
-        (double u, double v) = uv ?? (sf.Domain(0).Mid, sf.Domain(1).Mid);
-        return sf.Evaluate(u, v, order, out Point3d _, out Vector3d[] derivs) && sf.FrameAt(u, v, out Plane frame)
-            ? ((Func<Result<Analysis.IResult>>)(() => {
-                SurfaceCurvature sc = sf.CurvatureAt(u, v);
-                using AreaMassProperties? amp = AreaMassProperties.Compute(sf);
-                return amp is not null && RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)
-                    ? ResultFactory.Create(value: (Analysis.IResult)new Analysis.SurfaceData(
-                        sf.PointAt(u, v), derivs, sc.Gaussian, sc.Mean, sc.Kappa(0), sc.Kappa(1),
-                        sc.Direction(0), sc.Direction(1), frame, frame.Normal,
-                        sf.IsAtSeam(u, v) != 0, sf.IsAtSingularity(u, v, exact: true), amp.Area, amp.Centroid))
-                    : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.SurfaceAnalysisFailed);
-            }))()
-            : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.SurfaceAnalysisFailed);
-    };
-    private static readonly FrozenDictionary<Type, V> Modes = AnalysisConfig.ValidationModes;
-
-    private static readonly FrozenDictionary<Type, (V Mode, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>> Compute)> _strategies =
-        ((Func<FrozenDictionary<Type, (V, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>>)>>)(() => {
-            Dictionary<Type, (V, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>>)> map = new() {
-                [typeof(Curve)] = (Modes[typeof(Curve)], (g, ctx, t, _, _, _, order) => CurveLogic((Curve)g, ctx, t, order)),
-                [typeof(NurbsCurve)] = (Modes[typeof(NurbsCurve)], (g, ctx, t, _, _, _, order) => CurveLogic((NurbsCurve)g, ctx, t, order)),
-                [typeof(LineCurve)] = (Modes[typeof(LineCurve)], (g, ctx, t, _, _, _, order) => CurveLogic((LineCurve)g, ctx, t, order)),
-                [typeof(ArcCurve)] = (Modes[typeof(ArcCurve)], (g, ctx, t, _, _, _, order) => CurveLogic((ArcCurve)g, ctx, t, order)),
-                [typeof(PolyCurve)] = (Modes[typeof(PolyCurve)], (g, ctx, t, _, _, _, order) => CurveLogic((PolyCurve)g, ctx, t, order)),
-                [typeof(PolylineCurve)] = (Modes[typeof(PolylineCurve)], (g, ctx, t, _, _, _, order) => CurveLogic((PolylineCurve)g, ctx, t, order)),
-                [typeof(Surface)] = (Modes[typeof(Surface)], (g, ctx, _, uv, _, _, order) => SurfaceLogic((Surface)g, ctx, uv, order)),
-                [typeof(NurbsSurface)] = (Modes[typeof(NurbsSurface)], (g, ctx, _, uv, _, _, order) => SurfaceLogic((NurbsSurface)g, ctx, uv, order)),
-                [typeof(PlaneSurface)] = (Modes[typeof(PlaneSurface)], (g, ctx, _, uv, _, _, order) => SurfaceLogic((PlaneSurface)g, ctx, uv, order)),
-                [typeof(Brep)] = (Modes[typeof(Brep)], (g, ctx, _, uv, faceIdx, testPt, order) => {
-                    Brep brep = (Brep)g;
-                    int fIdx = RhinoMath.Clamp(faceIdx ?? 0, 0, brep.Faces.Count - 1);
-                    using Surface sf = brep.Faces[fIdx].UnderlyingSurface();
-                    (double u, double v) = uv ?? (sf.Domain(0).Mid, sf.Domain(1).Mid);
-                    Point3d testPoint = testPt ?? brep.GetBoundingBox(accurate: false).Center;
-                    return sf.Evaluate(u, v, order, out Point3d _, out Vector3d[] derivs) && sf.FrameAt(u, v, out Plane frame) &&
-                        brep.ClosestPoint(testPoint, out Point3d cp, out ComponentIndex ci, out double uOut, out double vOut, ctx.AbsoluteTolerance * AnalysisConfig.BrepClosestPointToleranceMultiplier, out Vector3d _)
-                        ? ((Func<Result<Analysis.IResult>>)(() => {
-                            SurfaceCurvature sc = sf.CurvatureAt(u, v);
-                            using AreaMassProperties? amp = AreaMassProperties.Compute(brep);
-                            using VolumeMassProperties? vmp = VolumeMassProperties.Compute(brep);
-                            return amp is not null && vmp is not null && RhinoMath.IsValidDouble(sc.Gaussian) && RhinoMath.IsValidDouble(sc.Mean)
-                                ? ResultFactory.Create(value: (Analysis.IResult)new Analysis.BrepData(
-                                    sf.PointAt(u, v), derivs, sc.Gaussian, sc.Mean, sc.Kappa(0), sc.Kappa(1),
-                                    sc.Direction(0), sc.Direction(1), frame, frame.Normal,
-                                    [.. brep.Vertices.Select((vtx, i) => (i, vtx.Location)),],
-                                    [.. brep.Edges.Select((e, i) => (i, new Line(e.PointAtStart, e.PointAtEnd))),],
-                                    brep.IsManifold, brep.IsSolid, cp, testPoint.DistanceTo(cp),
-                                    ci, (uOut, vOut), amp.Area, vmp.Volume, vmp.Centroid))
-                                : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.BrepAnalysisFailed);
-                        }))()
-                        : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.BrepAnalysisFailed);
-                }
-                ),
-                [typeof(Mesh)] = (Modes[typeof(Mesh)], (g, _, _, _, vertIdx, _, _) => {
-                    Mesh mesh = (Mesh)g;
-                    int vIdx = RhinoMath.Clamp(vertIdx ?? 0, 0, mesh.Vertices.Count - 1);
-                    Vector3d normal = mesh.Normals.Count > vIdx ? mesh.Normals[vIdx] : Vector3d.ZAxis;
-                    return ((Func<Result<Analysis.IResult>>)(() => {
-                        using AreaMassProperties? amp = AreaMassProperties.Compute(mesh);
-                        using VolumeMassProperties? vmp = VolumeMassProperties.Compute(mesh);
-                        return amp is not null && vmp is not null
-                            ? ResultFactory.Create(value: (Analysis.IResult)new Analysis.MeshData(
-                                mesh.Vertices[vIdx], new Plane(mesh.Vertices[vIdx], normal), normal,
-                                [.. Enumerable.Range(0, mesh.TopologyVertices.Count).Select(i => (i, (Point3d)mesh.TopologyVertices[i])),],
-                                [.. Enumerable.Range(0, mesh.TopologyEdges.Count).Select(i => (i, mesh.TopologyEdges.EdgeLine(i))),],
-                                mesh.IsManifold(topologicalTest: true, out bool _, out bool _), mesh.IsClosed, amp.Area, vmp.Volume))
-                            : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.MeshAnalysisFailed);
-                    }))();
-                }
-                ),
-            };
-
-            map[typeof(Extrusion)] = (Modes[typeof(Extrusion)], (g, ctx, _, uv, faceIdx, testPt, order) => ((Extrusion)g).ToBrep() is Brep extrusionBrep
-                ? ((Func<Result<Analysis.IResult>>)(() => {
-                    using Brep brep = extrusionBrep;
-                    return map[typeof(Brep)].Item2(brep, ctx, null, uv, faceIdx, testPt, order);
-                }))()
-                : ResultFactory.Create<Analysis.IResult>(error: E.Geometry.BrepAnalysisFailed));
-
-            return map.ToFrozenDictionary();
-        }))();
+    private static readonly FrozenDictionary<Type, DifferentialExecutor> DifferentialDispatch =
+        new Dictionary<Type, DifferentialExecutor> {
+            [typeof(Curve)] = CreateCurveExecutor(typeof(Curve)),
+            [typeof(NurbsCurve)] = CreateCurveExecutor(typeof(NurbsCurve)),
+            [typeof(LineCurve)] = CreateCurveExecutor(typeof(LineCurve)),
+            [typeof(ArcCurve)] = CreateCurveExecutor(typeof(ArcCurve)),
+            [typeof(PolyCurve)] = CreateCurveExecutor(typeof(PolyCurve)),
+            [typeof(PolylineCurve)] = CreateCurveExecutor(typeof(PolylineCurve)),
+            [typeof(Surface)] = CreateSurfaceExecutor(typeof(Surface)),
+            [typeof(NurbsSurface)] = CreateSurfaceExecutor(typeof(NurbsSurface)),
+            [typeof(PlaneSurface)] = CreateSurfaceExecutor(typeof(PlaneSurface)),
+            [typeof(Brep)] = CreateBrepExecutor(),
+            [typeof(Extrusion)] = CreateExtrusionExecutor(),
+            [typeof(Mesh)] = CreateMeshExecutor(),
+        }.ToFrozenDictionary();
 
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Result<IReadOnlyList<Analysis.IResult>> Execute(
-        object geometry,
-        IGeometryContext context,
-        double? t,
+        Analysis.DifferentialRequest request,
+        IGeometryContext context) =>
+        request switch {
+            Analysis.CurveAnalysis r => ExecuteSingle(
+                geometry: r.Geometry,
+                parameter: r.Parameter,
+                uv: null,
+                index: null,
+                testPoint: null,
+                derivativeOrder: r.DerivativeOrder,
+                key: typeof(Curve),
+                context: context),
+            Analysis.SurfaceAnalysis r => ExecuteSingle(
+                geometry: r.Geometry,
+                parameter: null,
+                uv: r.Parameter,
+                index: null,
+                testPoint: null,
+                derivativeOrder: r.DerivativeOrder,
+                key: typeof(Surface),
+                context: context),
+            Analysis.BrepAnalysis r => ExecuteSingle(
+                geometry: r.Geometry,
+                parameter: null,
+                uv: r.Parameter,
+                index: r.FaceIndex,
+                testPoint: r.TestPoint,
+                derivativeOrder: r.DerivativeOrder,
+                key: typeof(Brep),
+                context: context),
+            Analysis.ExtrusionAnalysis r => ExecuteSingle(
+                geometry: r.Geometry,
+                parameter: null,
+                uv: r.Parameter,
+                index: r.FaceIndex,
+                testPoint: r.TestPoint,
+                derivativeOrder: r.DerivativeOrder,
+                key: typeof(Extrusion),
+                context: context),
+            Analysis.MeshAnalysis r => ExecuteSingle(
+                geometry: r.Geometry,
+                parameter: null,
+                uv: null,
+                index: r.VertexIndex,
+                testPoint: null,
+                derivativeOrder: 0,
+                key: typeof(Mesh),
+                context: context),
+            Analysis.BatchAnalysis r => ExecuteBatch(request: r, context: context),
+            _ => ResultFactory.Create<IReadOnlyList<Analysis.IResult>>(error: E.Geometry.UnsupportedAnalysis.WithContext(request.GetType().Name)),
+        };
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(double[] GaussianCurvatures, double[] MeanCurvatures, (double U, double V)[] SingularityLocations, double UniformityScore)> AnalyzeQuality(
+        Analysis.SurfaceQualityAnalysis request,
+        IGeometryContext context) =>
+        UnifiedOperation.Apply(
+            request.Geometry,
+            (Func<Surface, Result<IReadOnlyList<(double[], double[], (double, double)[], double)>>>)(surface =>
+                AnalysisCompute.SurfaceQuality(surface: surface, context: context, metadata: AnalysisConfig.SurfaceQuality)
+                    .Map(result => (IReadOnlyList<(double[], double[], (double, double)[], double)>)[result])),
+            new OperationConfig<Surface, (double[], double[], (double, double)[], double)> {
+                Context = context,
+                ValidationMode = AnalysisConfig.SurfaceQuality.ValidationMode,
+                OperationName = AnalysisConfig.SurfaceQuality.OperationName,
+                EnableDiagnostics = false,
+                AccumulateErrors = false,
+                EnableCache = false,
+                SkipInvalid = false,
+            })
+            .Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(double SmoothnessScore, double[] CurvatureSamples, (double Parameter, bool IsSharp)[] InflectionPoints, double EnergyMetric)> AnalyzeQuality(
+        Analysis.CurveFairnessAnalysis request,
+        IGeometryContext context) =>
+        UnifiedOperation.Apply(
+            request.Geometry,
+            (Func<Curve, Result<IReadOnlyList<(double, double[], (double, bool)[], double)>>>)(curve =>
+                AnalysisCompute.CurveFairness(curve: curve, context: context, metadata: AnalysisConfig.CurveFairness)
+                    .Map(result => (IReadOnlyList<(double, double[], (double, bool)[], double)>)[result])),
+            new OperationConfig<Curve, (double, double[], (double, bool)[], double)> {
+                Context = context,
+                ValidationMode = AnalysisConfig.CurveFairness.ValidationMode,
+                OperationName = AnalysisConfig.CurveFairness.OperationName,
+                EnableDiagnostics = false,
+                AccumulateErrors = false,
+                EnableCache = false,
+                SkipInvalid = false,
+            })
+            .Map(results => results[0]);
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Result<(double[] AspectRatios, double[] Skewness, double[] Jacobians, int[] ProblematicFaces, (int WarningCount, int CriticalCount) QualityFlags)> AnalyzeQuality(
+        Analysis.MeshQualityAnalysis request,
+        IGeometryContext context) =>
+        UnifiedOperation.Apply(
+            request.Geometry,
+            (Func<Mesh, Result<IReadOnlyList<(double[], double[], double[], int[], (int, int))>>>)(mesh =>
+                AnalysisCompute.MeshForFEA(mesh: mesh, context: context, metadata: AnalysisConfig.MeshQuality)
+                    .Map(result => (IReadOnlyList<(double[], double[], double[], int[], (int, int))>)[result])),
+            new OperationConfig<Mesh, (double[], double[], double[], int[], (int, int))> {
+                Context = context,
+                ValidationMode = AnalysisConfig.MeshQuality.ValidationMode,
+                OperationName = AnalysisConfig.MeshQuality.OperationName,
+                EnableDiagnostics = false,
+                AccumulateErrors = false,
+                EnableCache = false,
+                SkipInvalid = false,
+            })
+            .Map(results => results[0]);
+
+    private static Result<IReadOnlyList<Analysis.IResult>> ExecuteBatch(
+        Analysis.BatchAnalysis request,
+        IGeometryContext context) =>
+        UnifiedOperation.Apply(
+            request.Geometries,
+            (Func<object, Result<IReadOnlyList<Analysis.IResult>>>)(item =>
+                item is GeometryBase geometry
+                    ? ExecuteSingle(
+                        geometry: geometry,
+                        parameter: request.Parameter,
+                        uv: request.UvParameter,
+                        index: request.Index,
+                        testPoint: request.TestPoint,
+                        derivativeOrder: request.DerivativeOrder,
+                        key: geometry.GetType(),
+                        context: context)
+                    : ResultFactory.Create<IReadOnlyList<Analysis.IResult>>(error: E.Geometry.UnsupportedAnalysis.WithContext(item.GetType().Name)))),
+            new OperationConfig<object, Analysis.IResult> {
+                Context = context,
+                ValidationMode = AnalysisConfig.Batch.ValidationMode,
+                OperationName = AnalysisConfig.Batch.OperationName,
+                EnableDiagnostics = false,
+                AccumulateErrors = false,
+                EnableCache = true,
+                SkipInvalid = false,
+            });
+
+    private static Result<IReadOnlyList<Analysis.IResult>> ExecuteSingle(
+        GeometryBase geometry,
+        double? parameter,
         (double, double)? uv,
         int? index,
         Point3d? testPoint,
-        int derivativeOrder) =>
-        _strategies.TryGetValue(geometry.GetType(), out (V mode, Func<object, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>> compute) strategy)
+        int derivativeOrder,
+        Type key,
+        IGeometryContext context) =>
+        DifferentialDispatch.TryGetValue(key, out DifferentialExecutor? executor)
             ? UnifiedOperation.Apply(
                 geometry,
-                (Func<object, Result<IReadOnlyList<Analysis.IResult>>>)(item =>
-                    ResultFactory.Create(value: item)
-                        .Validate(args: [context, strategy.mode,])
-                        .Bind(valid =>
-                            strategy.compute(valid, context, t, uv, index, testPoint, derivativeOrder)
-                                .Map(result => (IReadOnlyList<Analysis.IResult>)[result])
-                        )),
-                new OperationConfig<object, Analysis.IResult> {
+                (Func<GeometryBase, Result<IReadOnlyList<Analysis.IResult>>>)(item =>
+                    executor.Executor(item, context, parameter, uv, index, testPoint, derivativeOrder)
+                        .Map(result => (IReadOnlyList<Analysis.IResult>)[result])),
+                new OperationConfig<GeometryBase, Analysis.IResult> {
                     Context = context,
-                    ValidationMode = V.None,
-                    OperationName = $"Analysis.{geometry.GetType().Name}",
+                    ValidationMode = executor.Metadata.ValidationMode,
+                    OperationName = executor.Metadata.OperationName,
                     EnableDiagnostics = false,
                     AccumulateErrors = false,
                     EnableCache = false,
                     SkipInvalid = false,
                 })
-            : ResultFactory.Create<IReadOnlyList<Analysis.IResult>>(error: E.Geometry.UnsupportedAnalysis.WithContext(geometry.GetType().Name));
+            : ResultFactory.Create<IReadOnlyList<Analysis.IResult>>(error: E.Geometry.UnsupportedAnalysis.WithContext(key.Name));
+
+    private static DifferentialExecutor CreateCurveExecutor(Type type) {
+        AnalysisConfig.DifferentialMetadata metadata = AnalysisConfig.DifferentialOperations[type];
+        return new DifferentialExecutor(
+            Metadata: metadata,
+            Executor: (geometry, context, parameter, _, _, _, derivativeOrder) => AnalysisCompute.CurveDifferential(
+                curve: (Curve)geometry,
+                context: context,
+                parameter: parameter ?? ((Curve)geometry).Domain.Mid,
+                derivativeOrder: derivativeOrder,
+                metadata: metadata)
+                .Map(result => (Analysis.IResult)result));
+    }
+
+    private static DifferentialExecutor CreateSurfaceExecutor(Type type) {
+        AnalysisConfig.DifferentialMetadata metadata = AnalysisConfig.DifferentialOperations[type];
+        return new DifferentialExecutor(
+            Metadata: metadata,
+            Executor: (geometry, _, _, uv, _, _, derivativeOrder) => {
+                Surface surface = (Surface)geometry;
+                (double u, double v) = uv ?? (surface.Domain(0).Mid, surface.Domain(1).Mid);
+                return AnalysisCompute.SurfaceDifferential(
+                    surface: surface,
+                    u: u,
+                    v: v,
+                    derivativeOrder: derivativeOrder)
+                    .Map(result => (Analysis.IResult)result);
+            });
+    }
+
+    private static DifferentialExecutor CreateBrepExecutor() {
+        AnalysisConfig.DifferentialMetadata metadata = AnalysisConfig.DifferentialOperations[typeof(Brep)];
+        return new DifferentialExecutor(
+            Metadata: metadata,
+            Executor: (geometry, context, _, uv, index, testPoint, derivativeOrder) => {
+                Brep brep = (Brep)geometry;
+                (double u, double v) = uv ?? (brep.Faces.Count > 0 ? brep.Faces[0].Domain(0).Mid : 0.5, brep.Faces.Count > 0 ? brep.Faces[0].Domain(1).Mid : 0.5);
+                Point3d probe = testPoint ?? brep.GetBoundingBox(accurate: false).Center;
+                return AnalysisCompute.BrepDifferential(
+                    brep: brep,
+                    context: context,
+                    uv: (u, v),
+                    faceIndex: index ?? 0,
+                    testPoint: probe,
+                    derivativeOrder: derivativeOrder,
+                    toleranceMultiplier: metadata.ClosestPointToleranceMultiplier)
+                    .Map(result => (Analysis.IResult)result);
+            });
+    }
+
+    private static DifferentialExecutor CreateExtrusionExecutor() {
+        AnalysisConfig.DifferentialMetadata metadata = AnalysisConfig.DifferentialOperations[typeof(Extrusion)];
+        return new DifferentialExecutor(
+            Metadata: metadata,
+            Executor: (geometry, context, _, uv, index, testPoint, derivativeOrder) =>
+                ((Extrusion)geometry).ToBrep() is Brep brep
+                    ? AnalysisCompute.BrepDifferential(
+                        brep: brep,
+                        context: context,
+                        uv: uv ?? (brep.Faces.Count > 0 ? brep.Faces[0].Domain(0).Mid : 0.5, brep.Faces.Count > 0 ? brep.Faces[0].Domain(1).Mid : 0.5),
+                        faceIndex: index ?? 0,
+                        testPoint: testPoint ?? brep.GetBoundingBox(accurate: false).Center,
+                        derivativeOrder: derivativeOrder,
+                        toleranceMultiplier: metadata.ClosestPointToleranceMultiplier)
+                        .Map(result => (Analysis.IResult)result)
+                    : ResultFactory.Create<Analysis.BrepData>(error: E.Geometry.BrepAnalysisFailed)
+                        .Map(result => (Analysis.IResult)result));
+    }
+
+    private static DifferentialExecutor CreateMeshExecutor() {
+        AnalysisConfig.DifferentialMetadata metadata = AnalysisConfig.DifferentialOperations[typeof(Mesh)];
+        return new DifferentialExecutor(
+            Metadata: metadata,
+            Executor: (geometry, _, _, _, index, _, _) => AnalysisCompute.MeshDifferential(
+                mesh: (Mesh)geometry,
+                vertexIndex: index ?? 0)
+                .Map(result => (Analysis.IResult)result));
+    }
+
+    private sealed record DifferentialExecutor(
+        AnalysisConfig.DifferentialMetadata Metadata,
+        Func<GeometryBase, IGeometryContext, double?, (double, double)?, int?, Point3d?, int, Result<Analysis.IResult>> Executor);
 }


### PR DESCRIPTION
## Summary
- restructure Analysis public API around algebraic request records for all analysis operations
- centralize validation and operation metadata in unified frozen dictionaries and metadata records
- route execution through AnalysisCore dispatchers into consolidated compute implementations using shared metadata

## Testing
- dotnet build *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4813de8083218f93452aa15e9e06)