### PR TITLE
Refactor Rhino intersection module structure

### DIFF
--- a/libs/rhino/intersection/Intersection.cs
+++ b/libs/rhino/intersection/Intersection.cs
@@ -43,11 +43,23 @@ public static class Intersection {
     public abstract record IntersectionType {
         private IntersectionType() { }
         /// <summary>Tangent intersection with near-parallel approach vectors.</summary>
-        public sealed record Tangent : IntersectionType;
+        public sealed record Tangent : IntersectionType {
+            private Tangent() { }
+            /// <summary>Singleton instance for tangent intersections.</summary>
+            public static Tangent Instance { get; } = new();
+        }
         /// <summary>Transverse intersection with significant angular separation.</summary>
-        public sealed record Transverse : IntersectionType;
+        public sealed record Transverse : IntersectionType {
+            private Transverse() { }
+            /// <summary>Singleton instance for transverse intersections.</summary>
+            public static Transverse Instance { get; } = new();
+        }
         /// <summary>Unknown classification when insufficient data available.</summary>
-        public sealed record Unknown : IntersectionType;
+        public sealed record Unknown : IntersectionType {
+            private Unknown() { }
+            /// <summary>Singleton instance for unknown classifications.</summary>
+            public static Unknown Instance { get; } = new();
+        }
     }
 
     /// <summary>Intersection operation result containing points, curves, parameters, and topology indices.</summary>
@@ -65,7 +77,7 @@ public static class Intersection {
     }
 
     /// <summary>Result of intersection classification analysis.</summary>
-    [DebuggerDisplay("Type={Type.Value}, IsGrazing={IsGrazing}, BlendScore={BlendScore:F3}")]
+    [DebuggerDisplay("Type={Type}, IsGrazing={IsGrazing}, BlendScore={BlendScore:F3}")]
     public sealed record ClassificationResult(
         IntersectionType Type,
         double[] ApproachAngles,

--- a/libs/rhino/intersection/Intersection.cs
+++ b/libs/rhino/intersection/Intersection.cs
@@ -39,15 +39,15 @@ public static class Intersection {
         double? Tolerance = null,
         bool Sorted = false);
 
-    /// <summary>Intersection type classification: tangent, transverse, or unknown.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct IntersectionType(byte Value) {
+    /// <summary>Base type for intersection type classification.</summary>
+    public abstract record IntersectionType {
+        private IntersectionType() { }
         /// <summary>Tangent intersection with near-parallel approach vectors.</summary>
-        public static readonly IntersectionType Tangent = new(0);
+        public sealed record Tangent : IntersectionType;
         /// <summary>Transverse intersection with significant angular separation.</summary>
-        public static readonly IntersectionType Transverse = new(1);
+        public sealed record Transverse : IntersectionType;
         /// <summary>Unknown classification when insufficient data available.</summary>
-        public static readonly IntersectionType Unknown = new(2);
+        public sealed record Unknown : IntersectionType;
     }
 
     /// <summary>Intersection operation result containing points, curves, parameters, and topology indices.</summary>

--- a/libs/rhino/intersection/IntersectionCompute.cs
+++ b/libs/rhino/intersection/IntersectionCompute.cs
@@ -147,8 +147,12 @@ internal static class IntersectionCompute {
                                                             ? Enumerable.Range(0, samplesPerDimension)
                                                                 .SelectMany(uIndex => Enumerable.Range(0, samplesPerDimension)
                                                                     .Select(vIndex => {
-                                                                        double u = uDomain.ParameterAt(uIndex / (double)(samplesPerDimension - 1));
-                                                                        double v = vDomain.ParameterAt(vIndex / (double)(samplesPerDimension - 1));
+                                                                        double u = samplesPerDimension > 1 
+                                                                            ? uDomain.ParameterAt(uIndex / (double)(samplesPerDimension - 1))
+                                                                            : uDomain.Mid;
+                                                                        double v = samplesPerDimension > 1
+                                                                            ? vDomain.ParameterAt(vIndex / (double)(samplesPerDimension - 1))
+                                                                            : vDomain.Mid;
                                                                         return entry.Face.IsAtSingularity(u, v, checkBothSides: true) ? Point3d.Unset : entry.Face.PointAt(u, v);
                                                                     }))
                                                                 .Where(static point => point.IsValid)

--- a/libs/rhino/intersection/IntersectionConfig.cs
+++ b/libs/rhino/intersection/IntersectionConfig.cs
@@ -104,6 +104,10 @@ internal static class IntersectionConfig {
     internal const double StabilityPerturbationFactor = 0.001;
     internal const int StabilitySampleCount = 8;
     internal const double UnstableCountDeltaThreshold = 1.0;
+    internal const double GoldenRatio = 1.618033988749894848204586834365638117720309179805762862135;
+
+    /// <summary>Minimum samples per Brep face for near-miss detection.</summary>
+    internal const int MinSamplesPerFace = 3;
 
     /// <summary>Blend quality scores for intersection types.</summary>
     internal const double TangentBlendScore = 1.0;

--- a/libs/rhino/intersection/IntersectionConfig.cs
+++ b/libs/rhino/intersection/IntersectionConfig.cs
@@ -103,6 +103,7 @@ internal static class IntersectionConfig {
     /// <summary>Stability analysis parameters.</summary>
     internal const double StabilityPerturbationFactor = 0.001;
     internal const int StabilitySampleCount = 8;
+    internal const double UnstableCountDeltaThreshold = 1.0;
 
     /// <summary>Blend quality scores for intersection types.</summary>
     internal const double TangentBlendScore = 1.0;

--- a/libs/rhino/intersection/IntersectionConfig.cs
+++ b/libs/rhino/intersection/IntersectionConfig.cs
@@ -104,7 +104,7 @@ internal static class IntersectionConfig {
     internal const double StabilityPerturbationFactor = 0.001;
     internal const int StabilitySampleCount = 8;
     internal const double UnstableCountDeltaThreshold = 1.0;
-    internal const double GoldenRatio = 1.618033988749894848204586834365638117720309179805762862135;
+    internal const double GoldenRatio = 1.618033988749895;
 
     /// <summary>Minimum samples per Brep face for near-miss detection.</summary>
     internal const int MinSamplesPerFace = 3;

--- a/libs/rhino/intersection/IntersectionCore.cs
+++ b/libs/rhino/intersection/IntersectionCore.cs
@@ -384,7 +384,7 @@ internal static class IntersectionCore {
             operation: (Func<GeometryBase, Result<IReadOnlyList<Intersection.ClassificationResult>>>)(geomA =>
                 IntersectionCompute.Classify(output: output, geomA: geomA, geomB: geometryB, context: context)
                     .Map(tuple => (IReadOnlyList<Intersection.ClassificationResult>)[new Intersection.ClassificationResult(
-                        Type: new Intersection.IntersectionType(tuple.Type),
+                        Type: tuple.Type,
                         ApproachAngles: tuple.ApproachAngles,
                         IsGrazing: tuple.IsGrazing,
                         BlendScore: tuple.BlendScore),


### PR DESCRIPTION
…ign with project patterns

## Critical Algorithmic Fixes

- **Brep near-miss sampling**: Replace geometrically invalid XY-plane grid with UV face parameterization sampling (IntersectionCompute.cs:137-156)
  - Previous implementation sampled single XY-plane at mid-Z, failing for non-planar Breps
  - New implementation samples each Brep face via UV domain, avoiding singularities

- **Spherical perturbation sampling**: Extend polar coverage to include south pole (IntersectionCompute.cs:193)
  - Changed range from [0, phiSteps) to [0, phiSteps+1) to include φ=π direction
  - Ensures full hemisphere coverage for stability analysis

- **Perturbation scale**: Consider both geometries when computing perturbation distance (IntersectionCompute.cs:201-204)
  - Previous implementation only used geometryA's bounding box diagonal
  - New implementation uses max(diagonalA, diagonalB) for appropriate scale

## Type System Improvements

- **IntersectionType refactoring**: Replace byte wrapper with algebraic sealed records pattern (Intersection.cs:42-51)
  - Aligns with Fields.CriticalPointKind and project algebraic type standards
  - Changes: `IntersectionType(byte)` → abstract base with `Tangent`, `Transverse`, `Unknown` sealed records
  - Updated all construction sites in IntersectionCompute.cs and IntersectionCore.cs

## Constant Normalization

- **Add UnstableCountDeltaThreshold constant**: Extract magic number 1.0 to IntersectionConfig.cs (line 106)
- **Fix RhinoMath consistency**: Replace `Math.PI` with `RhinoMath.PI` (IntersectionCompute.cs:196)
- **Use constant in stability analysis**: Replace hardcoded `1.0` with config constant (IntersectionCompute.cs:242)

## Parameter-Driven Improvements

- **Add perpendicularAngle intermediate variable**: Improve clarity in curve-surface classification (IntersectionCompute.cs:24)
- **Add maxDiagonalLength intermediate variable**: Make perturbation scale calculation explicit (IntersectionCompute.cs:201-203)

## Files Modified

- `libs/rhino/intersection/Intersection.cs`: IntersectionType algebraic refactor
- `libs/rhino/intersection/IntersectionConfig.cs`: Add UnstableCountDeltaThreshold constant
- `libs/rhino/intersection/IntersectionCore.cs`: Update IntersectionType construction
- `libs/rhino/intersection/IntersectionCompute.cs`: Algorithm fixes, constant normalization, intermediate variables

All changes preserve 4-file architecture, maintain UnifiedOperation wiring, and follow project coding standards.