### PR TITLE
Allow determinant magnitude validation for blended transforms

### DIFF
--- a/libs/rhino/transformation/TransformationCompute.cs
+++ b/libs/rhino/transformation/TransformationCompute.cs
@@ -378,7 +378,9 @@ internal static class TransformationCompute {
                     result.M12 *= scale.Z;
                     result.M22 *= scale.Z;
 
-                    return result.IsValid && result.Determinant > context.AbsoluteTolerance
+                    double determinantMagnitude = Math.Abs(result.Determinant);
+
+                    return result.IsValid && determinantMagnitude > context.AbsoluteTolerance
                         ? ResultFactory.Create(value: result)
                         : ResultFactory.Create<Transform>(error: E.Geometry.Transformation.InvalidTransformMatrix.WithContext($"Blend produced invalid matrix, det={result.Determinant.ToString("F6", System.Globalization.CultureInfo.InvariantCulture)}"));
                 }));
@@ -435,7 +437,9 @@ internal static class TransformationCompute {
                     result.M12 *= scale.Z;
                     result.M22 *= scale.Z;
 
-                    return result.IsValid && result.Determinant > context.AbsoluteTolerance
+                    double determinantMagnitude = Math.Abs(result.Determinant);
+
+                    return result.IsValid && determinantMagnitude > context.AbsoluteTolerance
                         ? ResultFactory.Create(value: result)
                         : ResultFactory.Create<Transform>(error: E.Geometry.Transformation.InvalidTransformMatrix.WithContext("Interpolation produced invalid matrix"));
                 }));


### PR DESCRIPTION
## Summary
- ensure blended and interpolated transform validation uses determinant magnitude so reflective transforms remain valid

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203cd9c1508321bf021201514ad132)