### PR TITLE
Improve near-miss sampling stability

### DIFF
--- a/libs/rhino/intersection/IntersectionCompute.cs
+++ b/libs/rhino/intersection/IntersectionCompute.cs
@@ -145,9 +145,10 @@ internal static class IntersectionCompute {
                                                 .Select(face => (Face: face, Size: face.GetSurfaceSize(out double width, out double height) && width > 0.0 && height > 0.0 ? width * height : 0.0))
                                                 .Where(entry => entry.Size > 0.0)
                                                 .ToArray() is (BrepFace Face, double Size)[] validFaces && validFaces.Length > 0 && validFaces.Sum(static entry => entry.Size) is double totalArea && totalArea > 0.0
-                                                && Math.Min(
-                                                    IntersectionConfig.MaxNearMissSamples,
-                                                    Math.Max(IntersectionConfig.MinBrepNearMissSamples, (int)Math.Ceiling(brepA.GetBoundingBox(accurate: false).Diagonal.Length / searchRadius))) is int totalBudget
+                                                && Math.Clamp(
+                                                    (int)Math.Ceiling(brepA.GetBoundingBox(accurate: false).Diagonal.Length / searchRadius),
+                                                    IntersectionConfig.MinBrepNearMissSamples,
+                                                    IntersectionConfig.MaxNearMissSamples) is int totalBudget
                                                 ? validFaces
                                                     .SelectMany(entry => {
                                                         int faceSamples = Math.Max(IntersectionConfig.MinSamplesPerFace, (int)Math.Round(totalBudget * (entry.Size / totalArea)));

--- a/libs/rhino/intersection/IntersectionCompute.cs
+++ b/libs/rhino/intersection/IntersectionCompute.cs
@@ -131,9 +131,11 @@ internal static class IntersectionCompute {
                                         (Curve curve, Surface surface) => Math.Max(IntersectionConfig.MinCurveNearMissSamples, (int)Math.Ceiling(curve.GetLength() / searchRadius)) is int samples
                                             ? Enumerable.Range(0, samples)
                                                 .Select(index => curve.PointAt(curve.Domain.ParameterAt(index / (double)(samples - 1))))
-                                                .Select(point => surface.ClosestPoint(point, out double u, out double v)
-                                                    ? (PointA: point, PointB: surface.PointAt(u, v), Distance: point.DistanceTo(surface.PointAt(u, v)))
-                                                    : (PointA: point, PointB: Point3d.Unset, Distance: double.MaxValue))
+                                                .Select(point => {
+                                                    Point3d closest = surface.ClosestPoint(point, out double u, out double v) ? surface.PointAt(u, v) : Point3d.Unset;
+                                                    double distance = closest.IsValid ? point.DistanceTo(closest) : double.MaxValue;
+                                                    return (PointA: point, PointB: closest, Distance: distance);
+                                                })
                                                 .Where(candidate => candidate.Distance < searchRadius && candidate.Distance > minDistance)
                                                 .ToArray() is (Point3d PointA, Point3d PointB, double Distance)[] pairs && pairs.Length > 0
                                                 ? ResultFactory.Create(value: unpackPairs(pairs))
@@ -143,7 +145,9 @@ internal static class IntersectionCompute {
                                                 .Select(face => (Face: face, Size: face.GetSurfaceSize(out double width, out double height) && width > 0.0 && height > 0.0 ? width * height : 0.0))
                                                 .Where(entry => entry.Size > 0.0)
                                                 .ToArray() is (BrepFace Face, double Size)[] validFaces && validFaces.Length > 0 && validFaces.Sum(static entry => entry.Size) is double totalArea && totalArea > 0.0
-                                                && Math.Max(IntersectionConfig.MinBrepNearMissSamples, (int)Math.Ceiling(brepA.GetBoundingBox(accurate: false).Diagonal.Length / searchRadius)) is int totalBudget
+                                                && Math.Min(
+                                                    IntersectionConfig.MaxNearMissSamples,
+                                                    Math.Max(IntersectionConfig.MinBrepNearMissSamples, (int)Math.Ceiling(brepA.GetBoundingBox(accurate: false).Diagonal.Length / searchRadius))) is int totalBudget
                                                 ? validFaces
                                                     .SelectMany(entry => {
                                                         int faceSamples = Math.Max(IntersectionConfig.MinSamplesPerFace, (int)Math.Round(totalBudget * (entry.Size / totalArea)));


### PR DESCRIPTION
## Summary
- cache curve-to-surface closest point evaluations while filtering invalid samples
- cap brep near-miss sampling budget using the shared maximum sample limit

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257f8724ec832183d30fe59e70fe8d)