### PR TITLE
Fix transform duplication casting for extrusions

### DIFF
--- a/libs/rhino/transformation/TransformationCore.cs
+++ b/libs/rhino/transformation/TransformationCore.cs
@@ -16,15 +16,11 @@ internal static class TransformationCore {
     internal static Result<IReadOnlyList<T>> ApplyTransform<T>(
         T item,
         Transform transform) where T : GeometryBase {
-        GeometryBase normalized = item is Extrusion extrusion
-            ? extrusion.ToBrep(splitKinkyFaces: true)
-            : item;
-        T duplicate = (T)normalized.Duplicate();
+        T duplicate = (T)item.Duplicate();
         Result<IReadOnlyList<T>> result = duplicate.Transform(transform)
             ? ResultFactory.Create<IReadOnlyList<T>>(value: [duplicate,])
             : ResultFactory.Create<IReadOnlyList<T>>(error: E.Geometry.Transformation.TransformApplicationFailed);
 
-        (item is Extrusion ? normalized : null)?.Dispose();
         (!result.IsSuccess ? duplicate : null)?.Dispose();
 
         return result;


### PR DESCRIPTION
## Summary
- ensure ApplyTransform duplicates the original geometry type rather than converting extrusions to breps that violate type constraints
- preserve transform application result handling while avoiding invalid casts for extrusion inputs

## Testing
- dotnet build *(fails: `dotnet` command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203cd9c1508321bf021201514ad132)