### PR TITLE
Dispose morph duplicates on failure

### DIFF
--- a/libs/rhino/transformation/TransformationCompute.cs
+++ b/libs/rhino/transformation/TransformationCompute.cs
@@ -23,7 +23,7 @@ internal static class TransformationCompute {
             ? ResultFactory.Create(value: duplicate)
             : ResultFactory.Create<T>(error: E.Geometry.Transformation.MorphApplicationFailed.WithContext($"Morph type: {typeof(TMorph).Name}"));
 
-        (!result.IsSuccess ? duplicate : null)?.Dispose();
+        (result.IsSuccess ? null : duplicate)?.Dispose();
 
         return result;
     }

--- a/libs/rhino/transformation/TransformationCompute.cs
+++ b/libs/rhino/transformation/TransformationCompute.cs
@@ -18,9 +18,14 @@ internal static class TransformationCompute {
         TMorph morph,
         T geometry) where TMorph : SpaceMorph where T : GeometryBase {
         T duplicate = (T)geometry.Duplicate();
-        return morph.Morph(duplicate)
+        bool success = morph.Morph(duplicate);
+        Result<T> result = success
             ? ResultFactory.Create(value: duplicate)
             : ResultFactory.Create<T>(error: E.Geometry.Transformation.MorphApplicationFailed.WithContext($"Morph type: {typeof(TMorph).Name}"));
+
+        (!result.IsSuccess ? duplicate : null)?.Dispose();
+
+        return result;
     }
 
     /// <summary>Apply SpaceMorph to geometry with duplication.</summary>


### PR DESCRIPTION
## Summary
- dispose morph duplicates when morph application fails to avoid leaking temporary geometry copies

## Testing
- dotnet build *(fails: `dotnet` is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205addb1488321a09e24dfe32af8c3)