### PR TITLE
Refactor transformation API into algebraic metadata-driven architecture

### DIFF
--- a/libs/rhino/transformation/Transformation.cs
+++ b/libs/rhino/transformation/Transformation.cs
@@ -1,10 +1,7 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
-using Arsenal.Core.Operations;
 using Arsenal.Core.Results;
-using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Transformation;
@@ -12,309 +9,122 @@ namespace Arsenal.Rhino.Transformation;
 /// <summary>Affine transforms, arrays, and deformations with unified polymorphic dispatch.</summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "MA0049:Type name should not match containing namespace", Justification = "Transformation is the primary API entry point for the Transformation namespace")]
 public static class Transformation {
-    /// <summary>Transform specification discriminated union.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct TransformSpec {
-        /// <summary>Direct transform matrix application.</summary>
-        public Transform? Matrix { get; init; }
-        /// <summary>Uniform scale: (anchor, factor).</summary>
-        public (Point3d Anchor, double Factor)? UniformScale { get; init; }
-        /// <summary>Non-uniform scale: (plane, xScale, yScale, zScale).</summary>
-        public (Plane Plane, double X, double Y, double Z)? NonUniformScale { get; init; }
-        /// <summary>Rotation: (angle radians, axis, center).</summary>
-        public (double Angle, Vector3d Axis, Point3d Center)? Rotation { get; init; }
-        /// <summary>Rotation from start direction to end direction: (start, end, center).</summary>
-        public (Vector3d Start, Vector3d End, Point3d Center)? RotationVectors { get; init; }
-        /// <summary>Mirror plane for reflection.</summary>
-        public Plane? MirrorPlane { get; init; }
-        /// <summary>Translation motion vector.</summary>
-        public Vector3d? Translation { get; init; }
-        /// <summary>Shear: (plane, direction, angle).</summary>
-        public (Plane Plane, Vector3d Direction, double Angle)? Shear { get; init; }
-        /// <summary>Projection: plane for orthogonal projection.</summary>
-        public Plane? ProjectionPlane { get; init; }
-        /// <summary>Change of basis: (from plane, to plane).</summary>
-        public (Plane From, Plane To)? ChangeBasis { get; init; }
-        /// <summary>Plane-to-plane transform: (from, to).</summary>
-        public (Plane From, Plane To)? PlaneToPlane { get; init; }
+    /// <summary>Affine transform request.</summary>
+    public abstract record TransformRequest;
 
-        /// <summary>Create matrix transform specification.</summary>
-        [Pure]
-        public static TransformSpec FromMatrix(Transform xform) => new() { Matrix = xform };
-        /// <summary>Create uniform scale specification.</summary>
-        [Pure]
-        public static TransformSpec FromScale(Point3d anchor, double factor) => new() { UniformScale = (anchor, factor) };
-        /// <summary>Create non-uniform scale specification.</summary>
-        [Pure]
-        public static TransformSpec FromScale(Plane plane, double x, double y, double z) => new() { NonUniformScale = (plane, x, y, z) };
-        /// <summary>Create rotation around axis specification.</summary>
-        [Pure]
-        public static TransformSpec FromRotation(double angle, Vector3d axis, Point3d center) => new() { Rotation = (angle, axis, center) };
-        /// <summary>Create rotation from vector to vector specification.</summary>
-        [Pure]
-        public static TransformSpec FromRotation(Vector3d start, Vector3d end, Point3d center) => new() { RotationVectors = (start, end, center) };
-        /// <summary>Create mirror reflection specification.</summary>
-        [Pure]
-        public static TransformSpec FromMirror(Plane plane) => new() { MirrorPlane = plane };
-        /// <summary>Create translation specification.</summary>
-        [Pure]
-        public static TransformSpec FromTranslation(Vector3d motion) => new() { Translation = motion };
-        /// <summary>Create shear specification.</summary>
-        [Pure]
-        public static TransformSpec FromShear(Plane plane, Vector3d direction, double angle) => new() { Shear = (plane, direction, angle) };
-        /// <summary>Create projection specification.</summary>
-        [Pure]
-        public static TransformSpec FromProjection(Plane plane) => new() { ProjectionPlane = plane };
-        /// <summary>Create change of basis specification.</summary>
-        [Pure]
-        public static TransformSpec FromChangeBasis(Plane from, Plane to) => new() { ChangeBasis = (from, to) };
-        /// <summary>Create plane-to-plane specification.</summary>
-        [Pure]
-        public static TransformSpec FromPlaneToPlane(Plane from, Plane to) => new() { PlaneToPlane = (from, to) };
-    }
+    /// <summary>Direct matrix transform.</summary>
+    public sealed record MatrixTransform(Transform Matrix) : TransformRequest;
 
-    /// <summary>Array transformation specification.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct ArraySpec {
-        /// <summary>Array mode: 1=Rectangular, 2=Polar, 3=Linear, 4=Path.</summary>
-        public byte Mode { get; init; }
-        /// <summary>Total count for polar/linear/path arrays.</summary>
-        public int Count { get; init; }
+    /// <summary>Uniform scale about an anchor point.</summary>
+    public sealed record UniformScaleTransform(Point3d Anchor, double Factor) : TransformRequest;
 
-        /// <summary>Rectangular: X count.</summary>
-        public int XCount { get; init; }
-        /// <summary>Rectangular: Y count.</summary>
-        public int YCount { get; init; }
-        /// <summary>Rectangular: Z count (optional).</summary>
-        public int? ZCount { get; init; }
-        /// <summary>Rectangular: X spacing.</summary>
-        public double XSpacing { get; init; }
-        /// <summary>Rectangular: Y spacing.</summary>
-        public double YSpacing { get; init; }
-        /// <summary>Rectangular: Z spacing (optional).</summary>
-        public double? ZSpacing { get; init; }
+    /// <summary>Non-uniform scale within a plane basis.</summary>
+    public sealed record NonUniformScaleTransform(Plane Plane, double XScale, double YScale, double ZScale) : TransformRequest;
 
-        /// <summary>Polar: center point.</summary>
-        public Point3d? Center { get; init; }
-        /// <summary>Polar: rotation axis.</summary>
-        public Vector3d? Axis { get; init; }
-        /// <summary>Polar: total angle in radians (default 2π).</summary>
-        public double? TotalAngle { get; init; }
+    /// <summary>Rotation about an axis through a center point.</summary>
+    public sealed record AxisRotationTransform(double AngleRadians, Vector3d Axis, Point3d Center) : TransformRequest;
 
-        /// <summary>Linear: direction vector.</summary>
-        public Vector3d? Direction { get; init; }
-        /// <summary>Linear/Path: spacing between instances.</summary>
-        public double Spacing { get; init; }
+    /// <summary>Rotation from start to end direction around a center point.</summary>
+    public sealed record VectorRotationTransform(Vector3d StartDirection, Vector3d EndDirection, Point3d Center) : TransformRequest;
 
-        /// <summary>Path: curve to follow.</summary>
-        public Curve? PathCurve { get; init; }
-        /// <summary>Path: orient geometry to curve frames.</summary>
-        public bool OrientToPath { get; init; }
+    /// <summary>Mirror reflection across a plane.</summary>
+    public sealed record MirrorTransform(Plane Plane) : TransformRequest;
 
-        /// <summary>Create rectangular array specification.</summary>
-        [Pure]
-        public static ArraySpec Rectangular(int xCount, int yCount, int zCount, double xSpace, double ySpace, double zSpace) =>
-            new() { Mode = 1, XCount = xCount, YCount = yCount, ZCount = zCount, XSpacing = xSpace, YSpacing = ySpace, ZSpacing = zSpace };
-        /// <summary>Create polar array specification.</summary>
-        [Pure]
-        public static ArraySpec Polar(Point3d center, Vector3d axis, int count, double totalAngle) =>
-            new() { Mode = 2, Center = center, Axis = axis, Count = count, TotalAngle = totalAngle };
-        /// <summary>Create linear array specification.</summary>
-        [Pure]
-        public static ArraySpec Linear(Vector3d direction, int count, double spacing) =>
-            new() { Mode = 3, Direction = direction, Count = count, Spacing = spacing };
-        /// <summary>Create path array specification.</summary>
-        [Pure]
-        public static ArraySpec Path(Curve path, int count, bool orient) =>
-            new() { Mode = 4, PathCurve = path, Count = count, OrientToPath = orient };
-    }
+    /// <summary>Translation by a motion vector.</summary>
+    public sealed record TranslationTransform(Vector3d Motion) : TransformRequest;
 
-    /// <summary>SpaceMorph operation specification.</summary>
-    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
-    public readonly record struct MorphSpec {
-        /// <summary>Morph operation: 1=Flow, 2=Twist, 3=Bend, 4=Taper, 5=Stretch, 6=Splop, 7=Sporph, 8=Maelstrom.</summary>
-        public byte Operation { get; init; }
-        /// <summary>Flow: base curve.</summary>
-        public Curve? BaseCurve { get; init; }
-        /// <summary>Flow: target curve.</summary>
-        public Curve? TargetCurve { get; init; }
-        /// <summary>Twist/Bend/Taper/Stretch: axis line.</summary>
-        public Line? Axis { get; init; }
-        /// <summary>Twist/Bend: rotation angle in radians.</summary>
-        public double Angle { get; init; }
-        /// <summary>Twist: infinite twist flag.</summary>
-        public bool Infinite { get; init; }
-        /// <summary>All morphs: preserve NURBS structure flag.</summary>
-        public bool PreserveStructure { get; init; }
-        /// <summary>Taper: start width.</summary>
-        public double? StartWidth { get; init; }
-        /// <summary>Taper: end width.</summary>
-        public double? EndWidth { get; init; }
-        /// <summary>Splop: base plane.</summary>
-        public Plane? BasePlane { get; init; }
-        /// <summary>Splop/Sporph: target surface.</summary>
-        public Surface? TargetSurface { get; init; }
-        /// <summary>Sporph: source surface.</summary>
-        public Surface? SourceSurface { get; init; }
-        /// <summary>Splop: target point on surface.</summary>
-        public Point3d? TargetPoint { get; init; }
-        /// <summary>Maelstrom: vortex center.</summary>
-        public Point3d? Center { get; init; }
-        /// <summary>Maelstrom: vortex radius.</summary>
-        public double? Radius { get; init; }
+    /// <summary>Shear relative to a plane and direction.</summary>
+    public sealed record ShearTransform(Plane Plane, Vector3d Direction, double AngleRadians) : TransformRequest;
 
-        /// <summary>Create flow morph specification.</summary>
-        [Pure]
-        public static MorphSpec Flow(Curve baseCurve, Curve targetCurve, bool preserve) =>
-            new() { Operation = 1, BaseCurve = baseCurve, TargetCurve = targetCurve, PreserveStructure = preserve };
-        /// <summary>Create twist morph specification.</summary>
-        [Pure]
-        public static MorphSpec Twist(Line axis, double angle, bool infinite) =>
-            new() { Operation = 2, Axis = axis, Angle = angle, Infinite = infinite };
-        /// <summary>Create bend morph specification.</summary>
-        [Pure]
-        public static MorphSpec Bend(Line axis, double angle) =>
-            new() { Operation = 3, Axis = axis, Angle = angle };
-        /// <summary>Create taper morph specification.</summary>
-        [Pure]
-        public static MorphSpec Taper(Line axis, double startWidth, double endWidth) =>
-            new() { Operation = 4, Axis = axis, StartWidth = startWidth, EndWidth = endWidth };
-        /// <summary>Create stretch morph specification.</summary>
-        [Pure]
-        public static MorphSpec Stretch(Line axis) =>
-            new() { Operation = 5, Axis = axis };
-        /// <summary>Create splop morph specification.</summary>
-        [Pure]
-        public static MorphSpec Splop(Plane basePlane, Surface targetSurface, Point3d targetPoint) =>
-            new() { Operation = 6, BasePlane = basePlane, TargetSurface = targetSurface, TargetPoint = targetPoint };
-        /// <summary>Create sporph morph specification.</summary>
-        [Pure]
-        public static MorphSpec Sporph(Surface sourceSurface, Surface targetSurface, bool preserve) =>
-            new() { Operation = 7, SourceSurface = sourceSurface, TargetSurface = targetSurface, PreserveStructure = preserve };
-        /// <summary>Create maelstrom morph specification.</summary>
-        [Pure]
-        public static MorphSpec Maelstrom(Point3d center, Vector3d axis, double radius, double angle) =>
-            new() { Operation = 8, Center = center, Axis = new Line(center, axis), Radius = radius, Angle = angle };
-    }
+    /// <summary>Orthogonal projection to a plane.</summary>
+    public sealed record ProjectionTransform(Plane Plane) : TransformRequest;
 
-    /// <summary>Apply transform specification to geometry.</summary>
+    /// <summary>Change of basis between planes.</summary>
+    public sealed record ChangeBasisTransform(Plane From, Plane To) : TransformRequest;
+
+    /// <summary>Transform geometry from one plane orientation to another.</summary>
+    public sealed record PlaneToPlaneTransform(Plane From, Plane To) : TransformRequest;
+
+    /// <summary>Array transformation request.</summary>
+    public abstract record ArrayRequest;
+
+    /// <summary>Rectangular grid array.</summary>
+    public sealed record RectangularArray(int XCount, int YCount, int ZCount, double XSpacing, double YSpacing, double ZSpacing) : ArrayRequest;
+
+    /// <summary>Polar array around an axis.</summary>
+    public sealed record PolarArray(Point3d Center, Vector3d Axis, int Count, double TotalAngle) : ArrayRequest;
+
+    /// <summary>Linear array along a direction.</summary>
+    public sealed record LinearArray(Vector3d Direction, int Count, double Spacing) : ArrayRequest;
+
+    /// <summary>Path array following a curve.</summary>
+    public sealed record PathArray(Curve Path, int Count, bool OrientToPath) : ArrayRequest;
+
+    /// <summary>SpaceMorph deformation request.</summary>
+    public abstract record MorphRequest;
+
+    /// <summary>Flow geometry from a base curve to a target curve.</summary>
+    public sealed record FlowMorph(Curve BaseCurve, Curve TargetCurve, bool PreserveStructure) : MorphRequest;
+
+    /// <summary>Twist geometry around an axis.</summary>
+    public sealed record TwistMorph(Line Axis, double AngleRadians, bool Infinite) : MorphRequest;
+
+    /// <summary>Bend geometry along an axis.</summary>
+    public sealed record BendMorph(Line Axis, double AngleRadians) : MorphRequest;
+
+    /// <summary>Taper geometry along an axis.</summary>
+    public sealed record TaperMorph(Line Axis, double StartWidth, double EndWidth) : MorphRequest;
+
+    /// <summary>Stretch geometry along an axis.</summary>
+    public sealed record StretchMorph(Line Axis) : MorphRequest;
+
+    /// <summary>Splop geometry from a plane to a target surface point.</summary>
+    public sealed record SplopMorph(Plane BasePlane, Surface TargetSurface, Point3d TargetPoint) : MorphRequest;
+
+    /// <summary>Sporph geometry from source surface to target surface.</summary>
+    public sealed record SporphMorph(Surface SourceSurface, Surface TargetSurface, bool PreserveStructure) : MorphRequest;
+
+    /// <summary>Maelstrom vortex deformation around an axis.</summary>
+    public sealed record MaelstromMorph(Point3d Center, Vector3d Axis, double Radius, double AngleRadians) : MorphRequest;
+
+    /// <summary>Apply transform request to geometry.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Apply<T>(
         T geometry,
-        TransformSpec spec,
+        TransformRequest request,
         IGeometryContext context,
         bool enableDiagnostics = false) where T : GeometryBase =>
-        TransformationCore.BuildTransform(spec: spec, context: context)
-            .Bind(xform => UnifiedOperation.Apply(
-                input: geometry,
-                operation: (Func<T, Result<IReadOnlyList<T>>>)(item =>
-                    TransformationCore.ApplyTransform(item: item, transform: xform)),
-                config: new OperationConfig<T, T> {
-                    Context = context,
-                    ValidationMode = TransformationConfig.GetValidationMode(typeof(T)),
-                    OperationName = "Transformation.Apply",
-                    EnableDiagnostics = enableDiagnostics,
-                }))
-            .Map(r => r[0]);
+        TransformationCore.ApplyTransform(
+            geometry: geometry,
+            request: request,
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Apply array transformation.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<IReadOnlyList<T>> ArrayTransform<T>(
         T geometry,
-        ArraySpec spec,
+        ArrayRequest request,
         IGeometryContext context,
         bool enableDiagnostics = false) where T : GeometryBase =>
-        spec.Mode switch {
-            1 => TransformationCore.RectangularArray(
-                geometry: geometry,
-                xCount: spec.XCount,
-                yCount: spec.YCount,
-                zCount: spec.ZCount ?? 1,
-                xSpacing: spec.XSpacing,
-                ySpacing: spec.YSpacing,
-                zSpacing: spec.ZSpacing ?? 0.0,
-                context: context,
-                enableDiagnostics: enableDiagnostics),
-            2 => TransformationCore.PolarArray(
-                geometry: geometry,
-                center: spec.Center!.Value,
-                axis: spec.Axis!.Value,
-                count: spec.Count,
-                totalAngle: spec.TotalAngle ?? RhinoMath.TwoPI,
-                context: context,
-                enableDiagnostics: enableDiagnostics),
-            3 => TransformationCore.LinearArray(
-                geometry: geometry,
-                direction: spec.Direction!.Value,
-                count: spec.Count,
-                spacing: spec.Spacing,
-                context: context,
-                enableDiagnostics: enableDiagnostics),
-            4 => TransformationCompute.PathArray(
-                geometry: geometry,
-                path: spec.PathCurve!,
-                count: spec.Count,
-                orientToPath: spec.OrientToPath,
-                context: context,
-                enableDiagnostics: enableDiagnostics),
-            _ => ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.Transformation.InvalidArrayMode),
-        };
+        TransformationCore.ArrayTransform(
+            geometry: geometry,
+            request: request,
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Apply SpaceMorph deformation.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Morph<T>(
         T geometry,
-        MorphSpec spec,
-        IGeometryContext context) where T : GeometryBase =>
-        spec.Operation switch {
-            1 => TransformationCompute.Flow(
-                geometry: geometry,
-                baseCurve: spec.BaseCurve!,
-                targetCurve: spec.TargetCurve!,
-                preserveStructure: spec.PreserveStructure,
-                context: context),
-            2 => TransformationCompute.Twist(
-                geometry: geometry,
-                axis: spec.Axis!.Value,
-                angleRadians: spec.Angle,
-                infinite: spec.Infinite,
-                context: context),
-            3 => TransformationCompute.Bend(
-                geometry: geometry,
-                spine: spec.Axis!.Value,
-                angle: spec.Angle,
-                context: context),
-            4 => TransformationCompute.Taper(
-                geometry: geometry,
-                axis: spec.Axis!.Value,
-                startWidth: spec.StartWidth!.Value,
-                endWidth: spec.EndWidth!.Value,
-                context: context),
-            5 => TransformationCompute.Stretch(
-                geometry: geometry,
-                axis: spec.Axis!.Value,
-                context: context),
-            6 => TransformationCompute.Splop(
-                geometry: geometry,
-                basePlane: spec.BasePlane!.Value,
-                targetSurface: spec.TargetSurface!,
-                targetPoint: spec.TargetPoint!.Value,
-                context: context),
-            7 => TransformationCompute.Sporph(
-                geometry: geometry,
-                sourceSurface: spec.SourceSurface!,
-                targetSurface: spec.TargetSurface!,
-                preserveStructure: spec.PreserveStructure,
-                context: context),
-            8 => TransformationCompute.Maelstrom(
-                geometry: geometry,
-                center: spec.Center!.Value,
-                axis: spec.Axis!.Value,
-                radius: spec.Radius!.Value,
-                angle: spec.Angle,
-                context: context),
-            _ => ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidMorphOperation),
-        };
+        MorphRequest request,
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        TransformationCore.Morph(
+            geometry: geometry,
+            request: request,
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Scale geometry uniformly about anchor point.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -322,8 +132,13 @@ public static class Transformation {
         T geometry,
         Point3d anchor,
         double factor,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromScale(anchor, factor), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new UniformScaleTransform(anchor, factor),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Scale geometry non-uniformly along plane axes.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -333,8 +148,13 @@ public static class Transformation {
         double xScale,
         double yScale,
         double zScale,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromScale(plane, xScale, yScale, zScale), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new NonUniformScaleTransform(plane, xScale, yScale, zScale),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Rotate geometry around axis by angle in radians.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -343,8 +163,13 @@ public static class Transformation {
         double angleRadians,
         Vector3d axis,
         Point3d center,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromRotation(angleRadians, axis, center), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new AxisRotationTransform(angleRadians, axis, center),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Rotate geometry from start direction to end direction around center.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -353,24 +178,39 @@ public static class Transformation {
         Vector3d startDirection,
         Vector3d endDirection,
         Point3d center,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromRotation(startDirection, endDirection, center), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new VectorRotationTransform(startDirection, endDirection, center),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Mirror geometry across plane.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Mirror<T>(
         T geometry,
         Plane plane,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromMirror(plane), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new MirrorTransform(plane),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Translate geometry by motion vector.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Translate<T>(
         T geometry,
         Vector3d motion,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromTranslation(motion), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new TranslationTransform(motion),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Translate geometry from start point to end point.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -378,8 +218,13 @@ public static class Transformation {
         T geometry,
         Point3d start,
         Point3d end,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromTranslation(end - start), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new TranslationTransform(end - start),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Shear geometry parallel to plane in given direction by angle.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -388,16 +233,26 @@ public static class Transformation {
         Plane plane,
         Vector3d direction,
         double angle,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromShear(plane, direction, angle), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new ShearTransform(plane, direction, angle),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Project geometry orthogonally to plane.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Project<T>(
         T geometry,
         Plane plane,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromProjection(plane), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new ProjectionTransform(plane),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Change coordinate system from one plane basis to another.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -405,8 +260,13 @@ public static class Transformation {
         T geometry,
         Plane fromPlane,
         Plane toPlane,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromChangeBasis(fromPlane, toPlane), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new ChangeBasisTransform(fromPlane, toPlane),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 
     /// <summary>Transform geometry from one plane orientation to another.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -414,6 +274,11 @@ public static class Transformation {
         T geometry,
         Plane fromPlane,
         Plane toPlane,
-        IGeometryContext context) where T : GeometryBase =>
-        Apply(geometry: geometry, spec: TransformSpec.FromPlaneToPlane(fromPlane, toPlane), context: context);
+        IGeometryContext context,
+        bool enableDiagnostics = false) where T : GeometryBase =>
+        Apply(
+            geometry: geometry,
+            request: new PlaneToPlaneTransform(fromPlane, toPlane),
+            context: context,
+            enableDiagnostics: enableDiagnostics);
 }

--- a/libs/rhino/transformation/TransformationCompute.cs
+++ b/libs/rhino/transformation/TransformationCompute.cs
@@ -1,269 +1,289 @@
+using System;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Arsenal.Core.Context;
-using Arsenal.Core.Errors;
-using Arsenal.Core.Operations;
-using Arsenal.Core.Results;
-using Arsenal.Core.Validation;
-using Rhino;
 using Rhino.Geometry;
 using Rhino.Geometry.Morphs;
 
 namespace Arsenal.Rhino.Transformation;
 
-/// <summary>SpaceMorph deformation operations and curve-based array transformations.</summary>
+/// <summary>SpaceMorph deformation operations and array transform generation.</summary>
+[Pure]
 internal static class TransformationCompute {
-    /// <summary>Flow geometry along base curve to target curve.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Flow<T>(
-        T geometry,
-        Curve baseCurve,
-        Curve targetCurve,
-        bool preserveStructure,
-        IGeometryContext context) where T : GeometryBase =>
-        baseCurve.IsValid && targetCurve.IsValid && geometry.IsValid
-            ? ApplyMorph(
-                morph: new FlowSpaceMorph(
-                    curve0: baseCurve,
-                    curve1: targetCurve,
-                    preventStretching: !preserveStructure) {
-                    PreserveStructure = preserveStructure,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidFlowCurves.WithContext($"Base: {baseCurve.IsValid}, Target: {targetCurve.IsValid}, Geometry: {geometry.IsValid}"));
+    internal static TransformationConfig.ComputeOutcome<IReadOnlyList<T>> ApplyTransform<T>(
+        T item,
+        Transform transform) where T : GeometryBase {
+        GeometryBase normalized = item is Extrusion extrusion
+            ? extrusion.ToBrep(splitKinkyFaces: true)
+            : item;
+        T duplicate = (T)normalized.Duplicate();
+        bool success = duplicate.Transform(transform);
 
-    /// <summary>Twist geometry around axis by angle.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Twist<T>(
-        T geometry,
-        Line axis,
-        double angleRadians,
-        bool infinite,
-        IGeometryContext context) where T : GeometryBase =>
-        axis.IsValid && Math.Abs(angleRadians) <= TransformationConfig.MaxTwistAngle && geometry.IsValid
-            ? ApplyMorph(
-                morph: new TwistSpaceMorph {
-                    TwistAxis = axis,
-                    TwistAngleRadians = angleRadians,
-                    InfiniteTwist = infinite,
-                    PreserveStructure = false,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidTwistParameters.WithContext($"Axis: {axis.IsValid}, Angle: {angleRadians.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"));
+        (item is Extrusion ? normalized : null)?.Dispose();
+        (!success ? duplicate : null)?.Dispose();
 
-    /// <summary>Bend geometry along spine.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Bend<T>(
-        T geometry,
-        Line spine,
-        double angle,
-        IGeometryContext context) where T : GeometryBase =>
-        spine.IsValid && Math.Abs(angle) <= TransformationConfig.MaxBendAngle && geometry.IsValid
-            ? ApplyMorph(
-                morph: new BendSpaceMorph(
-                    start: spine.From,
-                    end: spine.To,
-                    point: spine.PointAt(0.5),
-                    angle: angle,
-                    straight: false,
-                    symmetric: false) {
-                    PreserveStructure = false,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidBendParameters.WithContext($"Spine: {spine.IsValid}, Angle: {angle.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"));
+        return success
+            ? new TransformationConfig.ComputeOutcome<IReadOnlyList<T>>(true, [duplicate,], string.Empty)
+            : new TransformationConfig.ComputeOutcome<IReadOnlyList<T>>(false, Array.Empty<T>(), "Transform application failed");
+    }
 
-    /// <summary>Taper geometry along axis from start width to end width.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Taper<T>(
-        T geometry,
-        Line axis,
-        double startWidth,
-        double endWidth,
-        IGeometryContext context) where T : GeometryBase =>
-        axis.IsValid
-        && startWidth >= TransformationConfig.MinScaleFactor
-        && endWidth >= TransformationConfig.MinScaleFactor
-        && geometry.IsValid
-            ? ApplyMorph(
-                morph: new TaperSpaceMorph(
-                    start: axis.From,
-                    end: axis.To,
-                    startRadius: startWidth,
-                    endRadius: endWidth,
-                    bFlat: false,
-                    infiniteTaper: false) {
-                    PreserveStructure = false,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidTaperParameters.WithContext($"Axis: {axis.IsValid}, Start: {startWidth.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, End: {endWidth.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"));
+    internal static TransformationConfig.ComputeOutcome<Transform[]> RectangularArray(
+        Transformation.RectangularArray request,
+        IGeometryContext context) {
+        _ = context;
+        int totalCount = request.XCount * request.YCount * request.ZCount;
+        Transform[] transforms = new Transform[totalCount];
+        int index = 0;
 
-    /// <summary>Stretch geometry along axis.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Stretch<T>(
-        T geometry,
-        Line axis,
-        IGeometryContext context) where T : GeometryBase =>
-        axis.IsValid && geometry.IsValid
-            ? ApplyMorph(
-                morph: new StretchSpaceMorph(
-                    start: axis.From,
-                    end: axis.To,
-                    length: axis.Length * 2.0) {
-                    PreserveStructure = false,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidStretchParameters.WithContext($"Axis: {axis.IsValid}, Geometry: {geometry.IsValid}"));
-
-    /// <summary>Splop geometry from base plane to target surface point.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Splop<T>(
-        T geometry,
-        Plane basePlane,
-        Surface targetSurface,
-        Point3d targetPoint,
-        IGeometryContext context) where T : GeometryBase =>
-        basePlane.IsValid && targetSurface.IsValid && targetPoint.IsValid && geometry.IsValid
-            ? targetSurface.ClosestPoint(targetPoint, out double u, out double v)
-                ? ApplyMorph(
-                    morph: new SplopSpaceMorph(
-                        plane: basePlane,
-                        surface: targetSurface,
-                        surfaceParam: new Point2d(u, v)) {
-                        PreserveStructure = false,
-                        Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                        QuickPreview = false,
-                    },
-                    geometry: geometry)
-                : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidSplopParameters.WithContext("Surface closest point failed"))
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidSplopParameters.WithContext($"Plane: {basePlane.IsValid}, Surface: {targetSurface.IsValid}, Point: {targetPoint.IsValid}, Geometry: {geometry.IsValid}"));
-
-    /// <summary>Sporph geometry from source surface to target surface.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Sporph<T>(
-        T geometry,
-        Surface sourceSurface,
-        Surface targetSurface,
-        bool preserveStructure,
-        IGeometryContext context) where T : GeometryBase =>
-        sourceSurface.IsValid && targetSurface.IsValid && geometry.IsValid
-            ? ApplyMorph(
-                morph: new SporphSpaceMorph(
-                    surface0: sourceSurface,
-                    surface1: targetSurface) {
-                    PreserveStructure = preserveStructure,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidSporphParameters.WithContext($"Source: {sourceSurface.IsValid}, Target: {targetSurface.IsValid}, Geometry: {geometry.IsValid}"));
-
-    /// <summary>Maelstrom vortex deformation around axis.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<T> Maelstrom<T>(
-        T geometry,
-        Point3d center,
-        Line axis,
-        double radius,
-        double angle,
-        IGeometryContext context) where T : GeometryBase =>
-        center.IsValid && axis.IsValid && radius > context.AbsoluteTolerance && geometry.IsValid && Math.Abs(angle) <= RhinoMath.TwoPI
-            ? ApplyMorph(
-                morph: new MaelstromSpaceMorph(
-                    plane: new Plane(origin: center, normal: axis.Direction),
-                    radius0: 0.0,
-                    radius1: radius,
-                    angle: angle) {
-                    PreserveStructure = false,
-                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
-                    QuickPreview = false,
-                },
-                geometry: geometry)
-            : ResultFactory.Create<T>(error: E.Geometry.Transformation.InvalidMaelstromParameters.WithContext($"Center: {center.IsValid}, Axis: {axis.IsValid}, Radius: {radius.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"));
-
-    /// <summary>Array geometry along path curve with optional orientation.</summary>
-    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static Result<IReadOnlyList<T>> PathArray<T>(
-        T geometry,
-        Curve path,
-        int count,
-        bool orientToPath,
-        IGeometryContext context,
-        bool enableDiagnostics) where T : GeometryBase {
-        if (count <= 0 || count > TransformationConfig.MaxArrayCount || path?.IsValid != true || !geometry.IsValid) {
-            return ResultFactory.Create<IReadOnlyList<T>>(
-                error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    $"Count: {count}, Path: {path?.IsValid ?? false}, Geometry: {geometry.IsValid}")));
+        for (int i = 0; i < request.XCount; i++) {
+            double dx = i * request.XSpacing;
+            for (int j = 0; j < request.YCount; j++) {
+                double dy = j * request.YSpacing;
+                for (int k = 0; k < request.ZCount; k++) {
+                    double dz = k * request.ZSpacing;
+                    transforms[index++] = Transform.Translation(dx: dx, dy: dy, dz: dz);
+                }
+            }
         }
 
-        double curveLength = path.GetLength();
-        if (curveLength <= context.AbsoluteTolerance) {
-            return ResultFactory.Create<IReadOnlyList<T>>(
-                error: E.Geometry.Transformation.InvalidArrayParameters.WithContext(string.Create(
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    $"Count: {count}, PathLength: {curveLength.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}")));
+        return new TransformationConfig.ComputeOutcome<Transform[]>(true, transforms, string.Empty);
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<Transform[]> PolarArray(
+        Transformation.PolarArray request,
+        IGeometryContext context) {
+        _ = context;
+        Transform[] transforms = new Transform[request.Count];
+        double angleStep = request.TotalAngle / request.Count;
+
+        for (int i = 0; i < request.Count; i++) {
+            transforms[i] = Transform.Rotation(
+                angleRadians: angleStep * i,
+                rotationAxis: request.Axis,
+                rotationCenter: request.Center);
         }
 
-        double[] parameters = count == 1
-            ? [path.LengthParameter(curveLength * 0.5, out double singleParameter) ? singleParameter : path.Domain.ParameterAt(0.5),]
-            : path.DivideByCount(count - 1, includeEnds: true) is double[] divideParams && divideParams.Length == count
+        return new TransformationConfig.ComputeOutcome<Transform[]>(true, transforms, string.Empty);
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<Transform[]> LinearArray(
+        Transformation.LinearArray request,
+        IGeometryContext context) {
+        _ = context;
+        Transform[] transforms = new Transform[request.Count];
+        double dirLength = request.Direction.Length;
+        Vector3d step = (request.Direction / dirLength) * request.Spacing;
+
+        for (int i = 0; i < request.Count; i++) {
+            transforms[i] = Transform.Translation(step * i);
+        }
+
+        return new TransformationConfig.ComputeOutcome<Transform[]>(true, transforms, string.Empty);
+    }
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<Transform[]> PathArray(
+        Transformation.PathArray request,
+        IGeometryContext context) {
+        _ = context;
+        double curveLength = request.Path.GetLength();
+        double[] parameters = request.Count == 1
+            ? [request.Path.LengthParameter(curveLength * 0.5, out double singleParameter) ? singleParameter : request.Path.Domain.ParameterAt(0.5),]
+            : request.Path.DivideByCount(request.Count - 1, includeEnds: true) is double[] divideParams && divideParams.Length == request.Count
                 ? divideParams
-                : [.. Enumerable.Range(0, count)
+                : [.. Enumerable.Range(0, request.Count)
                     .Select(i => {
-                        double targetLength = curveLength * i / (count - 1);
-                        return path.LengthParameter(targetLength, out double tParam)
+                        double targetLength = curveLength * i / (request.Count - 1);
+                        return request.Path.LengthParameter(targetLength, out double tParam)
                             ? tParam
-                            : path.Domain.ParameterAt(Math.Clamp(targetLength / curveLength, 0.0, 1.0));
+                            : request.Path.Domain.ParameterAt(Math.Clamp(targetLength / curveLength, 0.0, 1.0));
                     }),
                 ];
 
-        Transform[] transforms = new Transform[count];
-        for (int i = 0; i < count; i++) {
+        Transform[] transforms = new Transform[request.Count];
+        for (int i = 0; i < request.Count; i++) {
             double t = parameters[i];
-            Point3d pt = path.PointAt(t);
+            Point3d pt = request.Path.PointAt(t);
 
-            transforms[i] = orientToPath && path.FrameAt(t, out Plane frame) && frame.IsValid
+            transforms[i] = request.OrientToPath && request.Path.FrameAt(t, out Plane frame) && frame.IsValid
                 ? Transform.PlaneToPlane(Plane.WorldXY, frame)
                 : Transform.Translation(pt - Point3d.Origin);
         }
 
-        return UnifiedOperation.Apply(
-            input: transforms,
-            operation: (Func<Transform, Result<IReadOnlyList<T>>>)(xform =>
-                TransformationCore.ApplyTransform(item: geometry, transform: xform)),
-            config: new OperationConfig<IReadOnlyList<Transform>, T> {
-                Context = context,
-                ValidationMode = V.None,
-                AccumulateErrors = false,
-                OperationName = "Transformation.PathArray",
-                EnableDiagnostics = enableDiagnostics,
-            });
+        return new TransformationConfig.ComputeOutcome<Transform[]>(true, transforms, string.Empty);
     }
 
-    /// <summary>Apply SpaceMorph to geometry with duplication.</summary>
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Result<T> ApplyMorph<TMorph, T>(
-        TMorph morph,
-        T geometry) where TMorph : SpaceMorph where T : GeometryBase {
-        using (morph as IDisposable) {
-            if (!SpaceMorph.IsMorphable(geometry)) {
-                return ResultFactory.Create<T>(error: E.Geometry.Transformation.GeometryNotMorphable.WithContext($"Geometry: {typeof(T).Name}, Morph: {typeof(TMorph).Name}"));
-            }
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Flow(
+        GeometryBase geometry,
+        Transformation.FlowMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new FlowSpaceMorph(
+                curve0: request.BaseCurve,
+                curve1: request.TargetCurve,
+                preventStretching: !request.PreserveStructure) {
+                PreserveStructure = request.PreserveStructure,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Flow");
 
-            T duplicate = (T)geometry.Duplicate();
-            return morph.Morph(duplicate)
-                ? ResultFactory.Create(value: duplicate)
-                : ResultFactory.Create<T>(error: E.Geometry.Transformation.MorphApplicationFailed.WithContext($"Morph type: {typeof(TMorph).Name}"));
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Twist(
+        GeometryBase geometry,
+        Transformation.TwistMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new TwistSpaceMorph {
+                TwistAxis = request.Axis,
+                TwistAngleRadians = request.AngleRadians,
+                InfiniteTwist = request.Infinite,
+                PreserveStructure = false,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Twist");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Bend(
+        GeometryBase geometry,
+        Transformation.BendMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new BendSpaceMorph(
+                start: request.Axis.From,
+                end: request.Axis.To,
+                point: request.Axis.PointAt(0.5),
+                angle: request.AngleRadians,
+                straight: false,
+                symmetric: false) {
+                PreserveStructure = false,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Bend");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Taper(
+        GeometryBase geometry,
+        Transformation.TaperMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new TaperSpaceMorph(
+                start: request.Axis.From,
+                end: request.Axis.To,
+                startRadius: request.StartWidth,
+                endRadius: request.EndWidth,
+                bFlat: false,
+                infiniteTaper: false) {
+                PreserveStructure = false,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Taper");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Stretch(
+        GeometryBase geometry,
+        Transformation.StretchMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new StretchSpaceMorph(
+                start: request.Axis.From,
+                end: request.Axis.To,
+                length: request.Axis.Length * 2.0) {
+                PreserveStructure = false,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Stretch");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Splop(
+        GeometryBase geometry,
+        Transformation.SplopMorph request,
+        IGeometryContext context) =>
+        request.TargetSurface.ClosestPoint(request.TargetPoint, out double u, out double v)
+            ? ApplyMorph(
+                morph: new SplopSpaceMorph(
+                    plane: request.BasePlane,
+                    surface: request.TargetSurface,
+                    surfaceParam: new Point2d(u, v)) {
+                    PreserveStructure = false,
+                    Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                    QuickPreview = false,
+                },
+                geometry: geometry,
+                context: context,
+                description: "Splop")
+            : new TransformationConfig.ComputeOutcome<GeometryBase>(false, geometry, "Surface closest point failed");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Sporph(
+        GeometryBase geometry,
+        Transformation.SporphMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new SporphSpaceMorph(
+                surface0: request.SourceSurface,
+                surface1: request.TargetSurface) {
+                PreserveStructure = request.PreserveStructure,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Sporph");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static TransformationConfig.ComputeOutcome<GeometryBase> Maelstrom(
+        GeometryBase geometry,
+        Transformation.MaelstromMorph request,
+        IGeometryContext context) =>
+        ApplyMorph(
+            morph: new MaelstromSpaceMorph(
+                plane: new Plane(origin: request.Center, normal: request.Axis),
+                radius0: 0.0,
+                radius1: request.Radius,
+                angle: request.AngleRadians) {
+                PreserveStructure = false,
+                Tolerance = Math.Max(context.AbsoluteTolerance, TransformationConfig.DefaultMorphTolerance),
+                QuickPreview = false,
+            },
+            geometry: geometry,
+            context: context,
+            description: "Maelstrom");
+
+    [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TransformationConfig.ComputeOutcome<GeometryBase> ApplyMorph<TMorph>(
+        TMorph morph,
+        GeometryBase geometry,
+        IGeometryContext context,
+        string description) where TMorph : SpaceMorph {
+        using (morph as IDisposable) {
+            GeometryBase duplicate = geometry.Duplicate();
+            bool success = morph.Morph(duplicate);
+            (!success ? duplicate : null)?.Dispose();
+
+            return success
+                ? new TransformationConfig.ComputeOutcome<GeometryBase>(true, duplicate, string.Empty)
+                : new TransformationConfig.ComputeOutcome<GeometryBase>(false, geometry, description);
         }
     }
 }

--- a/libs/rhino/transformation/TransformationConfig.cs
+++ b/libs/rhino/transformation/TransformationConfig.cs
@@ -1,16 +1,19 @@
+using System;
 using System.Collections.Frozen;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using Arsenal.Core.Errors;
 using Arsenal.Core.Validation;
 using Rhino;
 using Rhino.Geometry;
 
 namespace Arsenal.Rhino.Transformation;
 
-/// <summary>Transform validation modes and algorithmic constants.</summary>
+/// <summary>Unified metadata, constants, and dispatch tables for transformation operations.</summary>
+[Pure]
 internal static class TransformationConfig {
-    /// <summary>Geometry type validation mode mapping.</summary>
-    internal static readonly FrozenDictionary<Type, V> ValidationModes =
+    internal static readonly FrozenDictionary<Type, V> GeometryValidation =
         new Dictionary<Type, V> {
             [typeof(Curve)] = V.Standard | V.Degeneracy,
             [typeof(NurbsCurve)] = V.Standard | V.Degeneracy | V.NurbsGeometry,
@@ -29,31 +32,352 @@ internal static class TransformationConfig {
             [typeof(PointCloud)] = V.Standard,
         }.ToFrozenDictionary();
 
-    /// <summary>Minimum scale factor to prevent singularity.</summary>
+    internal static readonly OperationMetadata ApplyOperation = new(
+        ValidationMode: V.None,
+        OperationName: "Transformation.Apply",
+        Error: E.Geometry.Transformation.TransformApplicationFailed);
+
+    internal static readonly FrozenDictionary<Type, TransformMetadata> TransformDispatch =
+        new Dictionary<Type, TransformMetadata> {
+            [typeof(Transformation.MatrixTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidTransformMatrix,
+                Validate: (request, context) => request is Transformation.MatrixTransform transform
+                    ? (transform.Matrix.IsValid && Math.Abs(transform.Matrix.Determinant) > context.AbsoluteTolerance, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Valid: {transform.Matrix.IsValid}, Det: {transform.Matrix.Determinant.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: request => ((Transformation.MatrixTransform)request).Matrix),
+            [typeof(Transformation.UniformScaleTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidScaleFactor,
+                Validate: (request, _) => request is Transformation.UniformScaleTransform scale
+                    ? (scale.Factor >= MinScaleFactor && scale.Factor <= MaxScaleFactor, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Factor: {scale.Factor.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: request => Transform.Scale(((Transformation.UniformScaleTransform)request).Anchor, ((Transformation.UniformScaleTransform)request).Factor)),
+            [typeof(Transformation.NonUniformScaleTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidScaleFactor,
+                Validate: (request, _) => request is Transformation.NonUniformScaleTransform scale
+                    ? (scale.Plane.IsValid
+                        && scale.XScale >= MinScaleFactor && scale.XScale <= MaxScaleFactor
+                        && scale.YScale >= MinScaleFactor && scale.YScale <= MaxScaleFactor
+                        && scale.ZScale >= MinScaleFactor && scale.ZScale <= MaxScaleFactor,
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"Plane: {scale.Plane.IsValid}, X: {scale.XScale.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Y: {scale.YScale.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Z: {scale.ZScale.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: request => {
+                    Transformation.NonUniformScaleTransform scale = (Transformation.NonUniformScaleTransform)request;
+                    return Transform.Scale(scale.Plane, scale.XScale, scale.YScale, scale.ZScale);
+                }),
+            [typeof(Transformation.AxisRotationTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidRotationAxis,
+                Validate: (request, context) => request is Transformation.AxisRotationTransform rotation
+                    ? (rotation.Axis.Length > context.AbsoluteTolerance, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Axis: {rotation.Axis.Length.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: request => {
+                    Transformation.AxisRotationTransform rotation = (Transformation.AxisRotationTransform)request;
+                    return Transform.Rotation(rotation.AngleRadians, rotation.Axis, rotation.Center);
+                }),
+            [typeof(Transformation.VectorRotationTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidRotationAxis,
+                Validate: (request, context) => request is Transformation.VectorRotationTransform rotation
+                    ? (rotation.StartDirection.Length > context.AbsoluteTolerance && rotation.EndDirection.Length > context.AbsoluteTolerance, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Start: {rotation.StartDirection.Length.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, End: {rotation.EndDirection.Length.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: request => {
+                    Transformation.VectorRotationTransform rotation = (Transformation.VectorRotationTransform)request;
+                    return Transform.Rotation(rotation.StartDirection, rotation.EndDirection, rotation.Center);
+                }),
+            [typeof(Transformation.MirrorTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidMirrorPlane,
+                Validate: (request, _) => request is Transformation.MirrorTransform mirror
+                    ? (mirror.Plane.IsValid, string.Empty)
+                    : (false, string.Empty),
+                Build: request => Transform.Mirror(((Transformation.MirrorTransform)request).Plane)),
+            [typeof(Transformation.TranslationTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidTransformSpec,
+                Validate: (request, _) => request is Transformation.TranslationTransform translation
+                    ? (translation.Motion.IsValid, string.Empty)
+                    : (false, string.Empty),
+                Build: request => Transform.Translation(((Transformation.TranslationTransform)request).Motion)),
+            [typeof(Transformation.ShearTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidShearParameters,
+                Validate: (request, context) => request is Transformation.ShearTransform shear
+                    ? (shear.Plane.IsValid
+                        && shear.Direction.Length > context.AbsoluteTolerance
+                        && shear.Plane.ZAxis.IsParallelTo(shear.Direction, context.AngleToleranceRadians * AngleToleranceMultiplier) == 0,
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"Plane: {shear.Plane.IsValid}, Dir: {shear.Direction.Length.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: request => {
+                    Transformation.ShearTransform shear = (Transformation.ShearTransform)request;
+                    return Transform.Shear(shear.Plane, shear.Direction * Math.Tan(shear.AngleRadians), Vector3d.Zero, Vector3d.Zero);
+                }),
+            [typeof(Transformation.ProjectionTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidProjectionPlane,
+                Validate: (request, _) => request is Transformation.ProjectionTransform projection
+                    ? (projection.Plane.IsValid, string.Empty)
+                    : (false, string.Empty),
+                Build: request => Transform.PlanarProjection(((Transformation.ProjectionTransform)request).Plane)),
+            [typeof(Transformation.ChangeBasisTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidBasisPlanes,
+                Validate: (request, _) => request is Transformation.ChangeBasisTransform change
+                    ? (change.From.IsValid && change.To.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"From: {change.From.IsValid}, To: {change.To.IsValid}"))
+                    : (false, string.Empty),
+                Build: request => {
+                    Transformation.ChangeBasisTransform change = (Transformation.ChangeBasisTransform)request;
+                    return Transform.ChangeBasis(change.From, change.To);
+                }),
+            [typeof(Transformation.PlaneToPlaneTransform)] = new(
+                Operation: ApplyOperation,
+                Error: E.Geometry.Transformation.InvalidBasisPlanes,
+                Validate: (request, _) => request is Transformation.PlaneToPlaneTransform change
+                    ? (change.From.IsValid && change.To.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"From: {change.From.IsValid}, To: {change.To.IsValid}"))
+                    : (false, string.Empty),
+                Build: request => {
+                    Transformation.PlaneToPlaneTransform change = (Transformation.PlaneToPlaneTransform)request;
+                    return Transform.PlaneToPlane(change.From, change.To);
+                }),
+        }.ToFrozenDictionary();
+
+    internal static readonly FrozenDictionary<Type, ArrayOperationMetadata> ArrayDispatch =
+        new Dictionary<Type, ArrayOperationMetadata> {
+            [typeof(Transformation.RectangularArray)] = new(
+                Operation: new OperationMetadata(V.None, "Transformation.RectangularArray", E.Geometry.Transformation.InvalidArrayParameters),
+                Validate: (request, context) => request is Transformation.RectangularArray array
+                    ? (array.XCount > 0
+                        && array.YCount > 0
+                        && array.ZCount > 0
+                        && array.XCount * array.YCount * array.ZCount <= MaxArrayCount
+                        && Math.Abs(array.XSpacing) > context.AbsoluteTolerance
+                        && Math.Abs(array.YSpacing) > context.AbsoluteTolerance
+                        && (array.ZCount <= 1 || Math.Abs(array.ZSpacing) > context.AbsoluteTolerance),
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"XCount: {array.XCount}, YCount: {array.YCount}, ZCount: {array.ZCount}, Total: {(array.XCount * array.YCount * array.ZCount)}"))
+                    : (false, string.Empty),
+                Build: (request, context) => TransformationCompute.RectangularArray(
+                    request: (Transformation.RectangularArray)request,
+                    context: context)),
+            [typeof(Transformation.PolarArray)] = new(
+                Operation: new OperationMetadata(V.None, "Transformation.PolarArray", E.Geometry.Transformation.InvalidArrayParameters),
+                Validate: (request, context) => request is Transformation.PolarArray array
+                    ? (array.Count > 0
+                        && array.Count <= MaxArrayCount
+                        && array.Axis.Length > context.AbsoluteTolerance
+                        && array.TotalAngle > 0.0
+                        && array.TotalAngle <= RhinoMath.TwoPI,
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"Count: {array.Count}, Axis: {array.Axis.Length.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Angle: {array.TotalAngle.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: (request, context) => TransformationCompute.PolarArray(
+                    request: (Transformation.PolarArray)request,
+                    context: context)),
+            [typeof(Transformation.LinearArray)] = new(
+                Operation: new OperationMetadata(V.None, "Transformation.LinearArray", E.Geometry.Transformation.InvalidArrayParameters),
+                Validate: (request, context) => request is Transformation.LinearArray array
+                    ? (array.Count > 0
+                        && array.Count <= MaxArrayCount
+                        && array.Direction.Length > context.AbsoluteTolerance
+                        && Math.Abs(array.Spacing) > context.AbsoluteTolerance,
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"Count: {array.Count}, Direction: {array.Direction.Length.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Spacing: {array.Spacing.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"))
+                    : (false, string.Empty),
+                Build: (request, context) => TransformationCompute.LinearArray(
+                    request: (Transformation.LinearArray)request,
+                    context: context)),
+            [typeof(Transformation.PathArray)] = new(
+                Operation: new OperationMetadata(V.None, "Transformation.PathArray", E.Geometry.Transformation.InvalidArrayParameters),
+                Validate: (request, context) => request is Transformation.PathArray array
+                    ? (array.Count > 0
+                        && array.Count <= MaxArrayCount
+                        && array.Path is not null
+                        && array.Path.IsValid
+                        && array.Path.GetLength() > context.AbsoluteTolerance,
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"Count: {array.Count}, Path: {array.Path?.IsValid ?? false}"))
+                    : (false, string.Empty),
+                Build: (request, context) => TransformationCompute.PathArray(
+                    request: (Transformation.PathArray)request,
+                    context: context)),
+        }.ToFrozenDictionary();
+
+    internal static readonly FrozenDictionary<Type, MorphMetadata> MorphDispatch =
+        new Dictionary<Type, MorphMetadata> {
+            [typeof(Transformation.FlowMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Flow", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidFlowCurves,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, _) => request is Transformation.FlowMorph morph
+                    ? (morph.BaseCurve.IsValid && morph.TargetCurve.IsValid && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Base: {morph.BaseCurve.IsValid}, Target: {morph.TargetCurve.IsValid}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Flow(
+                    geometry: geometry,
+                    request: (Transformation.FlowMorph)request,
+                    context: context)),
+            [typeof(Transformation.TwistMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Twist", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidTwistParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, context) => request is Transformation.TwistMorph morph
+                    ? (morph.Axis.IsValid && Math.Abs(morph.AngleRadians) <= MaxTwistAngle && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Axis: {morph.Axis.IsValid}, Angle: {morph.AngleRadians.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Twist(
+                    geometry: geometry,
+                    request: (Transformation.TwistMorph)request,
+                    context: context)),
+            [typeof(Transformation.BendMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Bend", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidBendParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, context) => request is Transformation.BendMorph morph
+                    ? (morph.Axis.IsValid && Math.Abs(morph.AngleRadians) <= MaxBendAngle && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Spine: {morph.Axis.IsValid}, Angle: {morph.AngleRadians.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Bend(
+                    geometry: geometry,
+                    request: (Transformation.BendMorph)request,
+                    context: context)),
+            [typeof(Transformation.TaperMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Taper", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidTaperParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, _) => request is Transformation.TaperMorph morph
+                    ? (morph.Axis.IsValid && morph.StartWidth >= MinScaleFactor && morph.EndWidth >= MinScaleFactor && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Axis: {morph.Axis.IsValid}, Start: {morph.StartWidth.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, End: {morph.EndWidth.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Taper(
+                    geometry: geometry,
+                    request: (Transformation.TaperMorph)request,
+                    context: context)),
+            [typeof(Transformation.StretchMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Stretch", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidStretchParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, _) => request is Transformation.StretchMorph morph
+                    ? (morph.Axis.IsValid && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Axis: {morph.Axis.IsValid}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Stretch(
+                    geometry: geometry,
+                    request: (Transformation.StretchMorph)request,
+                    context: context)),
+            [typeof(Transformation.SplopMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Splop", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidSplopParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, _) => request is Transformation.SplopMorph morph
+                    ? (morph.BasePlane.IsValid && morph.TargetSurface.IsValid && morph.TargetPoint.IsValid && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Plane: {morph.BasePlane.IsValid}, Surface: {morph.TargetSurface.IsValid}, Point: {morph.TargetPoint.IsValid}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Splop(
+                    geometry: geometry,
+                    request: (Transformation.SplopMorph)request,
+                    context: context)),
+            [typeof(Transformation.SporphMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Sporph", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidSporphParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, _) => request is Transformation.SporphMorph morph
+                    ? (morph.SourceSurface.IsValid && morph.TargetSurface.IsValid && geometry.IsValid, string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"Source: {morph.SourceSurface.IsValid}, Target: {morph.TargetSurface.IsValid}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Sporph(
+                    geometry: geometry,
+                    request: (Transformation.SporphMorph)request,
+                    context: context)),
+            [typeof(Transformation.MaelstromMorph)] = new(
+                Operation: new OperationMetadata(V.Standard, "Transformation.Maelstrom", E.Geometry.Transformation.MorphApplicationFailed),
+                ValidationError: E.Geometry.Transformation.InvalidMaelstromParameters,
+                MorphabilityError: E.Geometry.Transformation.GeometryNotMorphable,
+                Validate: (request, geometry, context) => request is Transformation.MaelstromMorph morph
+                    ? (morph.Center.IsValid
+                        && morph.Axis.IsValid
+                        && morph.Radius > context.AbsoluteTolerance
+                        && geometry.IsValid
+                        && Math.Abs(morph.AngleRadians) <= RhinoMath.TwoPI,
+                        string.Create(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            $"Center: {morph.Center.IsValid}, Axis: {morph.Axis.IsValid}, Radius: {morph.Radius.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}, Geometry: {geometry.IsValid}"))
+                    : (false, string.Empty),
+                Execute: (request, geometry, context) => TransformationCompute.Maelstrom(
+                    geometry: geometry,
+                    request: (Transformation.MaelstromMorph)request,
+                    context: context)),
+        }.ToFrozenDictionary();
+
     internal const double MinScaleFactor = 1e-6;
-    /// <summary>Maximum scale factor to prevent overflow.</summary>
     internal const double MaxScaleFactor = 1e6;
-
-    /// <summary>Maximum array count to prevent memory exhaustion.</summary>
     internal const int MaxArrayCount = 10000;
-
-    /// <summary>Angular tolerance multiplier for vector parallelism checks.</summary>
     internal const double AngleToleranceMultiplier = 10.0;
-
-    /// <summary>Maximum twist angle in radians.</summary>
     internal const double MaxTwistAngle = RhinoMath.TwoPI * 10.0;
-    /// <summary>Maximum bend angle in radians.</summary>
     internal const double MaxBendAngle = RhinoMath.TwoPI;
-
-    /// <summary>Default tolerance for morph operations.</summary>
     internal const double DefaultMorphTolerance = 0.001;
 
-    /// <summary>Get validation mode for geometry type with inheritance fallback.</summary>
+    internal sealed record OperationMetadata(
+        V ValidationMode,
+        string OperationName,
+        SystemError Error);
+
+    internal sealed record TransformMetadata(
+        OperationMetadata Operation,
+        SystemError Error,
+        Func<Transformation.TransformRequest, IGeometryContext, (bool Valid, string Context)> Validate,
+        Func<Transformation.TransformRequest, Transform> Build);
+
+    internal sealed record ArrayOperationMetadata(
+        OperationMetadata Operation,
+        Func<Transformation.ArrayRequest, IGeometryContext, (bool Valid, string Context)> Validate,
+        Func<Transformation.ArrayRequest, IGeometryContext, ComputeOutcome<Transform[]>> Build);
+
+    internal sealed record MorphMetadata(
+        OperationMetadata Operation,
+        SystemError ValidationError,
+        SystemError MorphabilityError,
+        Func<Transformation.MorphRequest, GeometryBase, IGeometryContext, (bool Valid, string Context)> Validate,
+        Func<Transformation.MorphRequest, GeometryBase, IGeometryContext, ComputeOutcome<GeometryBase>> Execute);
+
+    internal readonly record struct ComputeOutcome<T>(
+        bool Success,
+        T Value,
+        string Context);
+
     [Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static V GetValidationMode(Type geometryType) =>
-        ValidationModes.TryGetValue(geometryType, out V mode)
+        GeometryValidation.TryGetValue(geometryType, out V mode)
             ? mode
-            : ValidationModes
+            : GeometryValidation
                 .Where(kv => kv.Key.IsAssignableFrom(geometryType))
                 .Aggregate(
                     ((V?)null, (Type?)null),


### PR DESCRIPTION
## Summary
- replace loose transformation specs with algebraic record-based requests for transforms, arrays, and morphs
- consolidate operation metadata, validation, and dispatch tables in TransformationConfig with FrozenDictionary lookups
- rework core and compute layers to route execution through unified metadata and pure compute outcomes without duplicated constants

## Testing
- `dotnet build -nologo` *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec77f92e48321b654673dcb776c9c)