### PR TITLE
Refine spatial proximity weighting and Delaunay validation

### DIFF
--- a/libs/rhino/spatial/SpatialCompute.cs
+++ b/libs/rhino/spatial/SpatialCompute.cs
@@ -396,8 +396,13 @@ internal static class SpatialCompute {
 
             (minX, minY, maxX, maxY) = (x < minX ? x : minX, y < minY ? y : minY, x > maxX ? x : maxX, y > maxY ? y : maxY);
         }
-        (double dx, double dy) = ((maxX - minX) * SpatialConfig.DelaunaySuperTriangleScale, (maxY - minY) * SpatialConfig.DelaunaySuperTriangleScale);
-        Point3d[] superTriangle = [new Point3d(minX - dx, minY - dy, z0), new Point3d(maxX + dx, minY - dy, z0), new Point3d(minX + ((maxX - minX) * SpatialConfig.DelaunaySuperTriangleCenterWeight), maxY + dy, z0),];
+        double extentX = maxX - minX;
+        double extentY = maxY - minY;
+        double extentTolerance = Math.Max(context.AbsoluteTolerance, RhinoMath.ZeroTolerance);
+        if (extentX <= extentTolerance || extentY <= extentTolerance) { return ResultFactory.Create<int[][]>(error: E.Validation.DegenerateGeometry.WithContext("DelaunayTriangulation2D requires non-collinear points")); }
+
+        (double dx, double dy) = (extentX * SpatialConfig.DelaunaySuperTriangleScale, extentY * SpatialConfig.DelaunaySuperTriangleScale);
+        Point3d[] superTriangle = [new Point3d(minX - dx, minY - dy, z0), new Point3d(maxX + dx, minY - dy, z0), new Point3d(minX + (extentX * SpatialConfig.DelaunaySuperTriangleCenterWeight), maxY + dy, z0),];
         HashSet<(int, int, int)> triangles = [(points.Length, points.Length + 1, points.Length + 2),];
         Point3d[] allPoints = [.. points, .. superTriangle,];
         for (int i = 0; i < points.Length; i++) {

--- a/libs/rhino/spatial/SpatialCore.cs
+++ b/libs/rhino/spatial/SpatialCore.cs
@@ -92,11 +92,11 @@ internal static class SpatialCore {
                     double angle = dist > context.AbsoluteTolerance ? Vector3d.VectorAngle(dir, toGeom / dist) : 0.0;
                     double weightedDist = dist * (1.0 + (request.AngleWeight * angle));
                     if (weightedDist <= request.MaxDistance) {
-                        results.Add(new Spatial.ProximityFieldResult(Index: args.Id, Distance: dist, Angle: angle));
+                        results.Add(new Spatial.ProximityFieldResult(Index: args.Id, Distance: dist, Angle: angle, WeightedDistance: weightedDist));
                     }
                 }
                 _ = tree.Search(searchSphere, CollectResults);
-                return ResultFactory.Create<Spatial.ProximityFieldResult[]>(value: [.. results.OrderBy(r => r.Distance * (1.0 + (request.AngleWeight * r.Angle))),]);
+                return ResultFactory.Create<Spatial.ProximityFieldResult[]>(value: [.. results.OrderBy(static r => r.WeightedDistance),]);
             }))(),
         };
 


### PR DESCRIPTION
## Summary
- adjust proximity field search to use spherical queries and order results by angle-weighted distance
- guard 2D Delaunay triangulation against degenerate extents when points are collinear or collapsed

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea53256f48321ab121c24e56f06a9)