### PR TITLE
Improve polar decomposition convergence handling

### DIFF
--- a/libs/rhino/transformation/TransformationCompute.cs
+++ b/libs/rhino/transformation/TransformationCompute.cs
@@ -583,7 +583,7 @@ internal static class TransformationCompute {
         IGeometryContext context) {
         double det = (q00 * ((q11 * q22) - (q12 * q21))) - (q01 * ((q10 * q22) - (q12 * q20))) + (q02 * ((q10 * q21) - (q11 * q20)));
         return Math.Abs(det) < context.AbsoluteTolerance
-            ? (q00, q01, q02, q10, q11, q12, q20, q21, q22, true, true)
+            ? (q00, q01, q02, q10, q11, q12, q20, q21, q22, false, true)
             : IterateNewtonSchulzCore(q00: q00, q01: q01, q02: q02, q10: q10, q11: q11, q12: q12, q20: q20, q21: q21, q22: q22, det: det, context: context);
     }
 

--- a/libs/rhino/transformation/TransformationCompute.cs
+++ b/libs/rhino/transformation/TransformationCompute.cs
@@ -564,7 +564,7 @@ internal static class TransformationCompute {
         IGeometryContext context) =>
         Enumerable.Range(0, TransformationConfig.MaxNewtonSchulzIterations).Aggregate(
             seed: (q00: m00, q01: m01, q02: m02, q10: m10, q11: m11, q12: m12, q20: m20, q21: m21, q22: m22, converged: false, singular: false),
-            func: (state, _) => state.converged
+            func: (state, _) => state.converged || state.singular
                 ? state
                 : IterateNewtonSchulz(state.q00, state.q01, state.q02, state.q10, state.q11, state.q12, state.q20, state.q21, state.q22, context: context),
             resultSelector: final => final.singular || !final.converged


### PR DESCRIPTION
## Summary
- add singularity tracking and convergence validation to shear-case polar decomposition
- surface an explicit invalid-transform error when Newton–Schulz iterations cannot converge

## Testing
- dotnet build *(fails: `dotnet` command not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205addb1488321a09e24dfe32af8c3)